### PR TITLE
docs(specs): design the demo apps as one tabletop shop

### DIFF
--- a/docs/specs/2026-09-10-demo-apps.md
+++ b/docs/specs/2026-09-10-demo-apps.md
@@ -1,0 +1,241 @@
+# Demo apps: Baize, a tabletop games shop
+
+Status: approved, not implemented
+Depends on: `2026-09-10-react-widget-rsc.md`, `2026-09-10-urn-rfc8141.md`, `2026-09-10-compose-unified-signature.md`, `2026-09-10-nestjs-correlation-id.md`
+
+## Why
+
+Nothing currently imports the published packages as a real consumer. `apps/docs`
+has no `@evanion/*` dependency at all — its `WidgetPlayground` supplies a
+hand-written `mockCreateWidgets`, so the documented API is exercised by nothing.
+That is the gap #21 and #27 both name.
+
+These apps close it. They are the first real consumers, and because nothing sets
+`resolve.conditions` for Vite, Astro or Next, they resolve `@evanion/*` through
+the normal `import`/`default` conditions to built `dist/` via the workspace
+symlinks. They therefore test the real packaging, not the source.
+
+## Decisions
+
+1. One connected system, not three isolated demos.
+2. Runnable locally. Not deployed.
+3. Subject: a tabletop games shop, called Baize.
+4. Scope: browse, cart, stubbed checkout. No payments, no auth, no database.
+5. The API is the contract. Each app types its own responses. No package that
+   exists only to serve demos.
+6. The storefront server-renders, so the correlation id crosses storefront → API
+   on a page view.
+7. Apps double as the source of documentation examples.
+
+Decisions 5 and 6 were assumed rather than confirmed. Both are cheap to reverse.
+
+## The apps
+
+### `apps/shop-api` — Nest
+
+Generated with `nx g @nx/nest:application`. `@nx/nest` is not installed yet and
+must be added; unlike Astro, an official nx plugin exists, so this is not
+hand-assembled.
+
+```
+GET  /games              list
+GET  /games/:urn         one
+GET  /inventory/:urn     stock for a game
+POST /orders             validates cart, returns an order urn
+```
+
+In-memory data. No persistence.
+
+**The correlation-id hop.** `withCorrelation` is decorative unless something
+outgoing actually carries the header. Rather than add a fourth app, the orders
+module calls the inventory module over HTTP on localhost through `HttpService`.
+Same process, real HTTP hop, and the correlation id is visible on both sides.
+
+That hop is also the exact shape that exposes #31: `withCorrelation` injects the
+request-scoped `CorrelationService` into an `HttpModuleOptions` factory, which
+makes `HttpService` request-scoped for every consumer in the module. The demo
+therefore doubles as the regression case — a singleton holding `HttpService`
+should be constructed once, and `onModuleInit` should fire.
+
+### `apps/storefront` — Astro
+
+The renamed `apps/astro-widget-demo`, grown. Keeps its history and tests.
+
+```
+/                landing, CMS block data
+/c/[category]    category page
+/g/[urn]         game detail
+/cart            cart, stubbed checkout
+```
+
+Server-rendered rather than statically built. A static build would bake the
+catalogue in and the correlation id would never cross on a page view, which
+removes the reason correlation-id is in the demo at all.
+
+Consumes `@evanion/astro-widget`. Needs the `meta` change from the react-widget
+spec applied here too: `Widgets.astro` currently destructures
+`const { type, id, children, ...props } = item` and spreads `{...props}` into
+both `<Item>` and `<Component>`, so placement data leaks into block props.
+
+### `apps/dashboard` — Next App Router
+
+Generated with `nx g @nx/next:application`. Built after the react-widget
+redesign lands, not before — every widget call site would otherwise be rewritten
+when `Output` becomes `children` and the provider and error boundary go.
+
+Merchant view: orders, stock by game, and a widget grid positioned by `meta`.
+That is #71's motivating case, so the dashboard validates the `meta` design
+rather than only documenting it. Widgets are async Server Components fetching
+from the API, which makes the RSC claim concrete.
+
+Providers — cart, session, theme — composed with `@evanion/compose`.
+
+## Domain and `urn`
+
+Entity identity across all three apps, with a subclass per entity type, which
+exercises the custom-`nid` path:
+
+```
+urn:game:wingspan
+urn:expansion:wingspan-europe
+urn:order:8f2c1a
+```
+
+An expansion belongs to a parent game, which is the composite-key case #10 was
+about. Under the RFC spec, `stringify` no longer deduplicates, so a composite
+NSS survives a round trip intact.
+
+NIDs here — `game`, `expansion`, `order` — all satisfy RFC 8141's 2–32 ldh
+grammar, so the demo stays inside the conformant path.
+
+## Visual design
+
+Reference point was oxm.gg, diverged from deliberately.
+
+What that site does well and is worth taking: colour is a data channel, not a
+mood. Its chrome is strictly neutral and saturation is rationed to
+identity-bearing tokens — class colours on names, instance colours on chips,
+status pills. Radii vary by role (3px chips, 6px buttons, 12px cards). Tracking
+runs opposite by size, negative on heavy display, positive on small labels.
+Shadows layer a black elevation with a tinted 4% glow. Icons carry meaning.
+Motion is interaction-only.
+
+**The structural divergence: Baize has no house colour.** oxm.gg has one bronze
+accent plus its class system. Here the catalogue supplies every saturated pixel,
+because a game shop's identity is its games. Primary actions invert ink and
+parchment rather than using a brand button. This also avoids the near-black
+plus one bright accent pattern.
+
+Ground is table baize, chromatic rather than tinted black:
+
+```
+ink      #0C1714   page
+felt     #142521   panels
+rule     #2A3F39   hairlines
+chalk    #F2EDE3   primary text, warm, rulebook paper rather than #fff
+lichen   #8FA69E   secondary text
+moss     #5E736C   tertiary text
+```
+
+Two informational colour systems on top:
+
+- **Mechanism** — categorical hues on game titles and tags. Worker placement,
+  deckbuilder, area control, co-op, dexterity. The class-colour analogue: how
+  players actually identify a game.
+- **Availability** — in stock, preorder, reprint pending, out of print. State
+  pills.
+
+Weight (1–5) takes a sequential ramp, not categorical hues, because it is
+ordinal.
+
+**Type.** Two families where oxm.gg uses one. Bricolage Grotesque for game
+titles, for its width and optical-size axes. Public Sans for text and data, set
+`font-variant-numeric: tabular-nums` because the stat line is numeric and must
+align down a column. Not Inter.
+
+**The stat line is the hero and the structural device.** Players, time and
+weight is how anyone identifies a game at a glance, so it leads rather than
+sitting beneath a photograph.
+
+```
+┌────────────────────────────────────────┐
+│ WINGSPAN                    ● IN STOCK │  title in mechanism hue
+│ engine building · set collection       │  tags, same hue, lower weight
+├────────────────────────────────────────┤
+│  1–5      40–70 min      2.4 / 5       │  tabular figures, aligned
+│  players  playtime       weight        │
+├────────────────────────────────────────┤
+│ [ box art — the only photographic      │
+│   colour on the card ]                 │
+└────────────────────────────────────────┘
+```
+
+Checked against the generic defaults: no cream ground, no terracotta, no serif
+display on parchment, no `01 / 02` markers, no all-caps eyebrow above every
+heading, no `→` appended to buttons, no uniform radius, no identical cards
+sharing one grey shadow. The dark ground is on the tell list and is kept
+deliberately: the subject is a table surface, and the hue is chromatic rather
+than a tinted near-black.
+
+## Docs integration
+
+Two independent mechanisms.
+
+**Snippet extraction.** A small custom remark plugin reading named region
+markers, wired through `nextra({ mdxOptions: { remarkPlugins } })`. It runs
+inside the MDX compile step of `next build`, so it needs no npm lifecycle hook —
+which matters because Nx invokes `next build` directly and that is already why
+pagefind's `postbuild` is a separate CI step. Static export is unaffected: the
+plugin reads files at build time and the output is static markdown before HTML
+is emitted.
+
+Not `remark-code-import`: last published 2023-05-06, still on
+`unist-util-visit@^4` against this repo's MDX 3 / unified 11 stack, and it
+supports only line ranges. Line numbers drift silently when the source file is
+edited above them. VitePress ships region-marker import first-party, so the
+feature class is solved elsewhere; there is simply no current remark package
+for it.
+
+Consequence to design around: extracted snippets are type-checked only because
+their source file compiles inside its own app. The docs build does not re-check
+them. Regions must therefore be self-contained — imports resolvable, nothing
+split across a boundary — or whole files.
+
+**Live rendering.** Replace `WidgetPlayground`'s `mockCreateWidgets` with a real
+`@evanion/react-widget` import. Mechanically trivial once the package is a docs
+dependency, and it works today because react-live evaluates client-side.
+Importing it as a plain MDX JSX tag in an RSC page needs the redesign first.
+Radix does exactly this — its docs import the real packages with no mock layer.
+
+`PlaygroundExamples.tsx` already has three hardcoded examples named `basic`,
+`ecommerce` and `dashboard`, all against the mock. These replace precisely those.
+
+## Sequencing
+
+1. Rename `astro-widget-demo` to `storefront`. In flight.
+2. `shop-api`, with the orders → inventory hop. Depends on nothing else.
+3. Storefront grown into the shop against the API.
+4. react-widget redesign lands.
+5. `dashboard`.
+6. Docs extraction plugin, once there is real source to extract from.
+
+Steps 2 and 3 do not depend on any library redesign. Step 5 does.
+
+## Conventions a new app must meet
+
+- Per-project `eslint.config.mjs` importing `baseConfig, { sharedRules }` from
+  the relative root config, spreading `baseConfig`, adding an `ignores` block,
+  reapplying `sharedRules` last.
+- A project-local `vite.config.ts` or `vitest.config.ts`, not just an entry in
+  the root aggregator, or `@nx/vitest` will not infer a `test` target. This is
+  why `fdd42f8` added one to the Astro app.
+- Extend `../../tsconfig.base.json`, and add the project to the root
+  `tsconfig.json` `references` array.
+- Nothing to do for release: `nx.json` `release.projects` is `libs/*` and
+  `nest/*`, so apps are never published.
+- Nothing to do for CI: `run-many` skips targets a project does not have, so a
+  new app is picked up automatically.
+- Watch the `typecheck`/`check` split on the Astro app. `@nx/js/typescript`
+  infers `typecheck` from `tsconfig.json` but replaces it with a no-op echo when
+  the resolved config sets `noEmit: true`, which Astro's shared base does. Real
+  type checking there is `astro check`, inferred as `check` by `tools/nx-astro`.


