### PR TITLE
fix(compose): allow ProviderArray values to be forwarded

### DIFF
--- a/libs/compose/src/Compose.test-d.tsx
+++ b/libs/compose/src/Compose.test-d.tsx
@@ -82,6 +82,21 @@ describe('compose type inference', () => {
     provider(ThemeProvider, { theme: 'dark' });
   });
 
+  it('forwards a ProviderArray-typed value through a wrapper component', () => {
+    function AppProviders({
+      providers,
+      children,
+    }: {
+      providers: ProviderArray;
+      children: React.ReactNode;
+    }) {
+      return (
+        <ComposeProvider providers={providers}>{children}</ComposeProvider>
+      );
+    }
+    expectTypeOf(AppProviders).toBeFunction();
+  });
+
   // Positive JSX cases, to prove the generic overloads still resolve in real use.
   it('compiles a correct ComposeProvider element', () => {
     const el = (

--- a/libs/compose/src/Compose.tsx
+++ b/libs/compose/src/Compose.tsx
@@ -55,14 +55,14 @@ export interface ComposeProviderProps<T extends ProviderArray = ProviderArray> {
   /**
    * Providers to compose. The first entry ends up outermost.
    *
-   * The `T & ValidateProviders<T>` intersection is deliberate. A bare
-   * `ValidateProviders<T>` is a non-homomorphic mapped type, which is not an
-   * inferable position -- TypeScript would give up on inferring `T`, fall back
-   * to the constraint, and accept anything. Keeping `T` in the intersection
-   * gives inference something to latch onto while the mapped half does the
-   * checking.
+   * The intersection with {@link ValidateProviders} is only applied when the
+   * caller passes an inline tuple literal. A value already widened to the public
+   * {@link ProviderArray} type cannot be validated element-by-element (its
+   * specific component/props types are already lost), so it is accepted as-is.
    */
-  providers: T & ValidateProviders<T>;
+  providers: T extends readonly [unknown, ...unknown[]]
+    ? T & ValidateProviders<T>
+    : ProviderArray;
   children: React.ReactNode;
 }
 
@@ -74,7 +74,9 @@ export interface ComposeProviderProps<T extends ProviderArray = ProviderArray> {
 export interface LegacyComposeProviderProps<
   T extends ProviderArray = ProviderArray,
 > {
-  components: T & ValidateProviders<T>;
+  components: T extends readonly [unknown, ...unknown[]]
+    ? T & ValidateProviders<T>
+    : ProviderArray;
   children: React.ReactNode;
 }
 


### PR DESCRIPTION
## What was wrong

`ComposeProviderProps<T>.providers` was typed as `T & ValidateProviders<T>`. `ValidateProviders` is a non-homomorphic mapped type applied element-by-element to a tuple literal, which works fine for an inline `[[Comp, props], ...]` literal but breaks when a caller has already widened their providers to the public `ProviderArray` type (e.g. accepted a `providers: ProviderArray` prop in their own wrapper component and forwarded it through). In that case the specific component/props types are already erased, so `ValidateProviders` cannot validate it element-by-element, and the type failed to accept a legitimately-typed `ProviderArray` value.

## Fix

`providers` (and the legacy `components` prop) is now conditionally typed: an inline tuple literal (`T extends readonly [unknown, ...unknown[]]`) still gets the full `T & ValidateProviders<T>` validation, but a value already widened to `ProviderArray` is accepted as-is, since it can't be validated element-by-element without its original literal type.

Closes #19

## Verification

Ran in the container workspace on this branch (via an isolated git worktree, since the shared compose checkout had unrelated uncommitted work on another branch that could not be disturbed):

```
npx nx run-many -t lint test build typecheck --projects=@evanion/compose
```

Result: lint, build, typecheck all succeeded; test suite passed — 2 test files, 27 tests passed, 0 failed, no type errors.

## Provenance

Written by an OpenClaw agent running in a container workspace; pushed to GitHub by a rescue/verification agent (not the original author) after independent verification.