### PR TITLE
chore(widget): documentation, api surface and internals cleanups

### DIFF
--- a/libs/widget/README.md
+++ b/libs/widget/README.md
@@ -179,14 +179,15 @@ import { createContext } from 'react';
 const MyWidgetContext = createContext({});
 
 const { Widgets, WidgetsProvider } = createWidgets({
-  components: {/* your components */},
+  components: { /* your components */ },
   context: MyWidgetContext,
 });
 
-// Use the context in your app
+// Use the context in your app. The provider value is merged under the
+// factory components and any instance components you pass to Widgets.
 function App() {
   return (
-    <WidgetsProvider>
+    <WidgetsProvider value={/* optional overrides */}>
       <MyLayout />
     </WidgetsProvider>
   );
@@ -270,10 +271,11 @@ Widgets support React Suspense for loading states:
 
 #### Performance Optimizations
 
-- `React.memo` for preventing unnecessary re-renders
-- `useCallback` for stable function references
-- Optimized dependency arrays for `useMemo`
+- `React.memo` for preventing unnecessary re-renders of the `Widgets` shell.
+- Stable component identities so custom chrome and nested `Output` components
+  do not remount on every parent render.
 - Silent error handling with console warnings for unknown widget types
+  (development only).
 
 #### Unknown Widget Handling
 
@@ -317,8 +319,8 @@ interface UserProps {
 }
 
 const { Widgets } = createWidgets<{
-  news: NewsProps;
-  userInfo: UserProps;
+  news: typeof NewsTeaser;
+  userInfo: typeof UserSidebar;
 }>({
   components: {
     news: NewsTeaser,

--- a/libs/widget/src/index.ts
+++ b/libs/widget/src/index.ts
@@ -15,4 +15,3 @@ export * from './widget.js';
 export * from './widgets.js';
 export * from './types.js';
 export * from './constants.js';
-export * from './utils.js';

--- a/libs/widget/src/utils.tsx
+++ b/libs/widget/src/utils.tsx
@@ -6,27 +6,9 @@ import type {
   WidgetItemComponent,
 } from './types.js';
 
-/**
- * Context carrying the current widget's children down to the injected `Output`
- * component, together with the chrome resolved for this render.
- *
- * Passing children through context (rather than closing over them in a
- * freshly-created component) is what keeps `Output` a single stable component
- * type, and what lets nesting recurse to arbitrary depth.
- */
-export interface NestedWidgets {
-  items: RenderableWidgetItem[];
-  ItemWrapper: WidgetItemComponent;
-}
-
 const DefaultNestedItemWrapper: WidgetItemComponent = (props) => (
   <div {...props} />
 );
-
-export const NestedWidgetsContext = React.createContext<NestedWidgets>({
-  items: [],
-  ItemWrapper: DefaultNestedItemWrapper,
-});
 
 export function renderWidget(
   item: RenderableWidgetItem,
@@ -45,7 +27,9 @@ export function renderWidget(
     : undefined;
 
   if (!Component) {
-    console.warn(ERROR_MESSAGES.UNKNOWN_WIDGET(item.type, item.id));
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(ERROR_MESSAGES.UNKNOWN_WIDGET(item.type, item.id));
+    }
     return null;
   }
 
@@ -64,3 +48,21 @@ export function renderWidget(
     </NestedWidgetsContext.Provider>
   );
 }
+
+/**
+ * Context carrying the current widget's children down to the injected `Output`
+ * component, together with the chrome resolved for this render.
+ *
+ * Passing children through context (rather than closing over them in a
+ * freshly-created component) is what keeps `Output` a single stable component
+ * type, and what lets nesting recurse to arbitrary depth.
+ */
+export interface NestedWidgets {
+  items: RenderableWidgetItem[];
+  ItemWrapper: WidgetItemComponent;
+}
+
+export const NestedWidgetsContext = React.createContext<NestedWidgets>({
+  items: [],
+  ItemWrapper: DefaultNestedItemWrapper,
+});

--- a/libs/widget/src/widgets.tsx
+++ b/libs/widget/src/widgets.tsx
@@ -62,7 +62,11 @@ export function DefaultItem(
   } = props;
 
   return (
-    <div {...restProps}>
+    <div
+      {...restProps}
+      data-widget-id={widgetId}
+      data-widget-type={widgetType}
+    >
       <WidgetErrorBoundary
         widgetId={widgetId || ERROR_MESSAGES.UNKNOWN}
         widgetType={widgetType || ERROR_MESSAGES.UNKNOWN}


### PR DESCRIPTION
## What was wrong

Four unrelated cleanups, all with the same root: things the package *claimed* did not match what it *did*.

- **README claimed a `useCallback` optimisation that does not exist** in the source, and did not mention that unknown-widget warnings are development-only.
- **The `WidgetsProvider` README example omitted `value`** and said nothing about merge order, so a reader could not tell which map wins.
- **The `createWidgets` example passed a props type where a component map belongs** (`typeof NewsTeaser`, `typeof UserSidebar`), so the documented call would not compile.
- **`index.ts` re-exported `./utils.js`**, putting renderer internals (`renderWidget`, `NestedWidgetsContext`) in the public API surface at 0.1.0 by accident, where they become a compatibility obligation.
- **The unknown-widget `console.warn` was unguarded**, so a stale CMS type spammed production browser consoles and SSR logs.
- **`DefaultItem` dropped `data-widget-id` / `data-widget-type`** from its root element, contradicting the `WidgetItemComponent` contract and the behaviour of the `utils` wrapper — so the attributes appeared or not depending on which wrapper rendered.

## Reviewer note — this changes public API

Dropping `export * from './utils.js'` removes `renderWidget` and `NestedWidgetsContext` from the package entry point. That is a breaking change for anyone importing them today. Issue #26 asks for "api surface … cleanups", so this is arguably in scope, and at 0.1.0 the cost is low — but it is a deliberate removal, not a doc fix, and deserves an explicit yes/no from a maintainer rather than being waved through with the README changes.

## Verification

`npx nx run-many -t lint test build typecheck --projects=@evanion/react-widget --skip-nx-cache`, run on this branch:

```
 Test Files  7 passed (7)
      Tests  57 passed (57)
Type Errors  no errors
EXIT=0
```

Identical to the `main` baseline (7 / 57), as expected: this commit adds no tests. Nothing regressed.

## Base

Branched directly from `main`; independent of the other four widget PRs — it applies and passes on `main` alone. It touches `utils.tsx` and so may conflict textually with #23 / #24 / #27 on whichever merges second.

Part of #26

---
Written by an OpenClaw agent; rescued from a container workspace and rebased onto `main` by another agent. No substance was changed.


---

**Validator note:** the closing keyword in this body was changed from `Fixes #26` to `Part of #26` by the PR-validation pass, because the PR does not address every part of the issue. See the validation comment on this PR for the list of parts that remain. The closing keyword also appears in this PR's **commit message**, which cannot be changed without a force-push — a human must squash-merge with a corrected message, or the issue will still be closed on merge.
