### PR TITLE
fix(nestjs-correlation-id): use configured header name in withCorrelation

### DIFF
--- a/nest/correlation-id/src/withCorrelation.function.spec.ts
+++ b/nest/correlation-id/src/withCorrelation.function.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  CORRELATION_CONFIG_TOKEN,
+  CORRELATION_ID_HEADER,
+} from './constants.js';
+import { CorrelationService } from './correlation.service.js';
+import { withCorrelation } from './withCorrelation.function.js';
+
+describe('withCorrelation', () => {
+  function mockService(id = 'REQ-1') {
+    return {
+      getCorrelationId: vi.fn(() => id),
+    } as unknown as CorrelationService;
+  }
+
+  it('uses the configured header name for the outbound correlation id', async () => {
+    const factory = withCorrelation();
+    const config = { header: 'X-Request-Id', generator: () => 'gen-id' };
+    const result = await factory.useFactory(mockService('REQ-1'), config);
+
+    expect(result.headers).toEqual({ 'X-Request-Id': 'REQ-1' });
+    expect(result.headers).not.toHaveProperty(CORRELATION_ID_HEADER);
+  });
+
+  it('falls back to the default header when no custom header is configured', async () => {
+    const factory = withCorrelation();
+    const config = { header: CORRELATION_ID_HEADER, generator: () => 'gen-id' };
+    const result = await factory.useFactory(mockService('REQ-2'), config);
+
+    expect(result.headers).toEqual({ [CORRELATION_ID_HEADER]: 'REQ-2' });
+  });
+
+  it('merges user-supplied headers without overriding the configured key', async () => {
+    const factory = withCorrelation({ headers: { Authorization: 'Bearer token' } });
+    const config = { header: 'X-Request-Id', generator: () => 'gen-id' };
+    const result = await factory.useFactory(mockService('REQ-3'), config);
+
+    expect(result.headers).toEqual({
+      Authorization: 'Bearer token',
+      'X-Request-Id': 'REQ-3',
+    });
+  });
+
+  it('declares both the service and the config token as dependencies', () => {
+    const factory = withCorrelation();
+    expect(factory.inject).toEqual([
+      CorrelationService,
+      CORRELATION_CONFIG_TOKEN,
+    ]);
+  });
+});

--- a/nest/correlation-id/src/withCorrelation.function.ts
+++ b/nest/correlation-id/src/withCorrelation.function.ts
@@ -1,16 +1,20 @@
 import type { HttpModuleOptions } from '@nestjs/axios';
-import { CORRELATION_ID_HEADER } from './constants.js';
+import { CORRELATION_CONFIG_TOKEN } from './constants.js';
+import type { CorrelationConfig } from './interfaces/correlation-config.interface.js';
 import { CorrelationModule } from './correlation.module.js';
 import { CorrelationService } from './correlation.service.js';
 
 export const withCorrelation = (config?: HttpModuleOptions) => ({
   imports: [CorrelationModule],
-  useFactory: async (correlationService: CorrelationService) => ({
+  useFactory: async (
+    correlationService: CorrelationService,
+    correlationConfig: CorrelationConfig,
+  ) => ({
     ...config,
     headers: {
       ...(config?.headers && config.headers),
-      [CORRELATION_ID_HEADER]: correlationService.getCorrelationId(),
+      [correlationConfig.header]: correlationService.getCorrelationId(),
     },
   }),
-  inject: [CorrelationService],
+  inject: [CorrelationService, CORRELATION_CONFIG_TOKEN],
 });


### PR DESCRIPTION
Closes #29.

`withCorrelation`'s outbound header was hard-coded to `CORRELATION_ID_HEADER` and never consulted `CorrelationConfig.header`, so a caller running `CorrelationModule.forRoot({ header: 'X-Request-Id' })` still sent the default `X-Correlation-Id` outbound — breaking trace propagation whenever a custom header name is configured.

Fix: inject `CORRELATION_CONFIG_TOKEN` alongside `CorrelationService` and use `correlationConfig.header` as the outbound key.

**Note on public API surface:** this changes the `inject` array and the `useFactory` signature returned by `withCorrelation()` (now expects `[CorrelationService, CORRELATION_CONFIG_TOKEN]` to be injected by Nest's `HttpModule.registerAsync`). This is consistent with the issue's suggested fix and is how the factory is normally consumed (via `HttpModule.registerAsync(withCorrelation())`), but it is a change to what NestJS injects into the factory, so flagging it explicitly for review.

## Verification

Ran in the rescued container workspace against project `@evanion/nestjs-correlation-id`:

```
npx nx run-many -t lint test build typecheck --projects=@evanion/nestjs-correlation-id
```

Result: lint pass, typecheck pass (no errors), build pass, test pass — 3 test files, 16 tests, exit 0.

Note: the companion test commit's `.gitignore` hunk (tracking `test-output`) was dropped when replaying this patch because that change already exists on `main` via a separate commit; only the actual test file addition was replayed.

## Provenance

This fix (and its test) was produced by an OpenClaw agent working in an ephemeral container workspace and rescued onto GitHub via patch export/replay, since the workspace itself is not durable. Commits are otherwise unchanged from what the agent produced.