### PR TITLE
fix(nestjs-correlation-id): validate incoming correlation ids before echoing

### DIFF
--- a/nest/correlation-id/src/constants.ts
+++ b/nest/correlation-id/src/constants.ts
@@ -1,2 +1,5 @@
 export const CORRELATION_ID_HEADER = 'X-Correlation-Id';
 export const CORRELATION_CONFIG_TOKEN = 'CORRELATION_CONFIG';
+export const DEFAULT_CORRELATION_ID_VALIDATOR = (value: string): boolean =>
+  /^[\w.:-]{1,128}$/.test(value);
+

--- a/nest/correlation-id/src/correlation-id.middleware.spec.ts
+++ b/nest/correlation-id/src/correlation-id.middleware.spec.ts
@@ -64,12 +64,44 @@ describe('CorrelationIdMiddleware', () => {
     expect(service.setCorrelationId).toHaveBeenCalledWith('test123');
   });
 
-  it('prefers an incoming correlation id and does not duplicate the header key', () => {
+  it('prefers a valid incoming correlation id and does not duplicate the header key', () => {
     const { req, res } = mockReqRes('from-caller');
     middleware.use(req as never, res as never, vi.fn());
     expect(service.setCorrelationId).toHaveBeenCalledWith('from-caller');
     expect(res.set).toHaveBeenCalledWith(HEADER, 'from-caller');
     expect(Object.keys(req.headers)).not.toContain(HEADER);
+  });
+
+  it('falls back to a generated id when the incoming value is invalid', () => {
+    const { req, res } = mockReqRes('contains spaces');
+    middleware.use(req as never, res as never, vi.fn());
+    expect(service.setCorrelationId).toHaveBeenCalledWith('test123');
+    expect(res.set).toHaveBeenCalledWith(HEADER, 'test123');
+  });
+
+  it('rejects an incoming id that is too long', () => {
+    const { req, res } = mockReqRes('a'.repeat(129));
+    middleware.use(req as never, res as never, vi.fn());
+    expect(service.setCorrelationId).toHaveBeenCalledWith('test123');
+    expect(res.set).toHaveBeenCalledWith(HEADER, 'test123');
+  });
+
+  it('rejects comma-joined repeated headers', () => {
+    const { req, res } = mockReqRes('aaa, bbb');
+    middleware.use(req as never, res as never, vi.fn());
+    expect(service.setCorrelationId).toHaveBeenCalledWith('test123');
+    expect(res.set).toHaveBeenCalledWith(HEADER, 'test123');
+  });
+
+  it('allows a custom validator to accept values the default rejects', () => {
+    const customMiddleware = new CorrelationIdMiddleware(service, {
+      ...config,
+      validate: () => true,
+    });
+    const { req, res } = mockReqRes('contains spaces');
+    customMiddleware.use(req as never, res as never, vi.fn());
+    expect(service.setCorrelationId).toHaveBeenCalledWith('contains spaces');
+    expect(res.set).toHaveBeenCalledWith(HEADER, 'contains spaces');
   });
 
   it('calls next exactly once', () => {

--- a/nest/correlation-id/src/correlation-id.middleware.ts
+++ b/nest/correlation-id/src/correlation-id.middleware.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, NestMiddleware } from '@nestjs/common';
 import type { Request, Response } from 'express';
-import { CORRELATION_CONFIG_TOKEN } from './constants.js';
+import { CORRELATION_CONFIG_TOKEN, DEFAULT_CORRELATION_ID_VALIDATOR } from './constants.js';
 import { CorrelationService } from './correlation.service.js';
 // Must be `import type`: with isolatedModules and emitDecoratorMetadata,
 // a type referenced in a decorated signature cannot be a value import.
@@ -14,10 +14,14 @@ export class CorrelationIdMiddleware implements NestMiddleware {
     private correlationConfig: CorrelationConfig,
   ) {}
   use(req: Request, res: Response, next: () => void) {
-    const { header } = this.correlationConfig;
+    const {
+      header,
+      validate = DEFAULT_CORRELATION_ID_VALIDATOR,
+    } = this.correlationConfig;
     const key = header.toLowerCase();
-    const correlationId =
-      req.get(header) || this.correlationService.getCorrelationId();
+    const incoming = req.get(header);
+    const generated = this.correlationService.getCorrelationId();
+    const correlationId = incoming && validate(incoming) ? incoming : generated;
 
     if (!req.headers[key]) req.headers[key] = correlationId;
     if (!res.get(header)) res.set(header, correlationId);

--- a/nest/correlation-id/src/correlation.module.ts
+++ b/nest/correlation-id/src/correlation.module.ts
@@ -1,6 +1,10 @@
 import { DynamicModule, Module, Provider } from '@nestjs/common';
 import { randomUUID } from 'node:crypto';
-import { CORRELATION_CONFIG_TOKEN, CORRELATION_ID_HEADER } from './constants.js';
+import {
+  CORRELATION_CONFIG_TOKEN,
+  CORRELATION_ID_HEADER,
+  DEFAULT_CORRELATION_ID_VALIDATOR,
+} from './constants.js';
 import { CorrelationService } from './correlation.service.js';
 // Must be `import type`: with isolatedModules and emitDecoratorMetadata,
 // a type referenced in a decorated signature cannot be a value import.
@@ -15,6 +19,7 @@ export class CorrelationModule {
         ...config,
         header: config?.header || CORRELATION_ID_HEADER,
         generator: config?.generator || randomUUID,
+        validate: config?.validate || DEFAULT_CORRELATION_ID_VALIDATOR,
       },
     };
     return {

--- a/nest/correlation-id/src/interfaces/correlation-config.interface.ts
+++ b/nest/correlation-id/src/interfaces/correlation-config.interface.ts
@@ -1,4 +1,5 @@
 export interface CorrelationConfig {
   header: string;
   generator: () => string;
+  validate?: (value: string) => boolean;
 }


### PR DESCRIPTION
Closes #30.

Previously any incoming correlation-id header value was trusted verbatim: echoed on the response, stored in the request-scoped service (reaching every log line), and forwarded downstream by `withCorrelation`. This allowed unbounded-length values, arbitrary printable content (log-forging risk), and comma-joined duplicate headers to pass straight through.

Fix: add a `DEFAULT_CORRELATION_ID_VALIDATOR` (`/^[\w.:-]{1,128}$/`), apply it in the middleware before accepting an incoming id (falling back to the generator on failure), and make it configurable via an optional `validate` field on `CorrelationConfig` / `CorrelationModule.forRoot(...)`, per the issue's suggested fix.

## Verification

Ran in the rescued container workspace against project `@evanion/nestjs-correlation-id`:

```
npx nx run-many -t lint test build typecheck --projects=@evanion/nestjs-correlation-id
```

Result: lint pass, typecheck pass (no errors), build pass, test pass — 2 test files, 16 tests, exit 0.

## Provenance

This fix (and its test) was produced by an OpenClaw agent working in an ephemeral container workspace and rescued onto GitHub via patch export/replay, since the workspace itself is not durable. Commits are unchanged from what the agent produced.