### PR TITLE
fix(widget): malformed items no longer crash the page

### DIFF
--- a/libs/widget/src/constants.ts
+++ b/libs/widget/src/constants.ts
@@ -6,6 +6,10 @@ export const ERROR_MESSAGES = {
   WIDGET_FAILED: (type: string) => `Widget failed to render: ${type}`,
   LOADING: 'Loading widget...',
   UNKNOWN: 'unknown',
+  MALFORMED_ITEMS:
+    'Malformed `items` prop: expected an array of widget items. Skipping render.',
+  MALFORMED_ITEM: (id: string | undefined, type: unknown) =>
+    `Malformed widget item (id="${id ?? 'unknown'}", type="${typeof type === 'string' ? type : 'unknown'}"). Skipping render.`,
 } as const;
 
 export const DEFAULT_STYLES = {

--- a/libs/widget/src/malformed-items.test.tsx
+++ b/libs/widget/src/malformed-items.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createWidgets } from './widget.js';
+
+const Leaf = ({ label }: { label: string }) => (
+  <span data-testid={`leaf-${label}`}>{label}</span>
+);
+
+describe('malformed items are skipped instead of crashing', () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it('warns and renders nothing when items is null', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { Widgets } = createWidgets({ components: { leaf: Leaf } });
+
+    expect(() =>
+      render(<Widgets items={null as unknown as Parameters<typeof Widgets>[0]['items']} />),
+    ).not.toThrow();
+
+    expect(screen.queryByTestId(/leaf-/)).not.toBeInTheDocument();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Malformed `items` prop'),
+    );
+    warn.mockRestore();
+  });
+
+  it('warns and renders nothing when items is not an array', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { Widgets } = createWidgets({ components: { leaf: Leaf } });
+
+    expect(() =>
+      render(
+        <Widgets
+          items={{ 0: { id: 'a', type: 'leaf', props: { label: 'a' } } } as unknown as Parameters<typeof Widgets>[0]['items']}
+        />,
+      ),
+    ).not.toThrow();
+
+    expect(screen.queryByTestId(/leaf-/)).not.toBeInTheDocument();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Malformed `items` prop'),
+    );
+    warn.mockRestore();
+  });
+
+  it('warns and skips null elements, keeping valid siblings', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { Widgets } = createWidgets({ components: { leaf: Leaf } });
+
+    expect(() =>
+      render(
+        <Widgets
+          items={[
+            null,
+            { id: 'ok', type: 'leaf' as const, props: { label: 'ok' } },
+          ] as unknown as Parameters<typeof Widgets>[0]['items']}
+        />,
+      ),
+    ).not.toThrow();
+
+    expect(screen.getByTestId('leaf-ok')).toBeInTheDocument();
+    expect(screen.queryByTestId('leaf-null')).not.toBeInTheDocument();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Malformed widget item'),
+    );
+    warn.mockRestore();
+  });
+
+  it('warns and skips invalid elements, keeping valid siblings', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { Widgets } = createWidgets({ components: { leaf: Leaf } });
+
+    expect(() =>
+      render(
+        <Widgets
+          items={[
+            { id: 'bad', type: 123, props: {} },
+            { id: 'ok', type: 'leaf' as const, props: { label: 'ok' } },
+          ] as unknown as Parameters<typeof Widgets>[0]['items']}
+        />,
+      ),
+    ).not.toThrow();
+
+    expect(screen.getByTestId('leaf-ok')).toBeInTheDocument();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Malformed widget item'),
+    );
+    warn.mockRestore();
+  });
+});

--- a/libs/widget/src/utils.tsx
+++ b/libs/widget/src/utils.tsx
@@ -6,6 +6,13 @@ import type {
   WidgetItemComponent,
 } from './types.js';
 
