### PR TITLE
chore: harden repository access, releases and supply chain

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Every change needs review from the maintainer.
+#
+# Paired with the `main` ruleset's "require review from Code Owners" rule, this
+# is what makes *my* approval the one that counts rather than any approval from
+# anyone with write access. It matters the moment a second collaborator exists.
+* @Evanion
+
+# The release path -- the workflow that holds npm publish rights, and the
+# config that decides what gets published -- is called out separately so that
+# a change to it is never buried in a large diff.
+/.github/workflows/release.yml @Evanion
+/nx.json                       @Evanion
+/package.json                  @Evanion
+/package-lock.json             @Evanion

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+
+updates:
+  # Actions are pinned to commit SHAs (the repo requires it), which means the
+  # tag no longer floats and security fixes do not arrive on their own.
+  # Dependabot reads the `# vX.Y.Z` comment next to each SHA to know what
+  # version is in use, and opens a PR that moves both the SHA and the comment.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: 'ci(deps)'
+    labels:
+      - dependencies
+      - github-actions
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    # A monorepo with three published libraries produces a lot of update noise
+    # if every package moves on its own PR. Group the routine ones; security
+    # updates are unaffected by grouping and still come through individually.
+    groups:
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      production-dependencies:
+        dependency-type: production
+        update-types:
+          - patch
+    commit-message:
+      prefix: 'build(deps)'
+      prefix-development: 'build(deps-dev)'
+    labels:
+      - dependencies
+    open-pull-requests-limit: 10
+    ignore:
+      # Nx packages move as a set and are upgraded with `nx migrate`, which
+      # also runs the codemods. Dependabot bumping one of them in isolation
+      # produces a broken workspace.
+      - dependency-name: '@nx/*'
+      - dependency-name: 'nx'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           filter: tree:0
           fetch-depth: 0
@@ -26,7 +26,7 @@ jobs:
       # - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       # Cache node_modules
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: 'npm'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,15 +28,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: 'npm'
 
       - run: npm ci
 
-      - uses: actions/configure-pages@v6
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       # `output: 'export'` writes a fully static site to apps/docs/out.
       - name: Build
@@ -62,7 +62,7 @@ jobs:
           [ "$(cat CNAME)" = "docs.evanion.com" ] || { echo "unexpected CNAME: $(cat CNAME)" >&2; exit 1; }
           echo "export looks deployable ($(find . -type f | wc -l | tr -d ' ') files)"
 
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: apps/docs/out
 
@@ -74,4 +74,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,14 +23,29 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # nx release reads the full history to infer versions from
           # conventional commits, and needs the tags to know where to start.
           fetch-depth: 0
           filter: tree:0
+          # Check out over SSH with a write deploy key rather than the default
+          # GITHUB_TOKEN.
+          #
+          # `nx release` pushes the version-bump commit and the tags straight to
+          # main (it is forced on by changelog.projectChangelogs.createRelease:
+          # "github" -- see nx's release.js, shouldPush). The main ruleset
+          # requires a reviewed pull request, and github-actions[bot] cannot be
+          # granted a bypass on a personal repository: the API rejects an
+          # Integration bypass actor outside an organisation. A deploy key can
+          # bypass, so the push authenticates as one.
+          #
+          # This key is git-write, this repo only. It cannot publish to npm --
+          # that stays credential-free OIDC below -- and it cannot change repo
+          # settings. Revoking it is deleting the deploy key.
+          ssh-key: ${{ secrets.RELEASE_SSH_KEY }}
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,9 +15,7 @@ cannot use it for any reason, email <evanion86@gmail.com> instead.
 
 Please include:
 
-- Which package is affected and its version. The published packages are
-  `@evanion/compose`, `@evanion/urn`, `@evanion/react-widget`,
-  `@evanion/astro-widget` and `@evanion/nestjs-correlation-id`.
+- Which package is affected and its version.
 - What an attacker can do with it — the impact, not just the mechanism.
 - The smallest reproduction you can manage.
 
@@ -35,27 +33,27 @@ not hear back within 14 days, escalating publicly is fair.
 
 ## Supported Versions
 
