### PR TITLE
fix(nestjs-correlation-id): store generated id under lowercased header key

### DIFF
--- a/nest/correlation-id/src/correlation-id.middleware.spec.ts
+++ b/nest/correlation-id/src/correlation-id.middleware.spec.ts
@@ -3,7 +3,7 @@ import { CorrelationIdMiddleware } from './correlation-id.middleware.js';
 import { CorrelationService } from './correlation.service.js';
 import { CorrelationConfig } from './interfaces/correlation-config.interface.js';
 
-const HEADER = 'x-correlation-id';
+const HEADER = 'X-Correlation-Id';
 
 const config: CorrelationConfig = {
   header: HEADER,
@@ -19,7 +19,9 @@ function mockService(existing = 'test123') {
 
 function mockReqRes(incoming?: string) {
   const req = {
-    get: vi.fn(() => incoming),
+    get: vi.fn((name: string) =>
+      name.toLowerCase() === HEADER.toLowerCase() ? incoming : undefined,
+    ),
     headers: {} as Record<string, unknown>,
   };
   const res = {
@@ -43,13 +45,14 @@ describe('CorrelationIdMiddleware', () => {
     expect(middleware).toBeDefined();
   });
 
-  it('sets the correlation id on the request when none was sent', () => {
+  it('sets the correlation id on the request under the canonical lower-case key', () => {
     const { req, res } = mockReqRes(undefined);
     middleware.use(req as never, res as never, vi.fn());
-    expect(req.headers[HEADER]).toBe('test123');
+    expect(req.headers['x-correlation-id']).toBe('test123');
+    expect(Object.keys(req.headers)).not.toContain(HEADER);
   });
 
-  it('sets the correlation id on the response', () => {
+  it('sets the correlation id on the response using the configured header casing', () => {
     const { req, res } = mockReqRes('test123');
     middleware.use(req as never, res as never, vi.fn());
     expect(res.set).toHaveBeenCalledWith(HEADER, 'test123');
@@ -61,11 +64,12 @@ describe('CorrelationIdMiddleware', () => {
     expect(service.setCorrelationId).toHaveBeenCalledWith('test123');
   });
 
-  it('prefers an incoming correlation id over a generated one', () => {
+  it('prefers an incoming correlation id and does not duplicate the header key', () => {
     const { req, res } = mockReqRes('from-caller');
     middleware.use(req as never, res as never, vi.fn());
     expect(service.setCorrelationId).toHaveBeenCalledWith('from-caller');
     expect(res.set).toHaveBeenCalledWith(HEADER, 'from-caller');
+    expect(Object.keys(req.headers)).not.toContain(HEADER);
   });
 
   it('calls next exactly once', () => {

--- a/nest/correlation-id/src/correlation-id.middleware.ts
+++ b/nest/correlation-id/src/correlation-id.middleware.ts
@@ -15,10 +15,11 @@ export class CorrelationIdMiddleware implements NestMiddleware {
   ) {}
   use(req: Request, res: Response, next: () => void) {
     const { header } = this.correlationConfig;
+    const key = header.toLowerCase();
     const correlationId =
       req.get(header) || this.correlationService.getCorrelationId();
 
-    if (!req.headers[header]) req.headers[header] = correlationId;
+    if (!req.headers[key]) req.headers[key] = correlationId;
     if (!res.get(header)) res.set(header, correlationId);
 
     this.correlationService.setCorrelationId(correlationId);


### PR DESCRIPTION
Closes #28.

Node lowercases every key in `req.headers`, so the guard `if (!req.headers[header])` with the mixed-case default header `'X-Correlation-Id'` never fires, and the subsequent write creates a mixed-case key alongside the lowercase key Express/Node actually use. This normalizes the key once (`header.toLowerCase()`) for the read/write against `req.headers`, while `res.set(header, …)` keeps the pretty casing on the response.

## Verification

Ran in the rescued container workspace against project `@evanion/nestjs-correlation-id`:

```
npx nx run-many -t lint test build typecheck --projects=@evanion/nestjs-correlation-id
```

Result: lint pass, typecheck pass (no errors), build pass, test pass — 2 test files, 12 tests, exit 0.

## Provenance

This fix (and its test) was produced by an OpenClaw agent working in an ephemeral container workspace and rescued onto GitHub via patch export/replay, since the workspace itself is not durable. Commits are unchanged from what the agent produced.