### PR TITLE
fix(compose): three ways to defeat provider validation

### DIFF
--- a/libs/compose/src/Compose.test-d.tsx
+++ b/libs/compose/src/Compose.test-d.tsx
@@ -82,6 +82,26 @@ describe('compose type inference', () => {
     provider(ThemeProvider, { theme: 'dark' });
   });
 
+  it('rejects a bare component that requires props', () => {
+    acceptsProviders([
+      // @ts-expect-error ThemeProvider requires props, so a bare component is invalid
+      ThemeProvider,
+    ]);
+  });
+
+  it('rejects a component placed in the props position of a tuple', () => {
+    acceptsProviders([
+      // @ts-expect-error the second tuple entry must be props, not another component
+      [SimpleProvider, ThemeProvider],
+    ]);
+  });
+
+  it('rejects excess props through provider() when passed as a variable', () => {
+    const themeProps = { theme: 'dark', primaryColor: '#fff', typo: 1 };
+    // @ts-expect-error `typo` is not a prop of ThemeProvider
+    provider(ThemeProvider, themeProps);
+  });
+
   // Positive JSX cases, to prove the generic overloads still resolve in real use.
   it('compiles a correct ComposeProvider element', () => {
     const el = (

--- a/libs/compose/src/Compose.types.ts
+++ b/libs/compose/src/Compose.types.ts
@@ -37,9 +37,12 @@ export type PropsWithoutChildren<T extends AnyComponent> = Omit<
  * });
  * ```
  */
-export function provider<T extends AnyComponent>(
+export function provider<
+  T extends AnyComponent,
+  P extends PropsWithoutChildren<T>,
+>(
   component: T,
-  props: PropsWithoutChildren<T>,
+  props: P & Record<Exclude<keyof P, keyof PropsWithoutChildren<T>>, never>,
 ): readonly [T, PropsWithoutChildren<T>] {
   return [component, props] as const;
 }
@@ -75,23 +78,27 @@ export type ProviderArray = readonly Provider[];
  */
 export type ValidateProvider<T> = T extends readonly [infer C, infer P]
   ? C extends AnyComponent
-    ? [P] extends [PropsWithoutChildren<C>]
-      ? // Assignability alone permits extra properties, so check for keys the
-        // component does not declare -- otherwise a typo in a prop name is
-        // silently accepted. The excess keys are mapped to `never` rather
-        // than simply dropped, because the caller's object would still
-        // satisfy an intersection that merely omitted them.
-        Exclude<keyof P, keyof PropsWithoutChildren<C>> extends never
-        ? T
-        : readonly [
-            C,
-            PropsWithoutChildren<C> &
-              Record<Exclude<keyof P, keyof PropsWithoutChildren<C>>, never>,
-          ]
-      : readonly [C, PropsWithoutChildren<C>]
+    ? P extends AnyComponent
+      ? never
+      : [P] extends [PropsWithoutChildren<C>]
+        ? // Assignability alone permits extra properties, so check for keys the
+          // component does not declare -- otherwise a typo in a prop name is
+          // silently accepted. The excess keys are mapped to `never` rather
+          // than simply dropped, because the caller's object would still
+          // satisfy an intersection that merely omitted them.
+          Exclude<keyof P, keyof PropsWithoutChildren<C>> extends never
+          ? T
+          : readonly [
+              C,
+              PropsWithoutChildren<C> &
+                Record<Exclude<keyof P, keyof PropsWithoutChildren<C>>, never>,
+            ]
+        : readonly [C, PropsWithoutChildren<C>]
     : never
   : T extends AnyComponent
-    ? T
+    ? Record<string, never> extends PropsWithoutChildren<T>
+      ? T
+      : readonly [T, PropsWithoutChildren<T>]
     : never;
 
 /**


### PR DESCRIPTION
## What was wrong

`ValidateProviders`'s type-level checking had three gaps that let invalid provider entries through the compile-time guard:

1. A bare component that requires props (no tuple, just the component itself) was accepted as valid, instead of being rejected for missing its required props.
2. A component placed where props should be, in the second slot of a `[Component, Props]` tuple (e.g. `[SimpleProvider, ThemeProvider]`), was not rejected.
3. `provider()` only had a single generic `T`, so excess-key checking (typo'd prop names) worked for inline array literals but not when props were passed as a separately-declared variable through `provider()`.

## Fix

- A bare component with required (non-optional) props now maps to a tuple shape in `ValidateProvider`, so it is caught.
- `P extends AnyComponent ? never : ...` rejects a component placed in the props position of a tuple.
- `provider()` now infers a second generic `P` and applies the same excess-key-to-`never` guard used elsewhere, so it also catches excess/typo'd keys when props come from a variable.

Closes #18

## Verification

Ran in the container workspace on this branch (via an isolated git worktree, since the shared compose checkout had unrelated uncommitted work on another branch that could not be disturbed):

```
npx nx run-many -t lint test build typecheck --projects=@evanion/compose
```

Result: lint, build, typecheck all succeeded; test suite passed — 2 test files, 29 tests passed, 0 failed, no type errors.

## Provenance

Written by an OpenClaw agent running in a container workspace; pushed to GitHub by a rescue/verification agent (not the original author) after independent verification.