### PR TITLE
feat(urn)!: implement RFC 8141 with role-scoped grammars

### DIFF
--- a/libs/urn/README.md
+++ b/libs/urn/README.md
@@ -63,7 +63,10 @@ console.log(parsed); // -> {urn:'trn', nid: 'bar', nss: 'foo'}
 - **Namespace Support**: Handle custom namespaces and identifiers
 - **Class Inheritance**: Extend the base URN class for domain-specific implementations
 - **TypeScript Support**: Full TypeScript support with comprehensive type definitions
-- **Validation**: Built-in validation for every URN component (`a-z`, `0-9`, `-`, `.`, `_`, `~`, `:`, case insensitive)
+- **RFC 8141 grammar**: A role-scoped grammar for the scheme, the NID and the
+  NSS, rather than one flat character class
+- **Case-folded comparison**: `sameNamespace`, `belongsToNamespace` and
+  `equals` fold the scheme and the NID, per RFC 8141 §3.1
 
 ## Why should you use a URN
 
@@ -134,11 +137,39 @@ const parsed = UserTRN.parse('trn:order:42');
 console.log(parsed); // -> {urn: 'trn', nid: 'order', nss: 'order:42'}
 ```
 
+A foreign **scheme** is retained the same way, verbatim, so a record read from
+another scheme cannot be silently re-labelled as this one:
+
+```ts
+UserTRN.parse('ftp:user:1'); // -> {urn: 'ftp', nid: 'user', nss: 'ftp:user:1'}
+UserTRN.parse('trn:user:1'); // -> {urn: 'trn', nid: 'user', nss: '1'}
+```
+
+The comparisons are case-folded, so `URN:USER:1` is not foreign to a `urn` /
+`user` class. The parts always come back in the case they were written in.
+
 ## Validation & Error Handling
 
-The library validates the URN scheme, the NID **and** the NSS. A component may
-contain `a-z`, `0-9`, `-`, `.`, `_`, `~` and `:` (case insensitive), and must not
-be empty:
+The library validates the URN scheme, the NID **and** the NSS, each against its
+own grammar. There is no single character class: the three roles are different
+in the RFC and are different here.
+
+| Role           | Allowed                                                                                                                                   | Length                     |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| scheme (`urn`) | a letter, then letters, digits, `+`, `-`, `.`                                                                                             | unbounded                  |
+| NID            | letters and digits, plus `-` in the interior                                                                                              | 2–32 writing, 1–32 reading |
+| NSS            | letters, digits, `-` `.` `_` `~` `!` `$` `&` `'` `(` `)` `*` `+` `,` `;` `=` `:` `@`, percent-triplets, and `/` after the first character | unbounded                  |
+
+Letters are case-insensitive everywhere. Every component must be non-empty.
+
+Read the grammars off the class if you need them — they stay reactive to a
+subclass's `separator`:
+
+```ts
+URN.schemeGrammar; // /^[A-Za-z][A-Za-z0-9+.-]*$/
+URN.nidGrammar; // /^[A-Za-z0-9][A-Za-z0-9-]{0,30}[A-Za-z0-9]$/
+URN.nssGrammar; // the RFC 8141 `pchar *(pchar / "/")` set
+```
 
 ```ts
 import { URN, InvalidError } from '@evanion/urn';
@@ -151,7 +182,7 @@ UserTRN.stringify('1337', 'foo', 'b!r'); // -> will throw a URN ValidationError
 
 // Handle errors gracefully
 try {
-  const urn = URN.stringify('invalid!character', 'namespace');
+  const urn = URN.stringify('invalid character', 'namespace');
 } catch (error) {
   if (error instanceof InvalidError) {
     console.log('Invalid URN:', error.message);
@@ -159,24 +190,98 @@ try {
 }
 ```
 
-The library won't add a namespace if it already exists:
+### Read-lenient, write-strict
+
+`stringify` enforces the RFC 8141 NID exactly. `parse` accepts the same
+character set but allows a one-character NID, because RFC 2141 permitted one and
+RFC 8141 Appendix B keeps earlier-valid URNs valid. Nothing else is relaxed on
+read:
 
 ```ts
-UserTRN.stringify('user:1337'); // -> 'trn:user:1337'
+URN.parse('urn:x:1'); // ok
+URN.stringify('1', 'x'); // throws: NID must be at least 2 characters long
 ```
+
+### Percent-encoding
+
+`stringify` does not encode and `parse` does not decode. Both work on the wire
+form, so a value can never be double-encoded by accident. `stringify` rejects an
+NSS that is not already encoded:
+
+```ts
+URN.stringify('a b', 'example'); // throws
+URN.stringify('a%20b', 'example'); // 'urn:example:a%20b'
+URN.parse('urn:example:a%20b').nss; // 'a%20b' -- triplets come back intact
+```
+
+Two helpers cover the conversion explicitly:
+
+```ts
+import { encodeNss, decodeNss } from '@evanion/urn';
+
+encodeNss('café'); // 'caf%C3%A9'
+decodeNss('caf%C3%A9'); // 'café'
+```
+
+### Equivalence
+
+`URN.equals` implements RFC 8141 §3.1: the scheme and the NID are compared
+case-insensitively, the NSS character for character, except that the hex digits
+of a percent-triplet canonicalise to uppercase. A percent-encoded octet is never
+decoded for comparison:
+
+```ts
+URN.equals('URN:Example:a123%2cz456', 'urn:example:a123%2Cz456'); // true
+URN.equals('urn:example:a123%2Cz456', 'urn:example:a123,z456'); // false
+URN.equals('urn:example:A123', 'urn:example:a123'); // false
+```
+
+### Custom separators are not RFC 8141
+
+A subclass that overrides `separator` gets a generic character class with the
+separator excluded, for the scheme and the NID, and no RFC length bounds. The
+NSS keeps the RFC grammar under every separator. Such a subclass is **not**
+claimed to be RFC 8141 conformant.
 
 ## Important Caveats
 
-Since classes aren't aware of sibling classes, stringifying a `NSS` that contains another namespace will cause duplication of namespaces:
+`stringify` does not deduplicate. Whatever you pass as the NSS is emitted
+verbatim after the scheme and the NID, so an NSS whose first segment happens to
+equal the NID survives the round trip:
 
 ```ts
-UserTRN.stringify('order:42'); // -> 'trn:user:order:42' (duplicated!)
+UserTRN.stringify('user:42'); // -> 'trn:user:user:42'
+UserTRN.parse('trn:user:user:42').nss; // -> 'user:42'
 ```
 
-**Recommended solution**: Set the namespace to what you expect:
+Earlier versions dropped the repeated segment, which made `user:42` — a
+composite key imported from another system — irrecoverable. If you meant the
+other namespace, name it:
 
 ```ts
-UserTRN.stringify('order:42', 'order'); // -> 'trn:order:42' (correct!)
+UserTRN.stringify('42', 'order'); // -> 'trn:order:42'
+```
+
+`stringify` is also not idempotent, and is not a normaliser:
+
+```ts
+URN.stringify(URN.stringify('foo')); // -> 'urn:nid:urn:nid:foo'
+```
+
+The statics are unbound. Every one of them reads `this`, so unlike
+`JSON.stringify` they cannot be destructured:
+
+```ts
+const { stringify } = URN;
+stringify('a'); // TypeError -- the default parameter `nid = this.nid` needs `this`
+```
+
+The arguments to `stringify` are in the reverse order of `parse`'s return shape,
+so `stringify(...Object.values(parse(x)))` is silently wrong. Pass them by name:
+
+```ts
+const parsed = URN.parse(input);
+URN.stringify(parsed.nss, parsed.nid, parsed.urn);
 ```
 
 ## Common Use Cases
@@ -214,15 +319,25 @@ const userResourceUrn = ServiceURN.stringify('123', 'user-service');
   Throws `InvalidError` if any component is empty or contains a disallowed character.
 - `URN.parse(urnString)` — Parses a URN string into `{ urn, nid, nss }`.
   Throws `ValidationError` if the string is not a well-formed URN.
-- `URN.isValidFormat(urnString)` — `true` if the string has at least three
-  non-empty parts. Never throws, so it is the cheap way to test input first.
+- `URN.isValidFormat(urnString)` — `true` if the string parses. Delegates to
+  `parse`, so the two can never disagree. Never throws, so it is the cheap way
+  to test input first.
 - `URN.extractId(urnString)` — Returns everything after the scheme and the NID.
   Throws `ValidationError` on malformed input.
 - `URN.sameNamespace(a, b)` — `true` if both URNs share a scheme and NID.
   Returns `false` for malformed input rather than throwing.
 - `URN.belongsToNamespace(urnString, nid, urn?)` — `true` if the URN is in the
