### PR TITLE
docs(specs): build the dashboard on react router, not next

### DIFF
--- a/docs/specs/2026-09-10-demo-apps.md
+++ b/docs/specs/2026-09-10-demo-apps.md
@@ -17,7 +17,7 @@ symlinks. They therefore test the real packaging, not the source.
 
 ## Decisions
 
-1. One connected system, not three isolated demos.
+1. One connected system, not a set of isolated demos.
 2. Runnable locally. Not deployed.
 3. Subject: a tabletop games shop, called Baize.
 4. Scope: browse, cart, stubbed checkout. No payments, no auth, no database.
@@ -59,7 +59,8 @@ should be constructed once, and `onModuleInit` should fire.
 
 ### `apps/storefront` — Astro
 
-The renamed `apps/astro-widget-demo`, grown. Keeps its history and tests.
+The Astro app, grown. Renamed from `astro-widget-demo` in `e662bcd`, history
+and tests intact.
 
 ```
 /                landing, CMS block data
@@ -77,22 +78,59 @@ spec applied here too: `Widgets.astro` currently destructures
 `const { type, id, children, ...props } = item` and spreads `{...props}` into
 both `<Item>` and `<Component>`, so placement data leaks into block props.
 
-### `apps/dashboard` — Next App Router
+### `apps/admin` — React Router
 
-Generated with `nx g @nx/next:application`. Built after the react-widget
-redesign lands, not before — every widget call site would otherwise be rewritten
-when `Output` becomes `children` and the provider and error boundary go.
+The merchant back office, and the real dashboard. React Router is the working
+stack here and `nx.json` already configures `@nx/react/router-plugin`.
 
-Merchant view: orders, stock by game, and a widget grid positioned by `meta`.
-That is #71's motivating case, so the dashboard validates the `meta` design
-rather than only documenting it. Widgets are async Server Components fetching
-from the API, which makes the RSC claim concrete.
+Generated with `nx g @nx/react:application --useReactRouter=true --bundler=vite`.
+Note that `@nx/react@23.1.1` pins `reactRouterVersion = "^7.14.2"`, which
+predates React Router v8 and wires no RSC plugin, so the generated app needs a
+manual bump to v8 afterwards. `@nx/react/router-plugin` in `nx.json` is target
+inference on `react-router.config.*`, not a generator — it does not scaffold.
 
-Providers — cart, session, theme — composed with `@evanion/compose`.
+Standard SSR framework mode: loaders run server-only, route components are
+isomorphic and receive `loaderData` as props. Widget items come from the route
+loader and are passed down.
+
+What this app demonstrates, honestly: `@evanion/react-widget` with no
+`'use client'`, no context, no class error boundary, rendering server-side in a
+mainstream framework. Orders, stock by game, and a widget grid positioned by
+`meta` — #71's motivating case, so it validates the `meta` design rather than
+only documenting it. Providers — cart, session, theme — composed with
+`@evanion/compose`.
+
+What it must not claim: that a widget fetches its own data. On stable React
+Router a route component is not a server component; it always ships to and runs
+on the client, and data has to come from a loader. That claim belongs to the
+Next app below.
+
+### `apps/rsc-example` — Next App Router, minimal
+
+One page, one async widget, nothing else. Its only job is to prove the claim the
+react-widget redesign is actually about: a widget as an async Server Component
+fetching its own data, with no `'use client'` anywhere in the package.
+
+Next App Router RSC has been stable since Next 13, so this is the uncontested
+way to demonstrate the mechanism.
+
+React Router's own RSC support is not a substitute yet. It landed as a preview
+in v7.9.2 (18 September 2025) behind `unstable_reactRouterRSC` plus
+`@vitejs/plugin-rsc`, every API carries an `unstable_` prefix, the docs still
+warn of breaking changes in minor and patch releases, and there is no stated
+ETA. SPA mode, pre-rendering and custom build entries are unsupported under it.
+The underlying primitive is the same — `@vitejs/plugin-rsc` sets
+`resolve.conditions: ["react-server", ...]`, exactly what Next uses — so this
+becomes a React Router capability later. It is not one to build a demo's
+headline claim on today.
+
+Built after the react-widget redesign lands. Before that, every widget call site
+would be rewritten when `Output` becomes `children` and the provider and error
+boundary go.
 
 ## Domain and `urn`
 
-Entity identity across all three apps, with a subclass per entity type, which
+Entity identity across every app, with a subclass per entity type, which
 exercises the custom-`nid` path:
 
 ```
@@ -212,14 +250,15 @@ Radix does exactly this — its docs import the real packages with no mock layer
 
 ## Sequencing
 
-1. Rename `astro-widget-demo` to `storefront`. In flight.
+1. Rename `astro-widget-demo` to `storefront`. Done, `e662bcd`.
 2. `shop-api`, with the orders → inventory hop. Depends on nothing else.
 3. Storefront grown into the shop against the API.
 4. react-widget redesign lands.
-5. `dashboard`.
-6. Docs extraction plugin, once there is real source to extract from.
+5. `admin` on React Router.
+6. `rsc-example` on Next.
+7. Docs extraction plugin, once there is real source to extract from.
 
-Steps 2 and 3 do not depend on any library redesign. Step 5 does.
+Steps 2 and 3 depend on no library redesign. Steps 5 and 6 do.
 
 ## Conventions a new app must meet
 


### PR DESCRIPTION
Corrects the dashboard section of the demo-apps spec. Docs only.

## What changed

The working stack here is React Router, and `nx.json` already configures `@nx/react/router-plugin`. I should have read that as a signal instead of defaulting to Next.

It splits into two apps, because one of them cannot honestly make the claim the react-widget redesign is about.

**`apps/admin`** — the real merchant back office. React Router v8, standard SSR framework mode. Orders, stock by game, a widget grid positioned by `meta` (#71's motivating case), providers composed with `compose`.

It demonstrates `react-widget` with no `'use client'`, no context and no class error boundary, rendering server-side in a mainstream framework. It must **not** claim a widget fetches its own data: on stable React Router a route component is not a server component, it always ships to and runs on the client, and data comes from a loader as props.

**`apps/rsc-example`** — one page, one async widget, on Next App Router. Its only job is proving that claim. Next has had stable RSC since 13.

## Why React Router can't carry the RSC claim yet

Preview only. Landed in v7.9.2 (18 Sep 2025) behind `unstable_reactRouterRSC` plus `@vitejs/plugin-rsc`. Every API carries an `unstable_` prefix, the docs warn of breaking changes in minor and patch releases, and there is no stated ETA. SPA mode, pre-rendering and custom build entries are unsupported under it.

The primitive is the same — `@vitejs/plugin-rsc` sets `resolve.conditions: ["react-server", ...]`, exactly what Next uses — so this becomes a React Router capability later. It is not one to hang a demo's headline claim on today.

## Generator note

`@nx/react@23.1.1` pins `reactRouterVersion = "^7.14.2"`, which predates v8 and wires no RSC plugin, so `nx g @nx/react:application --useReactRouter=true --bundler=vite` needs a manual bump afterwards. `@nx/react/router-plugin` in `nx.json` is target inference on `react-router.config.*`, not a generator — it does not scaffold.

## Also in here

The rename to `apps/storefront` shipped in `e662bcd`, so the two lines still calling it "in flight" are corrected, and the app counts updated now that there are four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019s6FWxb6zpDUvbN4j1XH2B