### PR DESCRIPTION
Design for the demo apps. No code, one spec file.

## Why these exist

Nothing currently imports the published packages as a real consumer. `apps/docs` has no `@evanion/*` dependency at all — `WidgetPlayground` supplies a hand-written `mockCreateWidgets`, so the documented API is exercised by nothing. That is the gap #21 and #27 both name.

Because nothing sets `resolve.conditions` for Vite, Astro or Next, these apps resolve `@evanion/*` through the normal `import`/`default` conditions to built `dist/` via the workspace symlinks. They exercise the real packaging, not the source.

## Shape

One connected system rather than three isolated demos: a tabletop games shop called Baize.

| App | Stack | Libraries |
| --- | --- | --- |
| `apps/shop-api` | Nest, in-memory | `nestjs-correlation-id`, `urn` |
| `apps/storefront` | Astro, server-rendered | `astro-widget`, `urn` |
| `apps/dashboard` | Next App Router | `react-widget`, `compose`, `urn` |

Scope is browse, cart, stubbed checkout. No payments, no auth, no database.

The correlation-id hop is orders calling inventory over HTTP on localhost — a real hop without a fourth app. That is also the exact shape that exposes #31's scope bubbling, so the demo doubles as the regression case: a singleton holding `HttpService` should be constructed once, and `onModuleInit` should fire.

