### PR TITLE
fix(urn): reject separator inside components

### DIFF
--- a/libs/urn/src/lib/urn.spec.ts
+++ b/libs/urn/src/lib/urn.spec.ts
@@ -13,8 +13,19 @@ describe('URN', () => {
       expect(URN.stringify('foo', 'bar')).toBe('urn:bar:foo');
     });
 
-    it('should not duplicate nid', () => {
-      expect(URN.stringify('bar:foo', 'bar')).toBe('urn:bar:foo');
+    it('should reject components that contain the separator', () => {
+      expect(() => URN.stringify('a:b', 'nid')).toThrow(InvalidError);
+      expect(() => URN.stringify('a:b', 'nid')).toThrow(
+        "NSS contains invalid character ':' in 'a:b'",
+      );
+      expect(() => URN.stringify('foo', 'n:i')).toThrow(InvalidError);
+      expect(() => URN.stringify('foo', 'n:i')).toThrow(
+        "NID contains invalid character ':' in 'n:i'",
+      );
+      expect(() => URN.stringify('foo', 'nid', 'u:n')).toThrow(InvalidError);
+      expect(() => URN.stringify('foo', 'nid', 'u:n')).toThrow(
+        "URN contains invalid character ':' in 'u:n'",
+      );
     });
 
     it('should throw error if URN parameter contains an invalid character', () => {
@@ -46,6 +57,21 @@ describe('URN', () => {
         static override readonly separator = '-';
       }
       expect(TRN.stringify('foo', 'bar')).toBe('trn-bar-foo');
+    });
+
+    it('should reject components that contain a custom separator', () => {
+      class Dash extends URN {
+        static override readonly urn = 'trn';
+        static override readonly separator = '-';
+      }
+      expect(() => Dash.stringify('ab', 'n-id')).toThrow(InvalidError);
+      expect(() => Dash.stringify('ab', 'n-id')).toThrow(
+        "NID contains invalid character '-' in 'n-id'",
+      );
+      expect(() => Dash.stringify('a-b', 'nid')).toThrow(InvalidError);
+      expect(() => Dash.stringify('a-b', 'nid')).toThrow(
+        "NSS contains invalid character '-' in 'a-b'",
+      );
     });
 
     it('should derive from urn class and set nid', () => {

--- a/libs/urn/src/lib/urn.ts
+++ b/libs/urn/src/lib/urn.ts
@@ -1,6 +1,10 @@
 import { InvalidError, ValidationError } from './exceptions.js';
 import { ParsedURN } from './types.js';
 
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 export class URN {
   /**
    * separator between the different parts of the URN
@@ -78,18 +82,26 @@ export class URN {
   }
 
   /**
-   * Checks that a string contains only RFC-compliant URN characters.
-   * Allows: alphanumeric, hyphens, underscores, dots, tildes, and colons.
-   *
-   * Requires at least one character -- an empty component would otherwise
-   * produce a URN that `isValidFormat` rejects.
+   * Character class each component must match. Excludes the configured
+   * separator so a component cannot break parsing or round-trips.
    */
-  static readonly isValid = /^[a-z0-9\-._~:]+$/i;
+  static get isValid(): RegExp {
+    return new RegExp(
+      `^[a-z0-9\\-._~:${
+        this.separator === ':' ? '' : escapeRegex(this.separator)
+      }]+$`,
+      'i',
+    );
+  }
 
   /**
    * Throws a descriptive {@link InvalidError} if a component is not valid.
    */
   private static assertValidComponent(property: string, value: string): void {
+    const separator = this.separator;
+    if (value.includes(separator)) {
+      throw new InvalidError(property, value, separator);
+    }
     if (!this.isValid.test(value)) {
       throw new InvalidError(property, value, this.findInvalidChar(value));
     }


### PR DESCRIPTION
## What was wrong

`stringify` accepted a component (URN scheme, NID, or NSS) that itself contained the separator character. That silently broke round-tripping: `parse(stringify(nss, nid, urn))` would not reconstruct the original components if any of them embedded a `:` (or a custom separator on a subclass), because `split(separator)` cannot distinguish an embedded separator from a real boundary.

## Fix

`assertValidComponent` now explicitly rejects a component that contains the configured separator, throwing `InvalidError` before the (unreachable, since a passing NSS can no longer contain the separator) NID-dedup branch in `stringify` is reached. The `isValid` character class is now derived per-class from `this.separator`, since a subclass may override it.

Fixes #8

## Verification

Ran in the container workspace on this branch:

```
npx nx run-many -t lint test build typecheck --projects=@evanion/urn
```

Result: lint, build, typecheck all succeeded; test suite passed — 2 test files, 42 tests passed, 0 failed, no type errors.

## Something that looked wrong — flagging, not fixing

This commit removed the previous test `'should not duplicate nid'` (which asserted `stringify('bar:foo', 'bar')` collapses to `'urn:bar:foo'`) and replaced it with a test that the same call now throws. That is consistent with this fix's intent (an NSS containing the separator is now rejected outright), but it leaves the NID-prefix-dedup branch in `stringify` (`if (nss.startsWith(`${nid}${this.separator}`)) return ...`) as dead code — it can never be reached anymore, because `assertValidComponent` will already have thrown for any NSS containing the separator by the time that line runs.

Separately: branch `issue-10-urn-nid-prefix-truncation` on this same repo removes that same dedup branch entirely, for a different reason (it wants `user:42` NSS with `nid='user'` to always emit the full `urn:user:user:42` rather than being collapsed). Both branches touch the same dedup logic in `stringify` with different end states — #8 leaves it present-but-dead, #10 deletes it outright. If both get merged, whichever lands second will need to reconcile that overlap; I have not attempted to reconcile it here since that's a design decision, not mine to make.

## Provenance

Written by an OpenClaw agent running in a container workspace; pushed to GitHub by a rescue/verification agent (not the original author) after independent verification.