### PR TITLE
fix(urn): validate characters in parse and format checker

### DIFF
--- a/libs/urn/src/lib/urn.spec.ts
+++ b/libs/urn/src/lib/urn.spec.ts
@@ -103,6 +103,9 @@ describe('URN', () => {
         expect(URN.isValidFormat('user:123')).toBe(false); // Missing URN scheme
         expect(URN.isValidFormat('urn::123')).toBe(false); // Empty NID
         expect(URN.isValidFormat('')).toBe(false); // Empty string
+        expect(URN.isValidFormat('urn:us er:hello world!')).toBe(false);
+        expect(URN.isValidFormat('urn:!!!:@@@')).toBe(false);
+        expect(URN.isValidFormat('http://a:b')).toBe(false);
       });
     });
 

--- a/libs/urn/src/lib/urn.ts
+++ b/libs/urn/src/lib/urn.ts
@@ -117,7 +117,10 @@ export class URN {
    */
   static isValidFormat(urnString: string): boolean {
     const parts = urnString.split(this.separator);
-    return parts.length >= 3 && parts.every((part) => part.length > 0);
+    return (
+      parts.length >= 3 &&
+      parts.every((part) => part.length > 0 && this.isValid.test(part))
+    );
   }
 
   /**


### PR DESCRIPTION
## What was wrong

`URN.isValidFormat` only checked that a URN string split into >= 3 parts and that none were empty. It never checked the actual character content of each part, so strings like `urn:us er:hello world!` or `urn:!!!:@@@` passed format validation even though they contain characters `stringify`/`assertValidComponent` would reject on the write path. The read path (`parse`, `isValidFormat`) and write path (`stringify`) were validating against two different rules.

## Fix

Every part now goes through the same `isValid` character-class regex that `assertValidComponent` already used for the write path, so `isValidFormat` (and therefore `parse`) rejects strings with invalid characters instead of only checking arity/emptiness.

Fixes #9

## Verification

Ran in the container workspace on this branch:

```
npx nx run-many -t lint test build typecheck --projects=@evanion/urn
```

Result: lint, build, typecheck all succeeded; test suite passed — 2 test files, 41 tests passed, 0 failed, no type errors.

## Provenance

Written by an OpenClaw agent running in a container workspace; pushed to GitHub by a rescue/verification agent (not the original author) after independent verification.