`urn` carries entity identity across all three, with a subclass per type. An expansion belonging to a parent game is the composite-key case #10 was about.

## Visual direction

Reference point was oxm.gg, diverged from structurally rather than cosmetically.

What it does well: colour is a data channel, not a mood. Chrome stays strictly neutral and saturation is rationed to identity-bearing tokens. Radii vary by role. Tracking runs opposite by size. Motion is interaction-only.

The divergence: Baize has no house colour. The catalogue supplies every saturated pixel, because a game shop's identity is its games, and primary actions invert ink and parchment rather than using a brand button. Ground is table baize — chromatic, not tinted near-black. Two informational colour systems on top: mechanism (categorical) and availability (state). Weight takes a sequential ramp since it is ordinal.

## Docs integration

A small custom remark plugin reading named region markers, wired through `nextra({ mdxOptions })`. It runs inside `next build`'s MDX step, so no npm lifecycle hook is needed — which matters because Nx invokes `next build` directly, and that is already why pagefind's `postbuild` is a separate CI step.

Not `remark-code-import`: last published 2023-05-06, still on `unist-util-visit@^4` against this repo's MDX 3 stack, and line-range only. Line numbers drift silently when the source is edited above them.

Separately, `WidgetPlayground`'s mock gets replaced with a real import. `PlaygroundExamples.tsx` already has examples named `basic`, `ecommerce` and `dashboard` — these replace precisely those.

## Sequencing

`shop-api` and the storefront depend on no library redesign and can start now. `dashboard` waits for the react-widget spec to land, otherwise every widget call site is written twice. Docs extraction is last, once there is real source to extract from.

## Assumed, not confirmed

The API is the contract with each app typing its own responses, rather than a shared package that exists only to serve demos. The storefront server-renders so the correlation id crosses on a page view. Both are cheap to reverse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019s6FWxb6zpDUvbN4j1XH2B