### PR TITLE
fix(urn): stop truncating nss that starts with nid

### DIFF
--- a/libs/urn/src/lib/urn.spec.ts
+++ b/libs/urn/src/lib/urn.spec.ts
@@ -13,8 +13,16 @@ describe('URN', () => {
       expect(URN.stringify('foo', 'bar')).toBe('urn:bar:foo');
     });
 
-    it('should not duplicate nid', () => {
-      expect(URN.stringify('bar:foo', 'bar')).toBe('urn:bar:foo');
+    it('should not truncate an NSS that merely starts with the NID', () => {
+      class UserURN extends URN {
+        static override readonly nid = 'user';
+      }
+      expect(UserURN.stringify('user:42')).toBe('urn:user:user:42');
+      expect(UserURN.parse('urn:user:user:42').nss).toBe('user:42');
+    });
+
+    it('should never skip the NID even when the NSS repeats it', () => {
+      expect(URN.stringify('bar:foo', 'bar')).toBe('urn:bar:bar:foo');
     });
 
     it('should throw error if URN parameter contains an invalid character', () => {

--- a/libs/urn/src/lib/urn.ts
+++ b/libs/urn/src/lib/urn.ts
@@ -71,9 +71,6 @@ export class URN {
     this.assertValidComponent('NID', nid);
     this.assertValidComponent('NSS', nss);
 
-    if (nss.startsWith(`${nid}${this.separator}`))
-      return `${urn}${this.separator}${nss}`;
-
     return `${urn}${this.separator}${nid}${this.separator}${nss}`;
   }
 


### PR DESCRIPTION
## What was wrong

`stringify` silently deduplicated the NID when the NSS happened to start with `\`${nid}${separator}\``. That meant a legitimate NSS value like `user:42` (for a `UserURN` subclass with `nid = 'user'`) would come out as `urn:user:user:42` truncated down to `urn:user:42` -- indistinguishable on the wire from a URN whose NSS was simply `42`. This silently lost data whenever an NSS happened to start with the same string as its own NID.

## Fix

Removed the unconditional NID-prefix dedup branch in `stringify`. A value like `user:42` is now always emitted in full as `urn:user:user:42`, and parses back unchanged.

Part of #10

## Verification

Ran in the container workspace on this branch:

```
npx nx run-many -t lint test build typecheck --projects=@evanion/urn
```

Result: lint, build, typecheck all succeeded; test suite passed — 2 test files, 42 tests passed, 0 failed, no type errors.

## Something that looked wrong — flagging, not fixing

Branch `issue-8-urn-separator-in-components` on this same repo touches the exact same dedup branch in `stringify`, but for a different reason: it makes `assertValidComponent` reject any NSS that contains the separator at all (rather than removing the dedup branch). Both branches converge on "the dedup branch never fires again" but by different mechanisms and for different stated reasons (#8: prevent lossy round-trips by forbidding embedded separators outright; #10: prevent lossy truncation by removing the special-casing). If both PRs are merged, whichever lands second will conflict with or make dead code out of the other's change to that same block — I have not tried to reconcile this, since it is a design decision.

## Provenance

Written by an OpenClaw agent running in a container workspace; pushed to GitHub by a rescue/verification agent (not the original author) after independent verification.

---

**Validator note:** the closing keyword in this body was changed from `Fixes #10` to `Part of #10` by the PR-validation pass, because the PR does not address every part of the issue. See the validation comment on this PR for the list of parts that remain. The closing keyword also appears in this PR's **commit message**, which cannot be changed without a force-push — a human must squash-merge with a corrected message, or the issue will still be closed on merge.
