### PR TITLE
fix(release): nx was matching commit scopes against project names, downgrading react-widget to a patch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,12 +30,45 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org/) t
 
 ### Scopes
 
+A scope for a package must be that package's Nx project name with the
+`@evanion/` prefix stripped -- nothing else. Nx matches commit scopes against
+project names literally, so `widget` does **not** match the project
+`react-widget`; a mismatched scope is attributed to no project at all and the
+commit is silently downgraded to a `patch` bump. Nothing errors, you just get
+the wrong version, and published versions cannot be taken back. Run
+`npx nx show projects` if you are unsure of a name.
+
+Package scopes:
+
 - **compose**: Changes to the `@evanion/compose` library
 - **urn**: Changes to the `@evanion/urn` library
-- **widget**: Changes to the `@evanion/react-widget` library
-- **docs**: Changes to documentation
+- **react-widget**: Changes to the `@evanion/react-widget` library
+- **astro-widget**: Changes to the `@evanion/astro-widget` library
+- **nestjs-correlation-id**: Changes to the `@evanion/nestjs-correlation-id` library
+- **docs**: Changes to the docs app
+- **storefront**: Changes to the storefront demo app
+- **nx-astro**: Changes to the local Nx Astro plugin
+
+Repository scopes (these are not projects and never bump a package on their
+own):
+
+- **deps** / **deps-dev**: Changes to dependencies
 - **nx**: Changes to Nx configuration
-- **deps**: Changes to dependencies
+- **ci**: Changes to CI workflows
+- **repo**: Repository-wide chores
+- **release** / **releasing**: Release tooling and the release runbook
+- **specs**: Changes under `docs/specs`
+- **libs**: Cross-cutting changes to every library
+- **types**: Cross-cutting type changes
+- **packaging**: Package metadata and publishing config
+- **prettier**: Formatting configuration
+- **repo-checks**: Changes to the workspace-invariant tests
+
+The list is enforced. `commitlint.config.js` carries it as the `scope-enum`
+rule, and the commit-msg hook rejects anything outside it. It is a static list
+on purpose -- computing the Nx project graph on every commit would make the
+hook unusably slow -- so a test in `tools/repo-checks` fails the build if a new
+releasable project is added without a matching entry.
 
 Scopes drive the per-package changelogs, so keep library changes scoped to the
 library they touch.
@@ -43,10 +76,10 @@ library they touch.
 ### Examples
 
 ```bash
-feat(widget): add error boundary support
-fix(widget): resolve type issues in renderWidget function
+feat(react-widget): add error boundary support
+fix(react-widget): resolve type issues in renderWidget function
 docs: update README with new API examples
-test(widget): add performance tests for large widget sets
+test(react-widget): add performance tests for large widget sets
 chore: update dependencies to latest versions
 ```
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -18,6 +18,46 @@ module.exports = {
         'revert', // Reverts a previous commit
       ],
     ],
+    // Scopes for packages MUST equal the Nx project name with the `@evanion/`
+    // prefix stripped. Nx resolves conventional-commit scopes against project
+    // names, so a scope that does not match a project (`widget` vs the project
+    // `react-widget`) is attributed to nothing and silently downgraded to a
+    // patch bump instead of erroring.
+    //
+    // This list is deliberately STATIC. Deriving it from the Nx project graph
+    // would run a graph computation inside the commit-msg hook on every single
+    // commit. `tools/repo-checks` has a test that fails the build if a project
+    // under nx.json's `release.projects` globs is missing from this list.
+    'scope-enum': [
+      2,
+      'always',
+      [
+        // Nx projects (bare project names).
+        'astro-widget',
+        'compose',
+        'docs',
+        'nestjs-correlation-id',
+        'nx-astro',
+        'react-widget',
+        'repo-checks',
+        'storefront',
+        'urn',
+        // Repository scopes -- not projects. Taken from the scopes already in
+        // use on main, so existing practice keeps working.
+        'ci',
+        'deps',
+        'deps-dev',
+        'libs',
+        'nx',
+        'packaging',
+        'prettier',
+        'release',
+        'releasing',
+        'repo',
+        'specs',
+        'types',
+      ],
+    ],
     'type-case': [2, 'always', 'lower-case'],
     'type-empty': [2, 'never'],
     'subject-case': [2, 'always', ['sentence-case', 'lower-case']],