+/** Dev-only warning helper that is stripped in production builds. */
+function warn(message: string) {
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn(message);
+  }
+}
+
 /**
  * Context carrying the current widget's children down to the injected `Output`
  * component, together with the chrome resolved for this render.
@@ -34,6 +41,11 @@ export function renderWidget(
   ItemWrapper: WidgetItemComponent,
   Output: React.ComponentType,
 ) {
+  if (item == null || typeof item !== 'object' || typeof item.type !== 'string') {
+    warn(ERROR_MESSAGES.MALFORMED_ITEM(item?.id, item?.type));
+    return null;
+  }
+
   // `in` walks the prototype chain, so a CMS-supplied type of "constructor",
   // "toString" or "__proto__" would pass this guard and hand React something
   // off Object.prototype. Items are explicitly untrusted input.
@@ -45,7 +57,7 @@ export function renderWidget(
     : undefined;
 
   if (!Component) {
-    console.warn(ERROR_MESSAGES.UNKNOWN_WIDGET(item.type, item.id));
+    warn(ERROR_MESSAGES.UNKNOWN_WIDGET(item.type, item.id));
     return null;
   }
 

--- a/libs/widget/src/widget.tsx
+++ b/libs/widget/src/widget.tsx
@@ -8,6 +8,7 @@ import type {
 } from './types.js';
 import { DefaultItem, DefaultWrapper } from './widgets.js';
 import { renderWidget, NestedWidgetsContext } from './utils.js';
+import { ERROR_MESSAGES } from './constants.js';
 
 /**
  * Builds a widget set from a component map.
@@ -78,6 +79,13 @@ export function createWidgets<const C extends WidgetComponentMap>(
       () => ({ ...defaultComponents, ...instanceComponents }),
       [instanceComponents],
     );
+
+    if (!Array.isArray(items)) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn(ERROR_MESSAGES.MALFORMED_ITEMS);
+      }
+      return null;
+    }
 
     return (
       <WidgetsProvider value={components}>


### PR DESCRIPTION
## What was wrong

`Widgets` passed `items` straight to `.map()` and `renderWidget` assumed every element was a well-formed object with a string `type`. Neither made any check. A CMS feeding `null`, an object-shaped map, or an array containing a `null` or a non-string `type` therefore threw inside render — and because the throw happened *above* the per-widget error boundary, React unmounted the whole tree. One bad row from an untrusted source took down the entire page instead of being skipped.

The cause is a missing runtime contract at the trust boundary: `items` is *typed* as an array of widget items, but it is *fed* by external data, so the type says nothing at runtime.

## What this does

- `Widgets` checks `Array.isArray(items)` before mapping; a non-array logs one development warning and renders nothing.
- `renderWidget` rejects `null`, non-objects, and items without a string `type`, warning and returning `null` for that item so valid siblings still render.
- The existing unknown-widget `console.warn` is routed through a dev-only `warn` helper.
- New `malformed-items.test.tsx` covers `items = null`, `items = {…}`, a `null` element, and an element with a numeric `type`.

## Verification

`npx nx run-many -t lint test build typecheck --projects=@evanion/react-widget --skip-nx-cache`, run on this branch in the agent workspace:

```
 Test Files  8 passed (8)
      Tests  61 passed (61)
Type Errors  no errors
EXIT=0
```

Baseline on `main` for comparison: 7 files / 57 tests passed, exit 0.

Note for anyone reproducing in that container: it exports `NODE_ENV=production`, under which the suite fails on unmodified `main` too (React 19 has no `act` in the production `react-dom/test-utils` build). Verification above was run with `NODE_ENV` unset, as CI does.

## Base and conflicts

Branched directly from `main`; independent of the other widget PRs. It does textually conflict with the #25 branch, which independently duplicates the `Array.isArray` guard and adds a `MALFORMED_ITEMS` constant with different wording — see that PR.

Fixes #23

---
Written by an OpenClaw agent; rescued from a container workspace and rebased onto `main` by another agent. No substance of the fix was changed.