-Only the latest published version of each package receives security fixes.
-There are no long-term support branches. Fixes land on `main` and go out in the
-next release.
+This policy covers **every `@evanion/*` package published from this
+repository**. It is deliberately not a list: packages get added here over time,
+and a list would quietly go stale and read as if a new package were unsupported.
+The authoritative set is whatever is currently published — the non-private
+`package.json` files under the directories named in `nx.json`'s
+`release.projects`.
 
-| Package                          | Supported           |
-| -------------------------------- | ------------------- |
-| `@evanion/compose`               | Latest release only |
-| `@evanion/urn`                   | Latest release only |
-| `@evanion/react-widget`          | Latest release only |
-| `@evanion/astro-widget`          | Latest release only |
-| `@evanion/nestjs-correlation-id` | Latest release only |
+Only the **latest published version** of each receives security fixes. There
+are no long-term support branches. Fixes land on `main` and go out in the next
+release.
 
 ## Scope
 
-In scope: anything in the published packages — code injection, prototype
+In scope: anything in a published package — code injection, prototype
 pollution, an unsafe default, a dependency vulnerability that is actually
 reachable through this code.
 
-Out of scope: the docs site's content, vulnerabilities in dependencies that no
-code path in these packages can reach, and anything that requires an attacker
-to already control the machine running the code.
+Out of scope: the docs site's content, anything in this repository that is not
+published to npm (demo apps and internal tooling), vulnerabilities in
+dependencies that no published code path can reach, and anything that requires
+an attacker to already control the machine running the code.
 
 ## How This Repository Is Protected
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@ Report it privately through GitHub's private vulnerability reporting:
 **<https://github.com/Evanion/libraries/security/advisories/new>**
 
 That opens a private advisory visible only to you and the maintainer. If you
-cannot use it for any reason, email <evanion86@gmail.com> instead.
+cannot use it for any reason, email <evanion@icloud.com> instead.
 
 Please include:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,8 +15,9 @@ cannot use it for any reason, email <evanion86@gmail.com> instead.
 
 Please include:
 
-- Which package is affected (`@evanion/compose`, `@evanion/urn`, or
-  `@evanion/react-widget`) and the version.
+- Which package is affected and its version. The published packages are
+  `@evanion/compose`, `@evanion/urn`, `@evanion/react-widget`,
+  `@evanion/astro-widget` and `@evanion/nestjs-correlation-id`.
 - What an attacker can do with it — the impact, not just the mechanism.
 - The smallest reproduction you can manage.
 
@@ -38,11 +39,13 @@ Only the latest published version of each package receives security fixes.
 There are no long-term support branches. Fixes land on `main` and go out in the
 next release.
 
