### PR TITLE
fix(nx-astro): make astro build depend on upstream library builds

### DIFF
--- a/tools/nx-astro/src/index.test.ts
+++ b/tools/nx-astro/src/index.test.ts
@@ -27,6 +27,7 @@ describe('createNodesV2', () => {
     expect(Object.keys(targets).sort()).toEqual(['build', 'check', 'dev', 'preview']);
     expect(targets.build!.command).toBe('astro build');
     expect(targets.build!.options).toEqual({ cwd: 'apps/demo' });
+    expect(targets.build!.dependsOn).toEqual(['^build']);
     expect(targets.build!.cache).toBe(true);
     expect(targets.build!.outputs).toEqual(['{projectRoot}/dist']);
     expect(targets.dev!.cache).toBeUndefined();

--- a/tools/nx-astro/src/index.ts
+++ b/tools/nx-astro/src/index.ts
@@ -58,6 +58,7 @@ async function createNodesInternal(
 
   const build: TargetConfiguration = {
     command: 'astro build',
+    dependsOn: ['^build'],
     options: { cwd: projectRoot },
     cache: true,
     inputs: [


### PR DESCRIPTION
The inferred `build` target for Astro projects declared no `dependsOn`, so Nx could start `astro-widget-demo:build` before `@evanion/astro-widget:build` had produced its output.

It fails intermittently rather than always, which is why Nx has been reporting it as a flaky task: with a warm cache the library's `dist` is already there and the demo builds fine.

Why typecheck passes while the build fails, which is the confusing part:

- `tsconfig.base.json` sets `customConditions: ["@evanion/source"]`, so TypeScript resolves `@evanion/astro-widget` to its **source**.
- `libs/astro-widget/package.json` exports point `"."` at `./dist/index.js`.
- Vite/Rolldown inside `astro build` does not use that custom condition, so it resolves the **dist** path — and fails when the file is not there yet:

```
[vite]: Rolldown failed to resolve import "@evanion/astro-widget" from apps/astro-widget-demo/src/registry.ts
```

The fix adds `dependsOn: ['^build']` to the target where it is defined — `tools/nx-astro/src/index.ts`, the local plugin that infers Astro targets — rather than as a global `targetDefaults` entry, so it applies to exactly the projects this plugin creates. `tools/nx-astro/src/index.test.ts` gains an assertion that fails without it.

Verified with `npx nx run-many -t lint test build typecheck --skip-nx-cache` after clearing `dist` directories and the Nx cache: all 8 projects pass, lint 12 warnings and 0 errors.

This is currently red on every open pull request in the repository, for a reason unrelated to their contents, so it blocks the queue.

Diagnosed and fixed by an OpenClaw agent; pushed on its behalf because its token lacks write access.