-  given namespace. `urn` defaults to **this class's own scheme**, so it works on
-  subclasses without repeating the scheme.
+  given namespace, comparing case-insensitively. `urn` defaults to **this
+  class's own scheme**, so it works on subclasses without repeating the scheme.
+- `URN.equals(a, b)` — RFC 8141 §3.1 equivalence. Returns `false` for malformed
+  input rather than throwing.
+
+### Functions
+
+- `encodeNss(raw)` — percent-encodes everything outside RFC 3986's `unreserved`
+  set, producing a valid NSS.
+- `decodeNss(encoded)` — the inverse. Throws `ValidationError` on a malformed or
+  truncated percent sequence.
 
 #### `parse().nss` vs `extractId()`
 
@@ -242,16 +357,24 @@ trailing identifier.
 
 - `ValidationError` — base class for everything this library throws. Catch this
   to handle any validation failure.
-- `InvalidError extends ValidationError` — a component was empty or contained a
-  disallowed character. Carries `property` (`'URN' | 'NID' | 'NSS'`), `value`,
-  and `invalidChar` when one could be identified.
+- `InvalidError extends ValidationError` — a component was empty, contained a
+  disallowed character, or broke a structural rule of its grammar. Carries
+  `property` (`'URN' | 'NID' | 'NSS'`), `value`, `invalidChar` when a single
+  character is at fault, and `reason` when none is — a length bound, a leading
+  hyphen, a truncated percent-triplet.
 
 ### Class Properties
 
 - `static urn: string` - The URN scheme (default: 'urn')
 - `static separator: string` - The separator between components (default: ':')
 - `static nid: string` - The namespace identifier (default: 'nid')
-- `static isValid: RegExp` - The character class each component must match
+- `static schemeGrammar: RegExp` - The grammar the scheme must match
+- `static nidGrammar: RegExp` - The grammar the NID must match when writing
+- `static nssGrammar: RegExp` - The grammar the NSS must match
+
+`isValid` is gone. One flat regex cannot describe three roles across two
+separator regimes; the three getters can, and they stay reactive to a
+subclass's `separator`.
 
 When overriding these in a subclass, TypeScript's `noImplicitOverride` requires
 the `override` keyword:

