### PR TITLE
ci: ignore blocked typescript 7 and eslint 10 majors in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,3 +44,20 @@ updates:
       # produces a broken workspace.
       - dependency-name: '@nx/*'
       - dependency-name: 'nx'
+      # TypeScript 7 breaks `npm ci` with ERESOLVE: @astrojs/check@0.9.10
+      # (the latest published version) declares peerDependencies of
+      # `^5.0.0 || ^6.0.0`, so it rejects TypeScript 7 outright. `versions`
+      # is scoped to the 7.x line only, so 8.x and later are still proposed
+      # normally. Remove once @astrojs/check publishes a release whose
+      # peerDependencies allow TypeScript 7 (see dependabot PR #40).
+      - dependency-name: 'typescript'
+        versions: ['^7.0.0']
+      # eslint 10 breaks `npm ci` with ERESOLVE: eslint-plugin-import@2.32.0
+      # (the latest published version) declares peerDependencies of
+      # `^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9`, so it rejects
+      # eslint 10 outright. `versions` is scoped to the 10.x line only, so
+      # 11.x and later are still proposed normally. Remove once
+      # eslint-plugin-import publishes a release whose peerDependencies
+      # allow eslint 10 (see dependabot PR #43).
+      - dependency-name: 'eslint'
+        versions: ['^10.0.0']


### PR DESCRIPTION
## Summary

Two dependabot PRs cannot merge because upstream peer dependencies do not support the new majors yet. Both fail `npm ci` with ERESOLVE. This adds two scoped `ignore` entries to `.github/dependabot.yml` so dependabot stops re-proposing exactly those majors, without suppressing any other future upgrade.

- **typescript 7.0.2** (PR #40): blocked by `@astrojs/check@0.9.10`, whose `peerDependencies` are `{"typescript": "^5.0.0 || ^6.0.0"}`. 0.9.10 is the latest published version of `@astrojs/check`; no release supports TypeScript 7. Remove the ignore once `@astrojs/check` ships a version whose peer range accepts TypeScript 7.
- **eslint 10.10.0** (PR #43): blocked by `eslint-plugin-import@2.32.0`, whose `peerDependencies` are `{"eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"}`. 2.32.0 is the latest published version of `eslint-plugin-import`; no release supports eslint 10. Remove the ignore once `eslint-plugin-import` ships a version whose peer range accepts eslint 10.

## Syntax chosen

Used `dependency-name` + `versions: ['^7.0.0']` / `['^10.0.0']` (npm semver range syntax, per the [dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference)), not `update-types: ["version-update:semver-major"]`.

`update-types: semver-major` scoped to a dependency ignores every future major forever — once TypeScript 8 or eslint 11 ship, dependabot would still be blind to them under that rule. A `versions` range scoped to the exact blocking major (`^7.0.0` = `>=7.0.0 <8.0.0`, `^10.0.0` = `>=10.0.0 <11.0.0`) blocks only the currently-unmergeable major and lets dependabot keep proposing later majors on its own, which matches "ignore only the blocking major, not the dependency forever."

## Test plan

- [x] `python3 -c "import yaml,sys; yaml.safe_load(open('.github/dependabot.yml'))"` parses cleanly
- [x] Matched existing file's ignore-block comment style (rationale + blocking package + removal condition)
- [ ] Maintainer confirms dependabot stops proposing typescript 7.x / eslint 10.x on the next run, and closes PR #40 and PR #43 once this merges (not done here — that's the maintainer's call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019s6FWxb6zpDUvbN4j1XH2B