### PR TITLE
docs(specs): correct three mechanisms the implementations measured wrong

### DIFF
--- a/docs/specs/2026-09-10-compose-unified-signature.md
+++ b/docs/specs/2026-09-10-compose-unified-signature.md
@@ -1,6 +1,6 @@
 # compose: one signature, readable diagnostics
 
-Status: approved, not implemented
+Status: Implemented in #79. Corrected below where the implementation measured the design wrong.
 Package: `@evanion/compose` (repo 2.0.0, npm 1.0.8 — breaking changes are free until 2.0.0 ships)
 Closes: #19, #20, #21.
 
@@ -75,11 +75,11 @@ export type ValidateProvider<T> = T extends readonly [infer C, infer P]
   ? C extends AnyComponent
     ? P extends AnyComponent
       ? ComposeError<'second tuple element must be props, not another component'>
-      : [P] extends [PropsWithoutChildren<C>]
-        ? Exclude<keyof P, keyof PropsWithoutChildren<C>> extends never
+      : Exclude<keyof P, keyof PropsWithoutChildren<C>> extends never
+        ? [P] extends [PropsWithoutChildren<C>]
           ? T
-          : ComposeError<`unknown prop '${Extract<Exclude<keyof P, keyof PropsWithoutChildren<C>>, string>}'`>
-        : readonly [C, PropsWithoutChildren<C>]
+          : readonly [C, PropsWithoutChildren<C>]
+        : ComposeError<`unknown prop '${Extract<Exclude<keyof P, keyof PropsWithoutChildren<C>>, string>}'`>
     : ComposeError<'first tuple element must be a component'>
   : T extends AnyComponent
     ? Record<string, never> extends PropsWithoutChildren<T>
