### PR TITLE
fix(deps): override dompurify to clear four advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20551,9 +20551,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
-      "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "private": true,
   "overrides": {
+    "dompurify": "^3.4.13",
     "nextra": {
       "zod": "4.3.0"
     },


### PR DESCRIPTION
Dependabot could not fix these on its own. `monaco-editor@0.56.0` pins `dompurify` to exactly `3.4.8`, so every update path resolved back to the vulnerable version and the security job exited with `security_update_not_possible` — the red "Dependabot Updates" run right after the hardening PRs merged.

An `overrides` entry lifts it to **3.4.14**, clearing all four open advisories:

| Severity | Advisory | Patched at |
| --- | --- | --- |
| Medium | GHSA-55q2-fjhq-7xh7 — `IN_PLACE` hook removal leaves detached subtree executable (XSS) | 3.4.13 |
| Medium | GHSA-cmwh-pvxp-8882 — `ALLOWED_ATTR` pollution via `setConfig()` | 3.4.11 |
| Low | GHSA-c2j3-45gr-mqc4 — `CUSTOM_ELEMENT_HANDLING` bypasses `afterSanitizeElements` | 3.4.12 |
| Low | GHSA-vxr8-fq34-vvx9 — Trusted Types policy survives `clearConfig()` | 3.4.9 |

## Blast radius was small to begin with

`dompurify` reaches the tree only through the docs site — `@monaco-editor/react → monaco-editor` and `nextra → @theguild/remark-mermaid → mermaid`. **No published package depends on it.** The entire runtime surface of the five `@evanion/*` packages is `tslib` on two of them plus peer dependencies, so no consumer was ever exposed. This is a docs-site fix, not a library fix.

## Verification

- Lockfile diff is **exactly one package**: `dompurify` 3.4.8 → 3.4.14. Nothing else moved.
- `npm ci` from scratch, then `nx run-many -t lint test build typecheck --skip-nx-cache`: everything passes except one pre-existing failure unrelated to this change (see below).
- Both consumers accept it: `mermaid` declares `^3.3.3`; `monaco-editor`'s exact `3.4.8` pin is what the override deliberately supersedes. 3.4.8 → 3.4.14 is patch-level within `3.4.x`.

## Not fixed here: `image-size`

The two HIGH `image-size` advisories (CVE-2025-71329, CVE-2025-71330) report `first_patched_version: NONE` — there is no fixed release to move to. It arrives via `vite → less → image-size@0.5.5`, `less` is an **optional** peer of vite, and this repo contains **zero `.less` files**, so the parser never executes. Left alone deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zBLfbyDLQWJ78adH69KwT