### PR TITLE
fix(urn): retain foreign scheme during parse

### DIFF
--- a/libs/urn/src/lib/urn.spec.ts
+++ b/libs/urn/src/lib/urn.spec.ts
@@ -86,6 +86,23 @@ describe('URN', () => {
         nss: 'baz:foo',
       });
     });
+
+    it('should retain a foreign URN scheme in the NSS', () => {
+      class UserURN extends URN {
+        static override readonly urn = 'trn';
+        static override readonly nid = 'user';
+      }
+      expect(UserURN.parse('ftp:user:1')).toEqual({
+        urn: 'ftp',
+        nid: 'user',
+        nss: 'trn:user:1',
+      });
+      expect(UserURN.parse('trn:user:1')).toEqual({
+        urn: 'trn',
+        nid: 'user',
+        nss: '1',
+      });
+    });
   });
 
   describe('utility methods', () => {

--- a/libs/urn/src/lib/urn.ts
+++ b/libs/urn/src/lib/urn.ts
@@ -48,6 +48,14 @@ export class URN {
 
     const nss = rest.join(this.separator);
 
+    if (urn !== this.urn) {
+      return {
+        urn,
+        nid,
+        nss: `${this.urn}${this.separator}${nid}${this.separator}${nss}`,
+      };
+    }
+
     if (nid !== this.nid)
       return { urn, nid, nss: `${nid}${this.separator}${nss}` };
 


### PR DESCRIPTION
## What was wrong

`parse` already preserved a foreign NID by folding it back into the returned `nss` when the parsed NID didn't match `this.nid`, so callers wouldn't silently lose that namespace information. It did not do the equivalent for a foreign URN *scheme* -- if the string's leading scheme (e.g. `ftp`) didn't match `this.urn` (e.g. `trn`), that scheme was discarded rather than retained, so callers had no way to reconstruct the original identifier.

## Fix

`parse` now also checks the scheme: when it doesn't match `this.urn`, the returned `nss` is prefixed with the class's own scheme, NID, and separator so the full foreign identifier can be reconstructed later, mirroring the existing foreign-NID handling.

Part of #11

## Verification

Ran in the container workspace on this branch:

```
npx nx run-many -t lint test build typecheck --projects=@evanion/urn
```

Result: lint, build, typecheck all succeeded; test suite passed — 2 test files, 42 tests passed, 0 failed, no type errors.

## Provenance

Written by an OpenClaw agent running in a container workspace; pushed to GitHub by a rescue/verification agent (not the original author) after independent verification.

---

**Validator note:** the closing keyword in this body was changed from `Fixes #11` to `Part of #11` by the PR-validation pass, because the PR does not address every part of the issue. See the validation comment on this PR for the list of parts that remain. The closing keyword also appears in this PR's **commit message**, which cannot be changed without a force-push — a human must squash-merge with a corrected message, or the issue will still be closed on merge.