@@ -94,6 +94,13 @@ export type ValidateProviders<T extends ProviderArray> = {
 
 The missing-or-wrong-prop branch deliberately returns the real expected shape
 rather than a carrier, because that diagnostic is already readable.
+
+The excess-key check must run BEFORE the assignability check, not nested inside
+it. An earlier draft of this spec had them the other way round, which #79
+measured as still producing #20's 13-line `every` cascade: a component whose
+props are all optional is a weak type, so `{ b: 1 }` is not assignable to it and
+the case fell through to the repaired-shape branch — the exact comparison this
+design exists to avoid.
 
 Parameterising the failure branch instead of hardcoding `never` is prior art:
 ts-toolbelt's `Any.Try<A1, A2, Catch>`. Naming the message into the key is the

--- a/docs/specs/2026-09-10-nestjs-correlation-id.md
+++ b/docs/specs/2026-09-10-nestjs-correlation-id.md
@@ -1,6 +1,6 @@
 # nestjs-correlation-id: ESM-only, AsyncLocalStorage, platform-neutral
 
-Status: #32 approved. #31, #33, #34 designed but not separately approved.
+Status: implemented in #80.
 Package: `@evanion/nestjs-correlation-id` (repo 2.0.0, npm 1.1.0 — breaking changes are free until 2.0.0 ships)
 Closes: #32. Designs #31, #33, #34.
 
@@ -111,7 +111,7 @@ Remaining #33 cleanups, all independent and low-risk:
 ## #34: tests
 
 No e2e tests exist; only two `.spec.ts` unit files. Needs `@nestjs/testing` plus
-`supertest`, asserting:
+a raw `node:http` client, asserting:
 
 - header casing on the wire, post-#28
 - a genuine request-scope test — the current two-module test does not exercise
@@ -120,6 +120,10 @@ No e2e tests exist; only two `.spec.ts` unit files. Needs `@nestjs/testing` plus
 - that a singleton holding `HttpService` is constructed once across requests,
   the regression guard for #31
 - `onModuleInit` fires, the other #31 symptom
+
+Not `supertest`: its fetch-shaped API lower-cases every header name, so it
+cannot see the raw casing the first item asks to assert. A raw `node:http`
+client can, and it avoids a root lockfile change while other work is in flight.
 
 ## Migration
 

--- a/docs/specs/2026-09-10-react-widget-rsc.md
+++ b/docs/specs/2026-09-10-react-widget-rsc.md
@@ -1,6 +1,6 @@
 # react-widget: drop context, become RSC-capable
 
-Status: approved, not implemented
+Status: Implemented in #81. Corrected below where the implementation measured the design wrong.
 Package: `@evanion/react-widget` (0.1.0 published; `adjustSemverBumpsForZeroMajorVersion` in `nx.json` makes a breaking change a 0.2.0 bump)
 Closes: #25, #26, #27, #71. Reverts #24 and part of #23's approach.
 
@@ -165,8 +165,14 @@ public English-language library. Fix in the astro pass.
 
 `scripts/verify-packaging.mjs:191` asserts the `'use client'` directive is
 present. Invert it to assert absence, and add a grep of `dist/index.js` for
-`createContext(` and `useContext(` as a permanent regression guard. The directive
-check alone would not catch a context reintroduced without it.
+the imported specifiers on its `react` import as a permanent regression guard.
+The directive check alone would not catch a context reintroduced without it.
+
+Do not grep the bundle for `createContext(`. Rolldown renames imported bindings,
+so a build that genuinely creates and consumes a context emits
+`import { createContext as t } from "react"` and calls `t(...)`. #81 confirmed
+`grep -c "createContext(" dist/index.js` returns 0 on exactly such a build.
+Checking the import specifiers catches it either way, and is stronger.
 
 ## Disposition of existing work
 
@@ -194,7 +200,8 @@ check alone would not catch a context reintroduced without it.
 
 - Renders under the `react-server` condition without throwing. This is the test
   whose absence let the original directive bug through.
-- `dist/index.js` contains no `createContext(` or `useContext(`.
+- `dist/index.js` imports no client-only React API. Assert on the `react`
+  import's specifiers, not on call sites — see the packaging section.
 - Nested subtree state survives a parent re-render, the property
   `regressions.test.tsx:244-272` checks, now without the `Output` identity
   mechanism.

--- a/docs/specs/2026-09-10-urn-rfc8141.md
+++ b/docs/specs/2026-09-10-urn-rfc8141.md
@@ -1,6 +1,6 @@
 # urn: RFC 8141 conformance
 
-Status: approved, not implemented
+Status: Implemented in #78. Corrected below where the implementation measured the design wrong.
 Package: `@evanion/urn` (repo 2.0.0, npm 1.1.1 — breaking changes are free until 2.0.0 ships)
 Closes: #12, #10, #11, #13, #15. Reopens behaviour landed for #8 and #9.
 
@@ -191,8 +191,14 @@ grammar rewrite replaces.
 - #58 removes the dedup. Correct behaviour, carry it forward inside the
   rewritten `stringify`. Its commit message says `Fixes #10` while the body was
   corrected to `Part of #10`; squash-merge with a corrected message or close it.
-- #59 retains a foreign scheme. Correct behaviour, carry it forward inside the
-  rewritten `parse`.
+- #59 does NOT retain a foreign scheme, despite its title. Its diff prefixes
+  `this.urn` rather than the parsed scheme, so for a subclass with
+  `urn = 'trn'`, `parse('ftp:user:1').nss` returns `'trn:user:1'` — discarding
+  `ftp` and fabricating `trn`. That is the silent re-labelling #11 reports, not
+  a fix for it. #11's diagnosis is right; implement retention of the foreign
+  scheme verbatim, matching how a foreign NID is already retained. Corrected
+  after #78 measured it; my earlier close comment on #59 asserted otherwise
+  without checking.
 
 Cherry-pick the behaviour, not the diffs.
 


### PR DESCRIPTION
Docs only. The architecture in all four specs held; three mechanism details did not. Each was caught because the implementing agents were told to measure against real builds rather than trust the spec.

## urn — #59 was not the fix I said it was

The spec said PR #59 was "correct behaviour, carry it forward". It isn't. Its diff prefixes `this.urn` rather than the parsed scheme, so for a subclass with `urn = 'trn'`:

```
UserURN.parse('ftp:user:1').nss  =>  'trn:user:1'
```

That discards `ftp` and fabricates `trn` — the silent re-labelling #11 reports, not a fix for it. #78 implements retention of the foreign scheme verbatim, matching how a foreign NID is already retained.

I also asserted this in the close comment on #59, which is public and now [corrected there](https://github.com/Evanion/libraries/pull/59#issuecomment-5620340878).

## compose — the check order reproduced the cascade

The spec nested the excess-key check inside `[P] extends [PropsWithoutChildren<C>]`. #79 measured that as still producing #20's 13-line `every` cascade: a component whose props are all optional is a weak type, so `{ b: 1 }` is not assignable to it, and the case fell through to the repaired-shape branch — the exact comparison the design exists to avoid. The checks are swapped, with the reason recorded.

## react-widget — the packaging guard matched nothing

The spec says grep `dist/index.js` for `createContext(`. That never matches. Rolldown renames imported bindings, so a build that genuinely creates and consumes a context emits:

```js
import { Suspense as e, createContext as t, memo as n, useContext as r } from "react";
```

and calls `t(...)`. #81 confirmed `grep -c "createContext(" dist/index.js` returns 0 on exactly that build. The guard now asserts on the `react` import's specifiers, which catches the import whether or not the call site is recognisable — and #81 proved it load-bearing by reintroducing a context and watching both the test and `verify:packaging` fail.

A guard that silently matches nothing is worse than no guard, so this is the one of the three that would actually have cost something.

## nestjs — why not supertest

Records the reason the e2e suite uses a raw `node:http` client: supertest's fetch-shaped API lower-cases every header name, so it cannot assert the raw header casing #34 asks for.

## Statuses

All four move from "approved, not implemented" to naming the PR that implemented them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019s6FWxb6zpDUvbN4j1XH2B