-| Package                 | Supported            |
-| ----------------------- | -------------------- |
-| `@evanion/compose`      | Latest release only  |
-| `@evanion/urn`          | Latest release only  |
-| `@evanion/react-widget` | Latest release only  |
+| Package                          | Supported           |
+| -------------------------------- | ------------------- |
+| `@evanion/compose`               | Latest release only |
+| `@evanion/urn`                   | Latest release only |
+| `@evanion/react-widget`          | Latest release only |
+| `@evanion/astro-widget`          | Latest release only |
+| `@evanion/nestjs-correlation-id` | Latest release only |
 
 ## Scope
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,70 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Do not open a public issue for a security problem.** A public issue is visible
+to everyone, including anyone who would misuse it, before there is a fix to
+upgrade to.
+
+Report it privately through GitHub's private vulnerability reporting:
+
+**<https://github.com/Evanion/libraries/security/advisories/new>**
+
+That opens a private advisory visible only to you and the maintainer. If you
+cannot use it for any reason, email <evanion86@gmail.com> instead.
+
+Please include:
+
+- Which package is affected (`@evanion/compose`, `@evanion/urn`, or
+  `@evanion/react-widget`) and the version.
+- What an attacker can do with it — the impact, not just the mechanism.
+- The smallest reproduction you can manage.
+
+## What to Expect
+
+- **Acknowledgement within 7 days.** This is a spare-time project, not a funded
+  one; that is a realistic commitment rather than an optimistic one.
+- An assessment of whether it is exploitable and how severe it is.
+- A fix released to npm, and a GitHub Security Advisory published with a CVE
+  where the severity warrants one.
+- Credit in the advisory, unless you would rather stay anonymous.
+
+Please give the fix a reasonable window before disclosing publicly. If you do
+not hear back within 14 days, escalating publicly is fair.
+
+## Supported Versions
+
+Only the latest published version of each package receives security fixes.
+There are no long-term support branches. Fixes land on `main` and go out in the
+next release.
+
+| Package                 | Supported            |
+| ----------------------- | -------------------- |
+| `@evanion/compose`      | Latest release only  |
+| `@evanion/urn`          | Latest release only  |
+| `@evanion/react-widget` | Latest release only  |
+
+## Scope
+
+In scope: anything in the published packages — code injection, prototype
+pollution, an unsafe default, a dependency vulnerability that is actually
+reachable through this code.
+
+Out of scope: the docs site's content, vulnerabilities in dependencies that no
+code path in these packages can reach, and anything that requires an attacker
+to already control the machine running the code.
+
+## How This Repository Is Protected
+
+For anyone auditing the supply chain:
+
+- `main` is protected: every change goes through a pull request with maintainer
+  approval and green CI. Force-pushes and branch deletion are blocked.
+- Releases are published by a manually dispatched workflow, which only users
+  with write access can trigger.
+- npm publishing uses **trusted publishing (OIDC)**. There is no long-lived npm
+  token stored in this repository, and published packages carry provenance
+  attestation you can verify with `npm audit signatures`.
+- Every GitHub Action is pinned to a full commit SHA, and the repository
+  requires SHA pinning, so a compromised or retagged action version cannot
+  silently enter the release path.


### PR DESCRIPTION
Repository hardening for a public library: nothing reaches `main` without review, and the release path cannot be moved out from under us.

## Already applied on GitHub (not in this diff)

- **`main` ruleset** — pull request required with 1 approval, code-owner review, stale reviews dismissed on push, last-push approval, review threads resolved, rebase-only merge. Required status check `main` (strict). Force-push and deletion blocked. Bypass: Repository admin and DeployKey.
- **Dependabot** alerts and security updates enabled.
- **Private vulnerability reporting** enabled, so `SECURITY.md`'s advisory link works for outside reporters.
- **Write deploy key** + `RELEASE_SSH_KEY` secret for the release push.

## In this diff

**Actions pinned to commit SHAs.** A tag ref is mutable — `actions/checkout@v7` is whatever `v7` points at today. That matters most for `release.yml`, the one workflow holding npm publish rights. The `# vX.Y.Z` comments are kept so Dependabot can still bump them.

**Release checks out over SSH with a deploy key.** `nx release` pushes the version-bump commit and tags straight to `main` — forced on by `changelog.projectChangelogs.createRelease: "github"` — which the new ruleset would otherwise block. `github-actions[bot]` cannot be given a bypass: the rulesets API rejects an `Integration` bypass actor outside an organisation. A deploy key can, and it is git-write on this repo only. **npm publishing is unchanged and still credential-free OIDC.**

**`CODEOWNERS`** makes the maintainer's approval the one that satisfies the review requirement, rather than any approval from anyone with write access.

**`SECURITY.md`** gives reporters somewhere to go that is not a public issue.

**`dependabot.yml`** covers npm and github-actions. Actions matter more now that SHAs are pinned — the tag no longer floats, so fixes do not arrive on their own. `@nx/*` is excluded because those move as a set via `nx migrate`, which also runs the codemods.

## Follow-up after merge

Required SHA pinning is deliberately **not** enabled yet — turning it on before this lands would break `docs.yml` on `main`. Once merged:

```
gh api -X PUT repos/Evanion/libraries/actions/permissions \
  -f allowed_actions=all -F sha_pinning_required=true
```

## Verifying

The first release after this merges should be run with **`dry-run: true`** to confirm the deploy-key push works before anything is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zBLfbyDLQWJ78adH69KwT