--- a/nx.json
+++ b/nx.json
@@ -114,6 +114,37 @@
       "fallbackCurrentVersionResolver": "disk",
       "adjustSemverBumpsForZeroMajorVersion": true
     },
+    "conventionalCommits": {
+      // TEMPORARY -- deliberate, to be reverted in a follow-up PR.
+      //
+      // Nx 22.0.x silently made `useCommitScope: true` the default. With it on,
+      // a conventional-commit scope is matched against Nx PROJECT NAMES
+      // (getCommitsRelevantToProjects in
+      // nx/src/command-line/release/utils/shared.js) with
+      // /(?<![@a-zA-Z0-9-])<scope>(?![@a-zA-Z0-9-])/. The scope this repo
+      // documented for @evanion/react-widget was `widget`, and the hyphen in
+      // `react-widget` makes that regex fail, so every `widget`-scoped commit
+      // was attributed to no project at all. semver.js:29
+      // (`if (config.useCommitScope && !isProjectScopedCommit)`) then downgrades
+      // those commits to `patch`, so `feat(widget)!:` with a BREAKING CHANGE
+      // footer resolved as 0.1.1 instead of 0.2.0. Nothing errors, the version
+      // is just wrong, and published npm versions are immutable.
+      //
+      // Turning it off restores attribution by CHANGED FILES, which is what
+      // Nx's published release guide still describes.
+      //
+      // The tradeoff: with attribution by files, a commit touching a root file
+      // fans out to every project -- `nx show projects --affected
+      // --files=package-lock.json` returns all of them. A `deps` commit bumps
+      // everything rather than nothing: over-bumping, which is recoverable,
+      // instead of under-bumping, which is not.
+      //
+      // Turn this back on once (a) this release's tags reset the changelog
+      // range so no `widget`-scoped commit is in range any more, and (b) the
+      // `scope-enum` rule in commitlint.config.js has been enforcing
+      // project-name scopes long enough that history is clean.
+      "useCommitScope": false
+    },
     "changelog": {
       "workspaceChangelog": false,
       "projectChangelogs": {

--- a/tools/repo-checks/package.json
+++ b/tools/repo-checks/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@evanion/repo-checks",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/tools/repo-checks/src/commitlint-scope-enum.test.ts
+++ b/tools/repo-checks/src/commitlint-scope-enum.test.ts
@@ -1,0 +1,103 @@
+import { createProjectGraphAsync, parseJson, workspaceRoot } from '@nx/devkit';
+import { findMatchingProjects } from 'nx/src/devkit-internals';
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * `nx release` resolves conventional-commit scopes against Nx PROJECT NAMES
+ * (getCommitsRelevantToProjects in
+ * nx/src/command-line/release/utils/shared.js). A scope that matches no
+ * project is not an error -- semver.js downgrades the commit to a `patch`
+ * bump. That is how `feat(widget)!:` on `@evanion/react-widget` resolved as
+ * 0.1.1 instead of 0.2.0.
+ *
+ * commitlint's `scope-enum` is therefore the guardrail, and it has to be a
+ * static list: it runs in the commit-msg hook on every commit and cannot
+ * afford a project-graph computation. Static list, dynamic test -- this is the
+ * test. It fails the build when a releasable project is added without the
+ * matching scope.
+ */
+
+const require_ = createRequire(import.meta.url);
+
+interface CommitlintConfig {
+  rules: Record<string, unknown>;
+}
+
+function readScopeEnum(): string[] {
+  const config = require_(
+    join(workspaceRoot, 'commitlint.config.js'),
+  ) as CommitlintConfig;
+  const rule = config.rules['scope-enum'];
+
+  expect(
+    rule,
+    'commitlint.config.js must define a scope-enum rule',
+  ).toBeDefined();
+
+  const [level, applicable, scopes] = rule as [number, string, string[]];
+  expect(level, 'scope-enum must be an error, not a warning').toBe(2);
+  expect(applicable).toBe('always');
+  expect(Array.isArray(scopes)).toBe(true);
+
+  return scopes;
+}
+
+/** nx.json carries `//` comments, so it needs the JSONC parser Nx itself falls back to. */
+function readReleaseProjectPatterns(): string[] {
+  const nxJson = parseJson<{ release?: { projects?: string | string[] } }>(
+    readFileSync(join(workspaceRoot, 'nx.json'), 'utf-8'),
+    { expectComments: true },
+  );
+  const patterns = nxJson.release?.projects;
+
+  expect(patterns, 'nx.json must define release.projects').toBeDefined();
+
+  return Array.isArray(patterns) ? patterns : [patterns as string];
+}
+
+/** `@evanion/react-widget` -> `react-widget`. This is what Nx matches a scope against. */
+function bareName(projectName: string): string {
+  return projectName.replace(/^@[^/]+\//, '');
+}
+
+describe('commitlint scope-enum', () => {
+  it('covers every project nx.json releases', async () => {
+    const projectGraph = await createProjectGraphAsync({ exitOnError: false });
+    const releaseProjects = findMatchingProjects(
+      readReleaseProjectPatterns(),
+      projectGraph.nodes,
+    );
+
+    expect(
+      releaseProjects.length,
+      'release.projects matched no projects -- the globs or the graph are wrong',
+    ).toBeGreaterThan(0);
+
+    const scopes = readScopeEnum();
+    const missing = releaseProjects
+      .map(bareName)
+      .filter((name) => !scopes.includes(name))
+      .sort();
+
+    expect(
+      missing,
+      `Add these to 'scope-enum' in commitlint.config.js and to the Scopes ` +
+        `section of CONTRIBUTING.md. A releasable project with no matching ` +
+        `scope gets patch-bumped instead of erroring.`,
+    ).toEqual([]);
+  });
+
+  it('has no duplicate entries', () => {
+    const scopes = readScopeEnum();
+    expect(scopes).toEqual([...new Set(scopes)]);
+  });
+
+  it('lists no scope carrying the @evanion/ prefix', () => {
+    // A scope of `@evanion/react-widget` would not match the bare-name
+    // matching Nx does, so reject the prefixed form outright.
+    expect(readScopeEnum().filter((scope) => scope.includes('/'))).toEqual([]);
+  });
+});

--- a/tools/repo-checks/src/commitlint-scope-enum.test.ts
+++ b/tools/repo-checks/src/commitlint-scope-enum.test.ts
@@ -1,7 +1,7 @@
-import { createProjectGraphAsync, parseJson, workspaceRoot } from '@nx/devkit';
-import { findMatchingProjects } from 'nx/src/devkit-internals';
-import { createRequire } from 'node:module';
+import { parseJson, workspaceRoot } from '@nx/devkit';
+import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
@@ -45,7 +45,7 @@ function readScopeEnum(): string[] {
   return scopes;
 }
 
-/** nx.json carries `//` comments, so it needs the JSONC parser Nx itself falls back to. */
+/** nx.json carries `//` comments, so it needs the JSONC fallback Nx itself uses. */
 function readReleaseProjectPatterns(): string[] {
   const nxJson = parseJson<{ release?: { projects?: string | string[] } }>(
     readFileSync(join(workspaceRoot, 'nx.json'), 'utf-8'),
@@ -58,18 +58,51 @@ function readReleaseProjectPatterns(): string[] {
   return Array.isArray(patterns) ? patterns : [patterns as string];
 }
 
+/**
+ * Resolves nx.json's `release.projects` patterns through Nx itself, so the
+ * matching semantics here are the ones `nx release` uses.
+ *
+ * This shells out rather than calling `createProjectGraphAsync()` in-process.
+ * Building the graph from inside a running Nx task fails when the daemon is
+ * off -- which is exactly how CI runs it:
+ *
+ *   ProjectGraphError: Failed to process project graph.
+ *   ProjectsWithNoNameError: The projects in the following directories have
+ *   no name provided: tools/nx-astro, tools/repo-checks
+ *
+ * Root `package.json` has no `tools/*` workspace entry, so on a nested graph
+ * build those two are seen only through their vitest configs and come out
+ * unnamed. A fresh `nx` process resolves them correctly.
+ */
+function releaseProjectNames(): string[] {
+  const args = ['nx', 'show', 'projects', '--json'];
+  for (const pattern of readReleaseProjectPatterns()) {
+    args.push('--projects', pattern);
+  }
+
+  // Strip the NX_* task variables so the child does not believe it is nested.
+  const env = Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => !key.startsWith('NX_')),
+  );
+
+  const stdout = execFileSync('npx', args, {
+    cwd: workspaceRoot,
+    encoding: 'utf-8',
+    env,
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+
+  return JSON.parse(stdout) as string[];
+}
+
 /** `@evanion/react-widget` -> `react-widget`. This is what Nx matches a scope against. */
 function bareName(projectName: string): string {
   return projectName.replace(/^@[^/]+\//, '');
 }
 
 describe('commitlint scope-enum', () => {
-  it('covers every project nx.json releases', async () => {
-    const projectGraph = await createProjectGraphAsync({ exitOnError: false });
-    const releaseProjects = findMatchingProjects(
-      readReleaseProjectPatterns(),
-      projectGraph.nodes,
-    );
+  it('covers every project nx.json releases', () => {
+    const releaseProjects = releaseProjectNames();
 
     expect(
       releaseProjects.length,
@@ -96,7 +129,7 @@ describe('commitlint scope-enum', () => {
   });
 
   it('lists no scope carrying the @evanion/ prefix', () => {
-    // A scope of `@evanion/react-widget` would not match the bare-name
+    // A scope of `@evanion/react-widget` would not survive the bare-name
     // matching Nx does, so reject the prefixed form outright.
     expect(readScopeEnum().filter((scope) => scope.includes('/'))).toEqual([]);
   });

--- a/tools/repo-checks/tsconfig.json
+++ b/tools/repo-checks/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "types": ["node", "vitest/globals"],
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tools/repo-checks/vitest.config.ts
+++ b/tools/repo-checks/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vitest/config';
+
+// Test-only config, the same shape as tools/nx-astro's. tools/repo-checks
+// holds workspace invariants, not shipped code. Nx infers targets from a
+// project-local vite.config.ts/vitest.config.ts and not from the root
+// vitest.config.ts's `projects` array, so this file is what makes @nx/vitest
+// give the project a `test` target -- which is what puts these checks into
+// `nx run-many -t test`, CI, and the release gate.
+export default defineConfig({
+  root: import.meta.dirname,
+  cacheDir: '../../node_modules/.vite/tools/repo-checks',
+  test: {
+    name: '@evanion/repo-checks',
+    watch: false,
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
+    // The project graph is slower than a unit test.
+    testTimeout: 120_000,
+  },
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,9 @@
     },
     {
       "path": "./tools/nx-astro"
+    },
+    {
+      "path": "./tools/repo-checks"
     }
   ],
   "compilerOptions": {


### PR DESCRIPTION
## This blocks the release

Do not run `nx release` until this is merged. On `main` today, `@evanion/react-widget` resolves as a **patch** bump to 0.1.1 for a release that removes both React contexts, the error boundary and the `'use client'` directive. npm versions are immutable, so publishing that is not recoverable.

## Cause

`nx release` resolves conventional-commit scopes against Nx **project names** (`getCommitsRelevantToProjects`, `node_modules/nx/dist/src/command-line/release/utils/shared.js`), matching with:

```
/(?<![@a-zA-Z0-9-])<scope>(?![@a-zA-Z0-9-])/
```

`CONTRIBUTING.md:33` documented `widget` as the scope for the project `@evanion/react-widget`. The hyphen in `react-widget` blocks that regex, so every `widget`-scoped commit was attributed to **no project at all**. `semver.js:29` then does:

```js
if (config.useCommitScope && !isProjectScopedCommit) {
```

and downgrades those commits to `patch`. `daa297f feat(widget)!:` carries both the `!` marker and a `BREAKING CHANGE:` footer and still landed as a patch. Nothing errors; the version is just wrong.

Scope matching became the default in nx 22.0.x without being documented ([nrwl/nx#33686](https://github.com/nrwl/nx/issues/33686)); nx's published release guide still describes attribution by changed files.

## Before / after

`npx nx release version --dry-run`, same commit, only `useCommitScope` differs:

| Project | Current | Before (`useCommitScope: true`) | After (this PR) |
| --- | --- | --- | --- |
| `@evanion/react-widget` | 0.1.0 | patch -> **0.1.1** | major -> **0.2.0** |
| `@evanion/astro-widget` | 0.1.0 | major -> 0.2.0 | major -> 0.2.0 |
| `@evanion/compose` | 1.0.8 | major -> 2.0.0 | major -> 2.0.0 |
| `@evanion/urn` | 1.1.1 | major -> 2.0.0 | major -> 2.0.0 |
| `@evanion/nestjs-correlation-id` | 1.1.0 | major -> 2.0.0 | major -> 2.0.0 |

Before:

```
@evanion/astro-widget          📄 Resolved the specifier as "major" ... to get new version 0.2.0
@evanion/compose               📄 Resolved the specifier as "major" ... to get new version 2.0.0
@evanion/react-widget          📄 Resolved the specifier as "patch" ... to get new version 0.1.1
@evanion/urn                   📄 Resolved the specifier as "major" ... to get new version 2.0.0
@evanion/nestjs-correlation-id 📄 Resolved the specifier as "major" ... to get new version 2.0.0
```

After:

```
@evanion/astro-widget 🏷️  Resolved the current version as 0.1.0 from git tag "@evanion/astro-widget@0.1.0"
@evanion/astro-widget 📄 Resolved the specifier as "major" using git history and the conventional commits standard
@evanion/astro-widget ❓ Applied semver relative bump "major", derived from conventional commits data, to get new version 0.2.0
@evanion/compose 🏷️  Resolved the current version as 1.0.8 from git tag "@evanion/compose@1.0.8"
@evanion/compose 📄 Resolved the specifier as "major" using git history and the conventional commits standard
@evanion/compose ❓ Applied semver relative bump "major", derived from conventional commits data, to get new version 2.0.0
@evanion/react-widget 🏷️  Resolved the current version as 0.1.0 from git tag "@evanion/react-widget@0.1.0"
@evanion/react-widget 📄 Resolved the specifier as "major" using git history and the conventional commits standard
@evanion/react-widget ❓ Applied semver relative bump "major", derived from conventional commits data, to get new version 0.2.0
@evanion/urn 🏷️  Resolved the current version as 1.1.1 from git tag "@evanion/urn@1.1.1"
@evanion/urn 📄 Resolved the specifier as "major" using git history and the conventional commits standard
@evanion/urn ❓ Applied semver relative bump "major", derived from conventional commits data, to get new version 2.0.0
@evanion/nestjs-correlation-id 🏷️  Resolved the current version as 1.1.0 from git tag "@evanion/nestjs-correlation-id@1.1.0"
@evanion/nestjs-correlation-id 📄 Resolved the specifier as "major" using git history and the conventional commits standard
@evanion/nestjs-correlation-id ❓ Applied semver relative bump "major", derived from conventional commits data, to get new version 2.0.0
```

## Changes

**1. `nx.json` — `release.conventionalCommits.useCommitScope: false`**

Restores attribution by changed files. Carries a comment marking it **temporary** with the reasoning and the tradeoff: with attribution by files, a commit touching a root file fans out to every project (`nx show projects --affected --files=package-lock.json` returns all of them), so a `deps` commit bumps everything rather than nothing. Over-bumping is recoverable; under-bumping is not.

A follow-up PR turns it back on once this release's tags reset the changelog range and `scope-enum` has been enforcing correct scopes.

**2. `CONTRIBUTING.md` — `widget` -> `react-widget`**

Plus prose stating that a package scope must equal the Nx project name with `@evanion/` stripped, because Nx matches them that way, and that a mismatch silently downgrades the bump instead of erroring.

**3. `commitlint.config.js` — `scope-enum`, plus a test**

The enum is the nine Nx project bare names plus the non-project scopes actually present in `main`'s history (`git log origin/main --format='%s' | grep -oE '^[a-z]+\(([^)]+)\)'`), so existing practice keeps working:

```
astro-widget  compose  docs  nestjs-correlation-id  nx-astro  react-widget
repo-checks   storefront  urn
ci  deps  deps-dev  libs  nx  packaging  prettier  release  releasing  repo  specs  types
```

The two broken legacy scopes, `widget` and `correlation-id`, are deliberately excluded — they are exactly the mismatches that caused this.

The list is **static** on purpose: deriving it from the project graph would run a graph computation inside the `commit-msg` hook on every commit. The dynamic half is a test in `tools/repo-checks` that resolves `nx.json`'s `release.projects` globs through Nx and fails when a releasable project has no matching enum entry.

It shells out to `nx show projects --projects <glob> --json` rather than calling `createProjectGraphAsync()` in-process. The in-process call works locally with a warm daemon but fails in CI, where the daemon is off:

```
ProjectGraphError: Failed to process project graph.
ProjectsWithNoNameError: The projects in the following directories have no name provided:
  - tools/nx-astro
  - tools/repo-checks
```

Root `package.json` has no `tools/*` workspace entry, so on a nested graph build those two are seen only through their vitest configs and come out unnamed. That is a pre-existing latent gap, not something this PR introduces; `tools/nx-astro` has the same shape today. Worth a separate look. A fresh `nx` process resolves them, and `--projects` uses the same `findMatchingProjects` semantics `nx release` uses, so the check keeps its fidelity.

`tools/repo-checks` follows `tools/nx-astro`: a private, non-published project with a project-local `vitest.config.ts`, which is what makes `@nx/vitest` infer a `test` target. Nx infers targets from project-local configs, not from the root `vitest.config.ts`'s `projects` array — so this is what puts the check into `nx run-many -t test`, into CI, and into the release gate.

Demonstrated:

```
$ echo "feat(widget)!: drop the react contexts" | npx commitlint
✖   scope must be one of [astro-widget, compose, docs, nestjs-correlation-id, nx-astro,
    react-widget, repo-checks, storefront, urn, ci, deps, deps-dev, libs, nx, packaging,
    prettier, release, releasing, repo, specs, types] [scope-enum]
✖   found 1 problems, 0 warnings
EXIT=1

$ echo "feat(react-widget)!: drop the react contexts" | npx commitlint
EXIT=0
```

And the test fails when the enum falls out of sync (verified by temporarily deleting `urn`):

```
FAIL  src/commitlint-scope-enum.test.ts > commitlint scope-enum > covers every project nx.json releases
AssertionError: Add these to 'scope-enum' in commitlint.config.js and to the Scopes section of
CONTRIBUTING.md. A releasable project with no matching scope gets patch-bumped instead of erroring.
: expected [ 'urn' ] to deeply equal []
```

`tsconfig.json` picks up the new project reference from `nx sync`.

## Verification

```
$ npx nx run-many -t lint test build typecheck check --skip-nx-cache
 NX   Successfully ran targets lint, test, build, typecheck, check for 9 projects
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019s6FWxb6zpDUvbN4j1XH2B