--- a/libs/urn/src/lib/exceptions.ts
+++ b/libs/urn/src/lib/exceptions.ts
@@ -21,28 +21,39 @@ export class ValidationError extends Error {
 }
 
 /**
- * Thrown when a URN component is empty or contains characters outside the
- * permitted set.
+ * Thrown when a URN component is empty, contains a character outside its
+ * role's permitted set, or breaks a structural rule of its role's grammar
+ * (a length bound, a leading hyphen, a truncated percent-triplet).
  */
 export class InvalidError extends ValidationError {
-  constructor(property: string, value: string, invalidChar?: string) {
-    super(InvalidError.buildMessage(property, value, invalidChar));
+  constructor(
+    property: string,
+    value: string,
+    invalidChar?: string,
+    reason?: string,
+  ) {
+    super(InvalidError.buildMessage(property, value, invalidChar, reason));
     this.name = 'InvalidError';
     this.property = property;
     this.value = value;
     this.invalidChar = invalidChar;
+    this.reason = reason;
   }
 
   private static buildMessage(
     property: string,
     value: string,
     invalidChar?: string,
+    reason?: string,
   ): string {
     if (value === '') {
       return `${property} must not be empty`;
     }
     if (invalidChar) {
       return `${property} contains invalid character '${invalidChar}' in '${value}'`;
+    }
+    if (reason) {
+      return `${property} is invalid in '${value}': ${reason}`;
     }
     return `${property} contains invalid characters in '${value}'`;
   }
@@ -53,4 +64,10 @@ export class InvalidError extends ValidationError {
   readonly value: string;
   /** The first disallowed character, when one could be identified. */
   readonly invalidChar?: string;
+  /**
+   * Why the component failed when no single character is at fault: every
+   * character is permitted for the role, but the value breaks a structural
+   * rule such as the NID length bounds.
+   */
+  readonly reason?: string;
 }

--- a/libs/urn/src/lib/types.ts
+++ b/libs/urn/src/lib/types.ts
@@ -13,8 +13,7 @@ export type IFullURN<
   URN extends string,
   NID extends string,
   NSS extends string,
-  x extends string = '',
-> = `${URN}:${NID}:${NSS}${x}`;
+> = `${URN}:${NID}:${NSS}`;
 
 /**
  * The object returned by `URN.parse`.
@@ -32,8 +31,11 @@ export interface ParsedURN {
   /**
    * The namespace specific string.
    *
-   * When the parsed NID differs from the parsing class's own `nid`, the NID is
-   * retained here so the namespace is not silently lost.
+   * Returned in its original case, with percent-triplets intact.
+   *
+   * When the parsed scheme differs from the parsing class's own `urn`, the
+   * whole original identifier is retained here; when only the NID differs, the
+   * NID is retained here. Either way the namespace is not silently lost.
    */
   nss: string;
 }

--- a/libs/urn/src/lib/urn.spec.ts
+++ b/libs/urn/src/lib/urn.spec.ts
@@ -1,7 +1,21 @@
 import { describe, it, expect } from 'vitest';
 
 import { InvalidError, ValidationError } from './exceptions.js';
-import { URN } from './urn.js';
+import { decodeNss, encodeNss, URN } from './urn.js';
+
+/**
+ * Every `pchar` class plus `/`, and a percent-triplet, in one NSS. Starts with
+ * a `pchar` because RFC 8141 forbids a leading `/`.
+ */
+const PCHAR_SOUP = "abc-._~!$&'()*+,;=:@/%C3%A9";
+
+/** Builds a throwaway subclass so a URN can be round-tripped in its own namespace. */
+function namespaceOf(urn: string, nid: string): typeof URN {
+  return class extends URN {
+    static override readonly urn = urn;
+    static override readonly nid = nid;
+  };
+}
 
 describe('URN', () => {
   describe('stringify', () => {
@@ -13,11 +27,7 @@ describe('URN', () => {
       expect(URN.stringify('foo', 'bar')).toBe('urn:bar:foo');
     });
 
-    it('should reject components that contain the separator', () => {
-      expect(() => URN.stringify('a:b', 'nid')).toThrow(InvalidError);
-      expect(() => URN.stringify('a:b', 'nid')).toThrow(
-        "NSS contains invalid character ':' in 'a:b'",
-      );
+    it('should reject a scheme or NID that contains the separator', () => {
       expect(() => URN.stringify('foo', 'n:i')).toThrow(InvalidError);
       expect(() => URN.stringify('foo', 'n:i')).toThrow(
         "NID contains invalid character ':' in 'n:i'",
@@ -25,6 +35,29 @@ describe('URN', () => {
       expect(() => URN.stringify('foo', 'nid', 'u:n')).toThrow(InvalidError);
       expect(() => URN.stringify('foo', 'nid', 'u:n')).toThrow(
         "URN contains invalid character ':' in 'u:n'",
+      );
+    });
+
+    it('should accept an NSS that contains the separator', () => {
+      // Split-then-rejoin on the same delimiter is lossless for the tail, so
+      // the NSS can never structurally collide with the separator.
+      expect(URN.stringify('a:b', 'nid')).toBe('urn:nid:a:b');
+      expect(URN.parse('urn:nid:a:b').nss).toBe('a:b');
+    });
+
+    it('should no longer deduplicate an NSS that starts with the NID', () => {
+      const UserURN = namespaceOf('urn', 'user');
+      expect(UserURN.stringify('user:42')).toBe('urn:user:user:42');
+      expect(UserURN.parse('urn:user:user:42').nss).toBe('user:42');
+    });
+
+    it('should keep a foreign namespace prefix verbatim in the NSS', () => {
+      expect(URN.stringify('foo:bar', 'example')).toBe('urn:example:foo:bar');
+    });
+
+    it("should accept RFC 8141's own example NSS", () => {
+      expect(URN.stringify('a123,z456', 'example')).toBe(
+        'urn:example:a123,z456',
       );
     });
 
@@ -40,6 +73,163 @@ describe('URN', () => {
       expect(() => URN.stringify('foo', 'b?r')).toThrow(
         "NID contains invalid character '?' in 'b?r'",
       );
+    });
+
+    it('should reject a scheme that does not start with a letter', () => {
+      expect(() => URN.stringify('foo', 'bar', '1rn')).toThrow(InvalidError);
+      expect(() => URN.stringify('foo', 'bar', '1rn')).toThrow(
+        /URN is invalid in '1rn': must start with a letter/,
+      );
+    });
+  });
+
+  describe('NID grammar', () => {
+    it('should accept lengths 2 through 32 on the write path', () => {
+      expect(() => URN.stringify('x', 'ab')).not.toThrow();
+      expect(() => URN.stringify('x', 'a'.repeat(32))).not.toThrow();
+    });
+
+    it('should reject a 1-character NID on the write path', () => {
+      expect(() => URN.stringify('x', 'a')).toThrow(InvalidError);
+      expect(() => URN.stringify('x', 'a')).toThrow(
+        /NID is invalid in 'a': must be at least 2 characters long/,
+      );
+    });
+
+    it('should reject a 33-character NID on both paths', () => {
+      const long = 'a'.repeat(33);
+      expect(() => URN.stringify('x', long)).toThrow(
+        /NID is invalid in .*: must be at most 32 characters long/,
+      );
+      expect(URN.isValidFormat(`urn:${long}:x`)).toBe(false);
+    });
+
+    it('should reject a leading or trailing hyphen on both paths', () => {
+      expect(() => URN.stringify('x', '-bad')).toThrow(
+        /must not start or end with '-'/,
+      );
+      expect(() => URN.stringify('x', 'bad-')).toThrow(
+        /must not start or end with '-'/,
+      );
+      expect(URN.isValidFormat('urn:-bad:x')).toBe(false);
+      expect(URN.isValidFormat('urn:bad-:x')).toBe(false);
+    });
+
+    it("should reject '_', '.' and '~' in a NID on both paths", () => {
+      for (const nid of ['my_ns', 'my.ns', 'my~ns']) {
+        expect(() => URN.stringify('x', nid)).toThrow(InvalidError);
+        expect(URN.isValidFormat(`urn:${nid}:x`)).toBe(false);
+      }
+    });
+
+    it('should accept a 1-character NID on the read path only', () => {
+      // RFC 2141 permitted a 1-character NID and RFC 8141 Appendix B keeps
+      // earlier-valid URNs valid, so parse is lenient where stringify is not.
+      expect(URN.parse('urn:x:1')).toEqual({
+        urn: 'urn',
+        nid: 'x',
+        nss: 'x:1',
+      });
+      expect(URN.isValidFormat('urn:x:1')).toBe(true);
+      expect(() => URN.stringify('1', 'x')).toThrow(InvalidError);
+    });
+
+    it('should expose the write grammar through nidGrammar', () => {
+      expect(URN.nidGrammar.test('ab')).toBe(true);
+      expect(URN.nidGrammar.test('a')).toBe(false);
+      expect(URN.nidGrammar.test('a'.repeat(32))).toBe(true);
+      expect(URN.nidGrammar.test('a'.repeat(33))).toBe(false);
+      expect(URN.nidGrammar.test('')).toBe(false);
+    });
+  });
+
+  describe('NSS grammar', () => {
+    it('should accept the whole pchar set plus slash and percent-triplets', () => {
+      expect(URN.nssGrammar.test(PCHAR_SOUP)).toBe(true);
+      expect(() => URN.stringify(PCHAR_SOUP, 'example')).not.toThrow();
+    });
+
+    it('should reject a leading slash', () => {
+      expect(URN.nssGrammar.test('/a')).toBe(false);
+    });
+
+    it('should reject characters outside pchar', () => {
+      for (const nss of ['user#123', 'user 123', 'a?b', 'a[b', 'a"b', 'a\\b']) {
+        expect(URN.nssGrammar.test(nss)).toBe(false);
+        expect(() => URN.stringify(nss, 'example')).toThrow(InvalidError);
+      }
+    });
+
+    it('should accept sub-delims, colon and at-sign that used to be rejected', () => {
+      for (const nss of ['user@123', 'user$123', 'user!123', 'foo/bar']) {
+        expect(() => URN.stringify(nss, 'example')).not.toThrow();
+      }
+    });
+
+    it('should reject a malformed percent-triplet with a structural reason', () => {
+      expect(() => URN.stringify('a%zz', 'example')).toThrow(
+        /NSS is invalid in 'a%zz': contains a malformed percent-encoded octet/,
+      );
+      expect(() => URN.stringify('a%C', 'example')).toThrow(InvalidError);
+    });
+
+    it('should not encode or decode on the write path', () => {
+      // stringify operates on the wire form: it validates, it never encodes.
+      expect(() => URN.stringify('a b', 'example')).toThrow(InvalidError);
+      expect(URN.stringify('a%20b', 'example')).toBe('urn:example:a%20b');
+    });
+
+    it('should return percent-triplets intact on the read path', () => {
+      expect(URN.parse('urn:nid:a%20b').nss).toBe('a%20b');
+    });
+  });
+
+  describe('scheme grammar', () => {
+    it('should follow RFC 3986 under the default separator', () => {
+      expect(URN.schemeGrammar.test('urn')).toBe(true);
+      expect(URN.schemeGrammar.test('my-scheme')).toBe(true);
+      expect(URN.schemeGrammar.test('a+b.c-d')).toBe(true);
+      expect(URN.schemeGrammar.test('1rn')).toBe(false);
+      expect(URN.schemeGrammar.test('')).toBe(false);
+    });
+  });
+
+  describe('round-tripping', () => {
+    it('should round-trip the full pchar set through stringify and parse', () => {
+      const Example = namespaceOf('urn', 'example');
+      expect(Example.parse(Example.stringify(PCHAR_SOUP)).nss).toBe(PCHAR_SOUP);
+    });
+
+    it('should round-trip an NSS containing the separator', () => {
+      const Example = namespaceOf('urn', 'example');
+      expect(Example.parse(Example.stringify('a:b:c')).nss).toBe('a:b:c');
+    });
+
+    it("should round-trip RFC 8141's own example URNs unchanged", () => {
+      const cases = [
+        'urn:example:a123,z456',
+        'urn:example:A123,z456',
+        'urn:example:a123%2Cz456',
+        'urn:oasis:names:specification:docbook:dtd:xml:4.1.2',
+        'urn:ietf:rfc:2648',
+        'urn:isbn:0451450523',
+        'urn:ISSN:0167-6423',
+        'urn:nbn:de:bvb:19-146642',
+      ];
+
+      for (const original of cases) {
+        const [, nid] = original.split(':') as [string, string];
+        const Namespace = namespaceOf('urn', nid);
+        const parsed = Namespace.parse(original);
+        expect(Namespace.stringify(parsed.nss, parsed.nid, parsed.urn)).toBe(
+          original,
+        );
+      }
+    });
+
+    it('should not be idempotent, and should say so honestly', () => {
+      // stringify is not a normaliser: re-stringifying a URN nests it.
+      expect(URN.stringify(URN.stringify('foo'))).toBe('urn:nid:urn:nid:foo');
     });
   });
 
@@ -59,21 +249,6 @@ describe('URN', () => {
       expect(TRN.stringify('foo', 'bar')).toBe('trn-bar-foo');
     });
 
-    it('should reject components that contain a custom separator', () => {
-      class Dash extends URN {
-        static override readonly urn = 'trn';
-        static override readonly separator = '-';
-      }
-      expect(() => Dash.stringify('ab', 'n-id')).toThrow(InvalidError);
-      expect(() => Dash.stringify('ab', 'n-id')).toThrow(
-        "NID contains invalid character '-' in 'n-id'",
-      );
-      expect(() => Dash.stringify('a-b', 'nid')).toThrow(InvalidError);
-      expect(() => Dash.stringify('a-b', 'nid')).toThrow(
-        "NSS contains invalid character '-' in 'a-b'",
-      );
-    });
-
     it('should derive from urn class and set nid', () => {
       class TRN extends URN {
         static override urn = 'trn';
@@ -83,6 +258,48 @@ describe('URN', () => {
         static override readonly nid = 'bar';
       }
       expect(BarTRN.stringify('foo')).toBe('trn:bar:foo');
+    });
+  });
+
+  describe('custom separator', () => {
+    class Dash extends URN {
+      static override readonly urn = 'trn';
+      static override readonly separator = '-';
+    }
+
+    it('should exclude the separator from the scheme and the NID', () => {
+      expect(Dash.nidGrammar.test('n-id')).toBe(false);
+      expect(Dash.schemeGrammar.test('t-rn')).toBe(false);
+      expect(() => Dash.stringify('ab', 'n-id')).toThrow(InvalidError);
+      expect(() => Dash.stringify('ab', 'n-id')).toThrow(
+        "NID contains invalid character '-' in 'n-id'",
+      );
+      expect(() => Dash.stringify('ab', 'nid', 't-rn')).toThrow(
+        "URN contains invalid character '-' in 't-rn'",
+      );
+    });
+
+    it('should drop the RFC length bounds for the scheme and the NID', () => {
+      expect(() => Dash.stringify('ab', 'a')).not.toThrow();
+      expect(() => Dash.stringify('ab', 'a'.repeat(40))).not.toThrow();
+    });
+
+    it('should keep the RFC pchar grammar for the NSS', () => {
+      expect(Dash.nssGrammar.source).toBe(URN.nssGrammar.source);
+      expect(Dash.stringify('a-b', 'nid')).toBe('trn-nid-a-b');
+      expect(Dash.parse('trn-nid-a-b').nss).toBe('a-b');
+      expect(Dash.stringify('a:b', 'nid')).toBe('trn-nid-a:b');
+    });
+
+    it('should round-trip through parse, extractId and isValidFormat', () => {
+      class DashUser extends Dash {
+        static override readonly nid = 'user';
+      }
+      expect(DashUser.stringify('a:b/c')).toBe('trn-user-a:b/c');
+      expect(DashUser.parse('trn-user-a:b/c').nss).toBe('a:b/c');
+      expect(DashUser.extractId('trn-user-a:b/c')).toBe('a:b/c');
+      expect(DashUser.isValidFormat('trn-user-a:b/c')).toBe(true);
+      expect(DashUser.isValidFormat('trn-user')).toBe(false);
     });
   });
 
@@ -100,7 +317,7 @@ describe('URN', () => {
       });
     });
 
-    it("should parse URN and return all parts in object, but keep nid with nss if it's not the same generator", () => {
+    it('should retain a foreign NID in the NSS', () => {
       class BarTRN extends URN {
         static override urn = 'trn';
         static override readonly nid = 'bar';
@@ -111,6 +328,53 @@ describe('URN', () => {
         nid: 'baz',
         nss: 'baz:foo',
       });
+    });
+
+    it('should retain a foreign scheme in the NSS, verbatim', () => {
+      class UserTRN extends URN {
+        static override readonly urn = 'trn';
+        static override readonly nid = 'user';
+      }
+
+      // The foreign scheme is kept as-is. Substituting this.urn here would
+      // silently re-label the record, which is the bug in #11.
+      expect(UserTRN.parse('ftp:user:1')).toEqual({
+        urn: 'ftp',
+        nid: 'user',
+        nss: 'ftp:user:1',
+      });
+      expect(UserTRN.parse('trn:user:1')).toEqual({
+        urn: 'trn',
+        nid: 'user',
+        nss: '1',
+      });
+    });
+
+    it('should distinguish a foreign scheme from the class scheme', () => {
+      class UserTRN extends URN {
+        static override readonly urn = 'trn';
+        static override readonly nid = 'user';
+      }
+      expect(UserTRN.parse('ftp:user:1').nss).not.toBe(
+        UserTRN.parse('trn:user:1').nss,
+      );
+    });
+
+    it('should return the original case', () => {
+      // The scheme and NID match case-insensitively, so nothing is retained,
+      // and the returned parts keep the case they were written in.
+      expect(URN.parse('URN:NID:Foo')).toEqual({
+        urn: 'URN',
+        nid: 'NID',
+        nss: 'Foo',
+      });
+    });
+
+    it('should reject character-invalid input', () => {
+      expect(() => URN.parse('urn:us er:hello')).toThrow(ValidationError);
+      expect(() => URN.parse('urn:nid:hello world')).toThrow(ValidationError);
+      expect(() => URN.parse('urn:my_ns:x')).toThrow(ValidationError);
+      expect(() => URN.parse('1rn:nid:x')).toThrow(ValidationError);
     });
   });
 
@@ -133,6 +397,35 @@ describe('URN', () => {
         expect(URN.isValidFormat('urn:!!!:@@@')).toBe(false);
         expect(URN.isValidFormat('http://a:b')).toBe(false);
       });
+
+      it('should agree with parse on every input', () => {
+        const inputs = [
+          'urn:user:123',
+          'urn:example:a123,z456',
+          'urn:example:foo/bar',
+          'urn:x:1',
+          'urn:user:',
+          'urn:user',
+          'urn::123',
+          '',
+          'urn:my_ns:x',
+          'urn:-bad:x',
+          `urn:${'a'.repeat(33)}:x`,
+          'urn:nid:hello world',
+          'urn:nid:a%zz',
+          '1rn:nid:x',
+        ];
+
+        for (const input of inputs) {
+          let parsed = true;
+          try {
+            URN.parse(input);
+          } catch {
+            parsed = false;
+          }
+          expect([input, URN.isValidFormat(input)]).toEqual([input, parsed]);
+        }
+      });
     });
 
     describe('extractId', () => {
@@ -147,6 +440,10 @@ describe('URN', () => {
       it('should handle URNs with namespace in NSS', () => {
         expect(URN.extractId('urn:user:other:123')).toBe('other:123');
       });
+
+      it('should throw on character-invalid input', () => {
+        expect(() => URN.extractId('urn:my_ns:x')).toThrow(ValidationError);
+      });
     });
 
     describe('sameNamespace', () => {
@@ -155,6 +452,11 @@ describe('URN', () => {
         expect(
           URN.sameNamespace('custom:product:abc', 'custom:product:def'),
         ).toBe(true);
+      });
+
+      it('should fold the case of the scheme and the NID', () => {
+        expect(URN.sameNamespace('URN:user:1', 'urn:user:1')).toBe(true);
+        expect(URN.sameNamespace('urn:USER:1', 'urn:user:2')).toBe(true);
       });
 
       it('should return false for URNs in different namespaces', () => {
@@ -180,6 +482,12 @@ describe('URN', () => {
         ).toBe(true);
       });
 
+      it('should fold the case of the scheme and the NID', () => {
+        expect(URN.belongsToNamespace('URN:user:1', 'user')).toBe(true);
+        expect(URN.belongsToNamespace('urn:USER:1', 'user')).toBe(true);
+        expect(URN.belongsToNamespace('urn:user:1', 'USER')).toBe(true);
+      });
+
       it('should return false when URN does not belong to specified namespace', () => {
         expect(URN.belongsToNamespace('urn:user:123', 'product')).toBe(false);
         expect(
@@ -191,36 +499,75 @@ describe('URN', () => {
         expect(URN.belongsToNamespace('invalid-urn', 'user')).toBe(false);
       });
     });
+
+    describe('equals', () => {
+      it('should fold the case of the scheme and the NID', () => {
+        expect(URN.equals('URN:Example:a123', 'urn:example:a123')).toBe(true);
+      });
+
+      it('should compare the NSS byte for byte', () => {
+        expect(URN.equals('urn:example:A123', 'urn:example:a123')).toBe(false);
+      });
+
+      it('should canonicalise percent-triplet hex digits to uppercase', () => {
+        expect(
+          URN.equals('urn:example:a123%2cz456', 'urn:example:a123%2Cz456'),
+        ).toBe(true);
+      });
+
+      it('should not treat a percent-triplet as equal to the octet it encodes', () => {
+        // RFC 8141 3.1: percent-encoded octets are not decoded for equivalence.
+        expect(
+          URN.equals('urn:example:a123%2Cz456', 'urn:example:a123,z456'),
+        ).toBe(false);
+      });
+
+      it('should not be confused by the class own NID', () => {
+        // parse folds a foreign NID into the NSS; equals must not compare that.
+        expect(URN.equals('urn:user:1', 'URN:USER:1')).toBe(true);
+        expect(URN.equals('urn:user:1', 'urn:user:2')).toBe(false);
+      });
+
+      it('should return false for malformed input rather than throwing', () => {
+        expect(URN.equals('nope', 'urn:example:a')).toBe(false);
+        expect(URN.equals('nope', 'nope')).toBe(false);
+      });
+    });
   });
 
-  describe('RFC-compliant validation', () => {
-    it('should allow RFC-compliant characters', () => {
-      expect(() => URN.stringify('user-123', 'my-namespace')).not.toThrow();
-      expect(() => URN.stringify('user_123', 'my.namespace')).not.toThrow();
-      expect(() => URN.stringify('user~123', 'my.namespace')).not.toThrow();
+  describe('percent-encoding helpers', () => {
+    it('should encode everything outside the unreserved set', () => {
+      expect(encodeNss('a b')).toBe('a%20b');
+      expect(encodeNss('a/b')).toBe('a%2Fb');
+      expect(encodeNss('café')).toBe('caf%C3%A9');
+      expect(encodeNss('a-b._~')).toBe('a-b._~');
     });
 
-    it('should reject invalid characters', () => {
-      expect(() => URN.stringify('user#123', 'namespace')).toThrow(
-        InvalidError,
-      );
-      expect(() => URN.stringify('user@123', 'namespace')).toThrow(
-        InvalidError,
-      );
-      expect(() => URN.stringify('user 123', 'namespace')).toThrow(
-        InvalidError,
-      );
-      expect(() => URN.stringify('user!123', 'namespace')).toThrow(
-        InvalidError,
-      );
-      expect(() => URN.stringify('user$123', 'namespace')).toThrow(
-        InvalidError,
-      );
+    it('should produce an NSS the grammar accepts', () => {
+      for (const raw of ['a b', 'café', 'a#b', '?', '/leading']) {
+        expect(URN.nssGrammar.test(encodeNss(raw))).toBe(true);
+      }
+    });
+
+    it('should round-trip through decodeNss', () => {
+      for (const raw of ['a b', 'café', 'a#b?c/d', '100%', '😀']) {
+        expect(decodeNss(encodeNss(raw))).toBe(raw);
+      }
+    });
+
+    it('should decode triplets the library itself never produces', () => {
+      expect(decodeNss('a123%2Cz456')).toBe('a123,z456');
+      expect(decodeNss('a123%2cz456')).toBe('a123,z456');
+    });
+
+    it('should throw a ValidationError on a malformed percent sequence', () => {
+      expect(() => decodeNss('a%zz')).toThrow(ValidationError);
+      expect(() => decodeNss('a%C3')).toThrow(ValidationError);
     });
   });
+
   describe('malformed input', () => {
     it('should throw instead of leaking the string "undefined:" from parse', () => {
-      // Previously returned { urn: 'foo', nid: undefined, nss: 'undefined:' }
       expect(() => URN.parse('foo')).toThrow(ValidationError);
       expect(() => URN.parse('')).toThrow(ValidationError);
       expect(() => URN.parse('urn:user')).toThrow(ValidationError);
@@ -236,7 +583,6 @@ describe('URN', () => {
     });
 
     it('should not report two identical malformed strings as the same namespace', () => {
-      // Both used to parse to nid: undefined and compare equal.
       expect(URN.sameNamespace('invalid-urn', 'invalid-urn')).toBe(false);
       expect(URN.sameNamespace('', '')).toBe(false);
     });
@@ -244,7 +590,6 @@ describe('URN', () => {
 
   describe('empty components', () => {
     it('should reject an empty NSS rather than emitting an unparseable URN', () => {
-      // URN.stringify('') used to return 'urn:nid:', which isValidFormat rejects.
       expect(() => URN.stringify('')).toThrow(InvalidError);
       expect(() => URN.stringify('')).toThrow(/NSS must not be empty/);
     });
@@ -257,7 +602,9 @@ describe('URN', () => {
     });
 
     it('should not consider the empty string a valid component', () => {
-      expect(URN.isValid.test('')).toBe(false);
+      expect(URN.schemeGrammar.test('')).toBe(false);
+      expect(URN.nidGrammar.test('')).toBe(false);
+      expect(URN.nssGrammar.test('')).toBe(false);
     });
   });
 
@@ -268,7 +615,6 @@ describe('URN', () => {
     }
 
     it('should default belongsToNamespace to the subclass scheme', () => {
-      // Used to hardcode 'urn', so this returned false on any subclass.
       expect(TRN.belongsToNamespace('trn:bar:foo', 'bar')).toBe(true);
       expect(TRN.belongsToNamespace('urn:bar:foo', 'bar')).toBe(false);
     });
@@ -284,12 +630,18 @@ describe('URN', () => {
         static override readonly nid = 'bar';
       }
 
-      // The retained nid used to be joined with a hardcoded ':'.
       expect(DashTRN.parse('trn-baz-foo')).toEqual({
         urn: 'trn',
         nid: 'baz',
         nss: 'baz-foo',
       });
+    });
+
+    it('should not let the statics be destructured', () => {
+      // Every static reads `this`, so unlike JSON.stringify they are unbound.
+      // The failure comes from the default parameter `nid = this.nid`.
+      const { stringify } = URN;
+      expect(() => stringify('a')).toThrow(TypeError);
     });
   });
 
@@ -298,9 +650,28 @@ describe('URN', () => {
       const error = new InvalidError('NSS', 'a b', ' ');
       expect(error).toBeInstanceOf(ValidationError);
       expect(error).toBeInstanceOf(Error);
+      expect(error.name).toBe('InvalidError');
       expect(error.property).toBe('NSS');
       expect(error.value).toBe('a b');
       expect(error.invalidChar).toBe(' ');
+    });
+
+    it('should carry a structural reason when no single character is at fault', () => {
+      try {
+        URN.stringify('x', 'a');
+        expect.unreachable('stringify should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(InvalidError);
+        expect((error as InvalidError).invalidChar).toBeUndefined();
+        expect((error as InvalidError).reason).toMatch(/at least 2 characters/);
+      }
+    });
+
+    it('should fall back to a generic message when given neither', () => {
+      // Not reachable from a library path; covered so the branch is not dead.
+      expect(new InvalidError('NSS', 'abc').message).toBe(
+        "NSS contains invalid characters in 'abc'",
+      );
     });
 
     it('should let a single catch handle both error kinds', () => {

--- a/libs/urn/src/lib/urn.test-d.ts
+++ b/libs/urn/src/lib/urn.test-d.ts
@@ -1,5 +1,5 @@
 import { describe, it, expectTypeOf } from 'vitest';
-import { URN } from './urn.js';
+import { decodeNss, encodeNss, URN } from './urn.js';
 import { InvalidError, ValidationError } from './exceptions.js';
 import type { IFullURN, ParsedURN } from './types.js';
 
@@ -32,6 +32,23 @@ describe('urn types', () => {
       URN.belongsToNamespace('urn:a:b', 'a'),
     ).toEqualTypeOf<boolean>();
     expectTypeOf(URN.extractId('urn:a:b')).toEqualTypeOf<string>();
+    expectTypeOf(URN.equals('urn:a:b', 'urn:a:b')).toEqualTypeOf<boolean>();
+  });
+
+  it('types the three role-scoped grammars as regexes', () => {
+    expectTypeOf(URN.schemeGrammar).toEqualTypeOf<RegExp>();
+    expectTypeOf(URN.nidGrammar).toEqualTypeOf<RegExp>();
+    expectTypeOf(URN.nssGrammar).toEqualTypeOf<RegExp>();
+  });
+
+  it('no longer exposes a single flat isValid regex', () => {
+    // @ts-expect-error isValid was replaced by the three grammar getters
+    void URN.isValid;
+  });
+
+  it('types the percent-encoding helpers as string to string', () => {
+    expectTypeOf(encodeNss).toEqualTypeOf<(raw: string) => string>();
+    expectTypeOf(decodeNss).toEqualTypeOf<(encoded: string) => string>();
   });
 
   it('keeps InvalidError assignable to ValidationError', () => {
@@ -51,6 +68,10 @@ describe('urn types', () => {
     const ok: IFullURN<'urn', 'user', string> = 'urn:user:123';
     expectTypeOf(ok).toMatchTypeOf<string>();
 
+    // @ts-expect-error IFullURN takes three type parameters, not four
+    const dead: IFullURN<'urn', 'user', string, ''> = 'urn:user:123';
+    void dead;
+
     // @ts-expect-error wrong namespace for this URN type
     const bad: IFullURN<'urn', 'user', string> = 'urn:order:123';
     void bad;
@@ -69,5 +90,6 @@ describe('urn types', () => {
     expectTypeOf(
       TRN.belongsToNamespace('trn:bar:foo', 'bar'),
     ).toEqualTypeOf<boolean>();
+    expectTypeOf(TRN.nidGrammar).toEqualTypeOf<RegExp>();
   });
 });

--- a/libs/urn/src/lib/urn.ts
+++ b/libs/urn/src/lib/urn.ts
@@ -5,6 +5,43 @@ function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+/** RFC 3986 3.1: `scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`. */
+const SCHEME_GRAMMAR = /^[A-Za-z][A-Za-z0-9+.-]*$/;
+const SCHEME_CHAR = /^[A-Za-z0-9+.-]$/;
+
+/** RFC 8141 2: `NID = (alphanum) 0*30(ldh) (alphanum)`. */
+const NID_WRITE_GRAMMAR = /^[A-Za-z0-9][A-Za-z0-9-]{0,30}[A-Za-z0-9]$/;
+/** The same, with RFC 2141's floor of one character. See {@link URN.parse}. */
+const NID_READ_GRAMMAR = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,30}[A-Za-z0-9])?$/;
+const NID_CHAR = /^[A-Za-z0-9-]$/;
+
+/**
+ * RFC 8141 2: `NSS = pchar *(pchar / "/")`, where RFC 3986 3.3 defines
+ * `pchar = unreserved / pct-encoded / sub-delims / ":" / "@"`.
+ */
+const NSS_GRAMMAR =
+  /^(?:[A-Za-z0-9\-._~!$&'()*+,;=:@]|%[0-9A-Fa-f]{2})(?:[A-Za-z0-9\-._~!$&'()*+,;=:@/]|%[0-9A-Fa-f]{2})*$/;
+/** Every character a valid NSS may contain, `%` included, for diagnostics. */
+const NSS_CHAR = /^[A-Za-z0-9\-._~!$&'()*+,;=:@/%]$/;
+
+/** Characters that never need percent-encoding: RFC 3986 2.3 `unreserved`. */
+const UNRESERVED = /^[A-Za-z0-9\-._~]$/;
+
+/**
+ * A URN, as defined by RFC 8141, with one deliberate deviation: RFC 8141
+ * requires the literal scheme `urn`, and this class allows any scheme through
+ * the overridable {@link URN.urn} static.
+ *
+ * The RFC claim is scoped to the default `:` separator. A subclass that
+ * overrides {@link URN.separator} gets separator-derived exclusion for the
+ * scheme and the NID instead of the RFC grammars, and is not RFC 8141
+ * conformant. The NSS keeps the RFC grammar under every separator.
+ *
+ * Every static reads `this`, so they cannot be destructured the way
+ * `JSON.stringify` can: `const { stringify } = URN` then `stringify('a')`
+ * throws a `TypeError`, because the default parameter `nid = this.nid` runs
+ * with `this` undefined. Call them on the class.
+ */
 export class URN {
   /**
    * separator between the different parts of the URN
@@ -23,36 +60,100 @@ export class URN {
   static readonly nid: string = 'nid';
 
   /**
-   * Parses a URN and returns it's constituent parts.
+   * The grammar the scheme must match.
    *
-   * When the parsed NID differs from this class's own `nid`, the NID is kept as
-   * part of the returned `nss` -- so a subclass reading a URN from a foreign
-   * namespace does not silently lose that namespace.
+   * RFC 3986 3.1 under the default separator; a separator-excluding character
+   * class otherwise.
+   */
+  static get schemeGrammar(): RegExp {
+    return this.separator === ':' ? SCHEME_GRAMMAR : this.genericGrammar;
+  }
+
+  /**
+   * The grammar the NID must match on the **write** path.
+   *
+   * RFC 8141 2 under the default separator -- alphanumerics and `-`, two to
+   * thirty-two characters, no leading or trailing `-`. A separator-excluding
+   * character class with no length bounds otherwise.
+   */
+  static get nidGrammar(): RegExp {
+    return this.separator === ':' ? NID_WRITE_GRAMMAR : this.genericGrammar;
+  }
+
+  /**
+   * The grammar the NSS must match, on both paths and under every separator.
+   *
+   * RFC 8141 2 `pchar *(pchar / "/")`. The NSS never needs separator
+   * exclusion: `parse` splits on the separator and rejoins the tail, which is
+   * lossless, so the NSS cannot structurally collide with it.
+   */
+  static get nssGrammar(): RegExp {
+    return NSS_GRAMMAR;
+  }
+
+  /**
+   * The grammar the NID must match on the **read** path: {@link nidGrammar}
+   * with a floor of one character.
+   *
+   * RFC 2141 2 defined `NID ::= <let-num> [ 1,31<let-num-hyp> ]`, permitting a
+   * one-character NID, and RFC 8141 Appendix B keeps every URN that was valid
+   * under the earlier specification valid. The charset is not relaxed: RFC 2141
+   * never permitted `_`, `.` or `~` either.
+   */
+  protected static get nidReadGrammar(): RegExp {
+    return this.separator === ':' ? NID_READ_GRAMMAR : this.genericGrammar;
+  }
+
+  /**
+   * Fallback grammar for the scheme and the NID under a custom separator:
+   * a generic character class with the separator excluded by lookahead, which
+   * works even when the separator is alphanumeric.
+   */
+  private static get genericGrammar(): RegExp {
+    return new RegExp(
+      `^(?:(?!${escapeRegex(this.separator)})[A-Za-z0-9._~-])+$`,
+    );
+  }
+
+  private static get genericChar(): RegExp {
+    return new RegExp(
+      `^(?:(?!${escapeRegex(this.separator)})[A-Za-z0-9._~-])$`,
+    );
+  }
+
+  /**
+   * Parses a URN and returns its constituent parts.
+   *
+   * The parts are returned in their original case; nothing is normalised and
+   * no percent-triplet is decoded, because RFC 8141 3.1 requires that
+   * percent-encoded octets stay opaque for equivalence purposes. Use
+   * {@link equals} to compare two URNs, and {@link decodeNss} to decode.
+   *
+   * When the parsed scheme differs from this class's own `urn`, the whole
+   * original identifier is kept as the returned `nss`; when only the NID
+   * differs, the NID is kept as part of the `nss`. Either way a subclass
+   * reading a URN from a foreign namespace does not silently lose it. Both
+   * comparisons are case-folded, since RFC 8141 3.1 makes the scheme and the
+   * NID case-insensitive.
+   *
+   * The read path is lenient in exactly one respect: it accepts a
+   * one-character NID, which RFC 2141 permitted. See {@link nidReadGrammar}.
    *
    * @param urnString The URN string to parse
    * @returns object that contains the parts of the URN
    * @throws {ValidationError} if the string is not a well-formed URN
    */
   static parse(urnString: string): ParsedURN {
-    const [urn, nid, ...rest] = urnString.split(this.separator);
+    const { urn, nid, nss } = this.splitParts(urnString);
 
-    // The undefined checks are what narrow urn and nid to string under
-    // noUncheckedIndexedAccess. They are also the real guard: destructuring a
-    // short split is exactly how this method used to produce the literal string
-    // "undefined:".
-    if (
-      urn === undefined ||
-      nid === undefined ||
-      !this.isValidFormat(urnString)
-    ) {
-      throw new ValidationError(
-        `Invalid URN format: '${urnString}'. Expected at least three non-empty parts separated by '${this.separator}', e.g. '${this.urn}${this.separator}${this.nid}${this.separator}id'.`,
-      );
-    }
+    if (!this.sameToken(urn, this.urn))
+      return {
+        urn,
+        nid,
+        nss: `${urn}${this.separator}${nid}${this.separator}${nss}`,
+      };
 
-    const nss = rest.join(this.separator);
-
-    if (nid !== this.nid)
+    if (!this.sameToken(nid, this.nid))
       return { urn, nid, nss: `${nid}${this.separator}${nss}` };
 
     return { urn, nid, nss };
@@ -60,79 +161,49 @@ export class URN {
 
   /**
    * Takes a namespace specific string (ie object ID) and returns a URN.
-   * @param urn Schema
-   * @param nid Namespace ID
+   *
+   * The arguments are in the reverse order of `parse`'s return shape, so
+   * `stringify(...Object.values(parse(x)))` is wrong. Pass them by name:
+   * `stringify(parsed.nss, parsed.nid, parsed.urn)`.
+   *
+   * `stringify` operates on the wire form. It does not percent-encode: an NSS
+   * that is not already encoded, such as one containing a literal space, is
+   * rejected. Encode with {@link encodeNss} first if you need to.
+   *
    * @param nss Namespace specific string
+   * @param nid Namespace ID
+   * @param urn Schema
    * @returns generated URN
-   * @throws {InvalidError} if any component is empty or contains a disallowed character
+   * @throws {InvalidError} if any component is empty or breaks its grammar
    *
    * Returns a plain `string` rather than a template-literal type: `separator`
    * is a static that subclasses may override, so any `${urn}:${nid}:${nss}`
    * type would be wrong for them.
    */
   static stringify(nss: string, nid = this.nid, urn = this.urn): string {
-    this.assertValidComponent('URN', urn);
-    this.assertValidComponent('NID', nid);
-    this.assertValidComponent('NSS', nss);
-
-    if (nss.startsWith(`${nid}${this.separator}`))
-      return `${urn}${this.separator}${nss}`;
+    this.assertScheme(urn);
+    this.assertNid(nid, this.nidGrammar);
+    this.assertNss(nss);
 
     return `${urn}${this.separator}${nid}${this.separator}${nss}`;
   }
 
   /**
-   * Character class each component must match. Excludes the configured
-   * separator so a component cannot break parsing or round-trips.
-   */
-  static get isValid(): RegExp {
-    return new RegExp(
-      `^[a-z0-9\\-._~:${
-        this.separator === ':' ? '' : escapeRegex(this.separator)
-      }]+$`,
-      'i',
-    );
-  }
-
-  /**
-   * Throws a descriptive {@link InvalidError} if a component is not valid.
-   */
-  private static assertValidComponent(property: string, value: string): void {
-    const separator = this.separator;
-    if (value.includes(separator)) {
-      throw new InvalidError(property, value, separator);
-    }
-    if (!this.isValid.test(value)) {
-      throw new InvalidError(property, value, this.findInvalidChar(value));
-    }
-  }
-
-  /**
-   * Helper method to find the first invalid character in a string
-   * @param str The string to check
-   * @returns The first invalid character, or undefined if there is none
-   *   (which is the case for an empty string)
-   */
-  private static findInvalidChar(str: string): string | undefined {
-    for (const char of str) {
-      if (!this.isValid.test(char)) {
-        return char;
-      }
-    }
-    return undefined;
-  }
-
-  /**
-   * Checks if a string is a valid URN format (has the correct structure)
+   * Checks if a string is a valid URN.
+   *
+   * Delegates to {@link parse}, so the read path and this predicate cannot
+   * drift apart.
+   *
    * @param urnString The string to validate
-   * @returns true if the string has valid URN structure
+   * @returns true if the string parses
    */
   static isValidFormat(urnString: string): boolean {
-    const parts = urnString.split(this.separator);
-    return (
-      parts.length >= 3 &&
-      parts.every((part) => part.length > 0 && this.isValid.test(part))
-    );
+    try {
+      this.parse(urnString);
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   /**
@@ -168,23 +239,29 @@ export class URN {
   }
 
   /**
-   * Checks if two URNs are in the same namespace (same URN scheme and NID)
+   * Checks if two URNs are in the same namespace (same URN scheme and NID).
+   *
+   * The scheme and the NID are compared case-insensitively, per RFC 8141 3.1.
+   *
    * @param urn1 First URN string
    * @param urn2 Second URN string
    * @returns true if both URNs have the same scheme and namespace ID
    */
   static sameNamespace(urn1: string, urn2: string): boolean {
     try {
-      const parsed1 = this.parse(urn1);
-      const parsed2 = this.parse(urn2);
-      return parsed1.urn === parsed2.urn && parsed1.nid === parsed2.nid;
+      const a = this.splitParts(urn1);
+      const b = this.splitParts(urn2);
+      return this.sameToken(a.urn, b.urn) && this.sameToken(a.nid, b.nid);
     } catch {
       return false;
     }
   }
 
   /**
-   * Checks if a URN belongs to a specific namespace
+   * Checks if a URN belongs to a specific namespace.
+   *
+   * The scheme and the NID are compared case-insensitively, per RFC 8141 3.1.
+   *
    * @param urnString The URN string to check
    * @param expectedNid The expected namespace ID
    * @param expectedUrn The expected URN scheme; defaults to this class's own scheme
@@ -196,10 +273,187 @@ export class URN {
     expectedUrn: string = this.urn,
   ): boolean {
     try {
-      const parsed = this.parse(urnString);
-      return parsed.urn === expectedUrn && parsed.nid === expectedNid;
+      const parsed = this.splitParts(urnString);
+      return (
+        this.sameToken(parsed.urn, expectedUrn) &&
+        this.sameToken(parsed.nid, expectedNid)
+      );
     } catch {
       return false;
     }
+  }
+
+  /**
+   * URN equivalence, as defined by RFC 8141 3.1.
+   *
+   * The scheme and the NID are compared case-insensitively. The NSS is
+   * compared character for character, except that the hex digits of a
+   * percent-triplet are canonicalised to uppercase -- a percent-encoded octet
+   * is never decoded, so `%2C` and `,` are *not* equivalent.
+   *
+   * Returns `false` for malformed input rather than throwing.
+   */
+  static equals(a: string, b: string): boolean {
+    try {
+      const left = this.splitParts(a);
+      const right = this.splitParts(b);
+      return (
+        this.sameToken(left.urn, right.urn) &&
+        this.sameToken(left.nid, right.nid) &&
+        canonicaliseTriplets(left.nss) === canonicaliseTriplets(right.nss)
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Splits a URN into its three raw parts and validates each against its
+   * role's read grammar. Unlike {@link parse} it never folds a foreign scheme
+   * or NID into the NSS, which is what the comparison methods need.
+   */
+  private static splitParts(urnString: string): {
+    urn: string;
+    nid: string;
+    nss: string;
+  } {
+    const [urn, nid, ...rest] = urnString.split(this.separator);
+
+    // The undefined checks are what narrow urn and nid to string under
+    // noUncheckedIndexedAccess. They are also the real guard: destructuring a
+    // short split is exactly how this method used to produce the literal string
+    // "undefined:".
+    if (urn === undefined || nid === undefined || rest.length === 0) {
+      throw new ValidationError(
+        `Invalid URN format: '${urnString}'. Expected at least three non-empty parts separated by '${this.separator}', e.g. '${this.urn}${this.separator}${this.nid}${this.separator}id'.`,
+      );
+    }
+
+    const nss = rest.join(this.separator);
+
+    this.assertScheme(urn);
+    this.assertNid(nid, this.nidReadGrammar);
+    this.assertNss(nss);
+
+    return { urn, nid, nss };
+  }
+
+  /** Case-folded token comparison, per RFC 8141 3.1. */
+  private static sameToken(a: string, b: string): boolean {
+    return a.toLowerCase() === b.toLowerCase();
+  }
+
+  private static assertScheme(value: string): void {
+    if (value === '') throw new InvalidError('URN', value);
+    if (value.includes(this.separator))
+      throw new InvalidError('URN', value, this.separator);
+    if (this.schemeGrammar.test(value)) return;
+
+    const charClass = this.separator === ':' ? SCHEME_CHAR : this.genericChar;
+    this.reject('URN', value, charClass, 'must start with a letter');
+  }
+
+  private static assertNid(value: string, grammar: RegExp): void {
+    if (value === '') throw new InvalidError('NID', value);
+    if (value.includes(this.separator))
+      throw new InvalidError('NID', value, this.separator);
+    if (grammar.test(value)) return;
+
+    const charClass = this.separator === ':' ? NID_CHAR : this.genericChar;
+    this.reject('NID', value, charClass, describeNidFailure(value, grammar));
+  }
+
+  /**
+   * The NSS carries no separator guard. Split-then-rejoin on the same
+   * delimiter is lossless for the tail, so an NSS containing the separator
+   * still round-trips -- which is what makes `stringify('user:42')` legal.
+   */
+  private static assertNss(value: string): void {
+    if (value === '') throw new InvalidError('NSS', value);
+    if (this.nssGrammar.test(value)) return;
+
+    this.reject('NSS', value, NSS_CHAR, describeNssFailure(value));
+  }
+
+  /**
+   * Throws an {@link InvalidError} naming the first character outside the
+   * role's set, or the structural reason when every character is permitted.
+   */
+  private static reject(
+    property: string,
+    value: string,
+    charClass: RegExp,
+    reason?: string,
+  ): never {
+    const invalidChar = [...value].find((char) => !charClass.test(char));
+    throw new InvalidError(
+      property,
+      value,
+      invalidChar,
+      invalidChar === undefined ? reason : undefined,
+    );
+  }
+}
+
+function describeNidFailure(value: string, grammar: RegExp): string {
+  if (value.startsWith('-') || value.endsWith('-'))
+    return "must not start or end with '-'";
+  if (grammar === NID_WRITE_GRAMMAR && value.length < 2)
+    return 'must be at least 2 characters long';
+  if (value.length > 32) return 'must be at most 32 characters long';
+  return 'does not match the namespace identifier grammar';
+}
+
+function describeNssFailure(value: string): string {
+  if (value.includes('%')) return 'contains a malformed percent-encoded octet';
+  if (value.startsWith('/')) return "must not start with '/'";
+  return 'does not match the namespace specific string grammar';
+}
+
+/** Uppercases the hex digits of every percent-triplet, per RFC 8141 3.1. */
+function canonicaliseTriplets(value: string): string {
+  return value.replace(/%[0-9A-Fa-f]{2}/g, (triplet) => triplet.toUpperCase());
+}
+
+/**
+ * Percent-encodes an arbitrary string into a valid NSS.
+ *
+ * Everything outside RFC 3986's `unreserved` set is encoded as UTF-8
+ * percent-triplets with uppercase hex, so the result is safe in any position
+ * of an NSS. Neither `stringify` nor `parse` calls this: encoding is an
+ * explicit, separate step, so a value can never be double-encoded by accident.
+ */
+export function encodeNss(raw: string): string {
+  let encoded = '';
+  for (const char of raw) {
+    if (UNRESERVED.test(char)) {
+      encoded += char;
+      continue;
+    }
+    for (const byte of new TextEncoder().encode(char)) {
+      encoded += `%${byte.toString(16).toUpperCase().padStart(2, '0')}`;
+    }
+  }
+  return encoded;
+}
+
+/**
+ * Decodes the percent-triplets in an NSS back to the raw string.
+ *
+ * @throws {ValidationError} if the input contains a malformed or truncated
+ *   percent sequence.
+ */
+export function decodeNss(encoded: string): string {
+  if (/%(?![0-9A-Fa-f]{2})/.test(encoded)) {
+    throw new ValidationError(
+      `Malformed percent-encoding in '${encoded}': '%' must be followed by two hex digits.`,
+    );
+  }
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    throw new ValidationError(
+      `Malformed percent-encoding in '${encoded}': not a valid UTF-8 sequence.`,
+    );
   }
 }


### PR DESCRIPTION
Implements `docs/specs/2026-09-10-urn-rfc8141.md`.

`@evanion/urn` advertised `rfc8141` while diverging from it in both directions:
too permissive on NIDs, too strict on NSSs, no case-folded comparison, no
equivalence method. One flat character class was doing the work of three
different grammars. This replaces it with three role-scoped grammars and fixes
the read/write asymmetry that produced #10, #11 and #12.

## What changed

- **Three role-scoped grammars** replace `isValid`. `schemeGrammar` is RFC 3986
  §3.1, `nidGrammar` is RFC 8141 §2, `nssGrammar` is `pchar *(pchar / "/")`.
  All three are getters, so they stay reactive to a subclass's `separator`.
- **The separator guard is scoped to the scheme and the NID.** `parse` splits on
  the separator and rejoins the tail, which is lossless, so an NSS can never
  structurally collide with the separator whatever it is. Only the scheme and
  the NID occupy fixed single-token positions. Dropping the guard for the NSS is
  the single change that unblocks the three cases below.
- **Read-lenient, write-strict.** `stringify` enforces the RFC 8141 NID exactly.
  `parse` accepts the same charset and ceiling but allows a one-character NID:
  RFC 2141 §2 permitted one, and RFC 8141 Appendix B keeps earlier-valid URNs
  valid. The charset is *not* widened on read — RFC 2141 never permitted `_`,
  `.` or `~` in a NID either.
- **`isValidFormat` delegates to `parse`.** It used to check only for three
  non-empty parts, which is how the write path tightened while the read path
  did not. Delegating makes drift impossible; a test asserts they agree on
  fourteen inputs.
- **The NID dedup is gone** (#10). The README documented it as a feature at
  `README.md:170-174`; that section is rewritten. Worth noting: since the
  separator guard landed, the dedup was already unreachable — `stringify('user:42')`
  threw before it could fire, so the documented behaviour did not exist.
- **A foreign scheme is retained verbatim** (#11), the same way a foreign NID
  already was. Not substituted with `this.urn` — substituting is exactly the
  silent re-labelling #11 reports.
- **Case-folded comparison** in `sameNamespace` and `belongsToNamespace`, and a
  new `URN.equals` implementing RFC 8141 §3.1 equivalence, including
  percent-triplet hex canonicalisation.
- **`encodeNss` / `decodeNss`** as explicit, separate steps. `stringify` does
  not encode and `parse` does not decode; both work on the wire form, so a value
  cannot be double-encoded by accident.
- **`IFullURN` drops its dead fourth type parameter** (#15).
- `InvalidError` gains a `reason` field for failures where no single character
  is at fault — a length bound, a leading hyphen, a truncated percent-triplet.
  This also makes `buildMessage`'s third branch reachable, and it is now
  covered, which was the last item in #13's list.

## Before / after

Measured, not asserted. "Before" is `origin/main` (`ca58efa`) compiled and run;
"after" is `libs/urn/dist` from this branch.

| Case | Before | After |
| --- | --- | --- |
| `UserURN.stringify('user:42')` | `THROWS InvalidError: NSS contains invalid character ':' in 'user:42'` | `'urn:user:user:42'` |
| `URN.stringify('a123,z456','example')` | `THROWS InvalidError: NSS contains invalid character ',' in 'a123,z456'` | `'urn:example:a123,z456'` |
| `URN.stringify('foo:bar','example')` | `THROWS InvalidError: NSS contains invalid character ':' in 'foo:bar'` | `'urn:example:foo:bar'` |
| `isValidFormat('urn:example:foo:bar')` vs `stringify('foo:bar','example')` | `true` while `stringify` throws | `true` / `'urn:example:foo:bar'` — both accept |
| `URN.isValid` | `/^[a-z0-9\-._~:]+$/i` | `undefined`; `schemeGrammar` `/^[A-Za-z][A-Za-z0-9+.-]*$/`, `nidGrammar` `/^[A-Za-z0-9][A-Za-z0-9-]{0,30}[A-Za-z0-9]$/`, `nssGrammar` the `pchar` set |
| `stringify('x','my_ns')` | `'urn:my_ns:x'` | `THROWS InvalidError: NID contains invalid character '_' in 'my_ns'` |
| `stringify('x','a')` (NID length 1) | `'urn:a:x'` | `THROWS InvalidError: NID is invalid in 'a': must be at least 2 characters long` |
| `stringify('x','a'.repeat(32))` | accepted | accepted |
| `stringify('x','a'.repeat(33))` | `'urn:aaa…a:x'` | `THROWS InvalidError: NID is invalid in 'aaa…a': must be at most 32 characters long` |
| `parse('urn:a:x')` (NID length 1, read) | `{urn:'urn',nid:'a',nss:'a:x'}` | `{urn:'urn',nid:'a',nss:'a:x'}` — unchanged, deliberately |
| `sameNamespace('URN:user:1','urn:user:1')` | `false` | `true` |
| `belongsToNamespace('URN:user:1','user')` | `false` | `true` |
| `URN.equals` | `undefined` | `equals('URN:Example:a%2cb','urn:example:a%2Cb')` → `true`; `equals('urn:example:a%2Cb','urn:example:a,b')` → `false` |
| dedup: `UserURN.parse(UserURN.stringify('user:42')).nss` | `THROWS` (the dedup was already unreachable) | `'user:42'` |
| `UserURN.parse('ftp:user:1')` (`urn='urn'`, `nid='user'`) | `{urn:'ftp',nid:'user',nss:'1'}` — scheme lost | `{urn:'ftp',nid:'user',nss:'ftp:user:1'}` — retained |
| `IFullURN<U,N,S,X>` | four type parameters | three; the fourth is a type error |

## Verification

```
$ npx nx run-many -t lint test build typecheck check
 NX   Successfully ran targets lint, test, build, typecheck, check for 8 projects
$ echo $?
0
```

```
$ npx nx test @evanion/urn
 ✓ |@evanion/urn| src/lib/urn.spec.ts (82 tests) 14ms
 ✓ |@evanion/urn|  TS  src/lib/urn.test-d.ts (10 tests)
 Test Files  2 passed (2)
      Tests  92 passed (92)
 Type Errors  no errors
```

Tests were written first and watched fail: the first run against the old
implementation was `50 failed | 42 passed`, `Type Errors 5 failed`.

Coverage added for everything the spec's testing section lists: round-tripping
across the full `pchar` set including percent-triplets, `/`, sub-delims and `:`
inside the NSS; RFC 8141's own example URNs re-emitted unchanged; NID boundaries
at 1, 2, 32 and 33 on both paths, plus leading and trailing `-` and `_ . ~`;
case-folding and `equals`; a custom separator exercised through `parse`,
`extractId` and `isValidFormat`; foreign scheme and foreign NID both retained;
and `isValidFormat` agreeing with `parse` on every case.

Two build tasks, `docs:build` and `storefront:build`, are flagged flaky by Nx —
a Turbopack error that clears on retry. Neither is in this diff's dependency
graph.

## Issues

Fully addressed, closed here:

- `Closes #10` — the dedup is deleted and the README section rewritten.
- `Closes #11` — `parse` retains a foreign scheme verbatim.
- `Closes #12` — the RFC 8141 decision is made and implemented: NID grammar,
  `pchar` NSS set, percent-encoding policy, case-folded comparison. The one
  deliberate deviation, an overridable scheme, is the maintainer's call on the
  issue and is documented as such.
- `Closes #13` — round-trip coverage added, every listed gap covered, and
  `InvalidError.buildMessage`'s dead third branch is now both reachable and
  tested.

Partly addressed, left open:

- `Part of #15` — `IFullURN`'s fourth type parameter is removed, and the unbound
  statics and the reversed argument order are documented and tested. `tslib` is
  confirmed absent from the built output but not removed: `importHelpers` is set
  workspace-wide, so deleting the dependency would break the day a construct
  needs a helper. Scoping `importHelpers` per package is the prerequisite.

Follow-ups opened:

- #77 — r-, q- and f-components, plus the `tslib` and formal/informal-NID items,
  plus the stale `isValid` reference in `apps/docs/content/urn/api.mdx`.

## Supersedes

- #58 (drop the dedup) and #59 (retain a foreign scheme) — both closed. The
  behaviour is carried forward inside the rewritten methods rather than the
  diffs. #59's implementation substituted `this.urn` for the foreign scheme,
  which loses it; this branch keeps the foreign scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019s6FWxb6zpDUvbN4j1XH2B
