### PR TITLE
fix(release): stop the version step publishing, restore scope matching

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,13 +7,9 @@ on:
   workflow_dispatch:
     inputs:
       dry-run:
-        description: 'Compute versions and changelogs without publishing anything'
+        description: 'Dry run'
         type: boolean
         default: true
-      first-release:
-        description: 'First release from this repo (no git tags exist yet)'
-        type: boolean
-        default: false
 
 permissions:
   contents: write # create tags and GitHub releases
@@ -92,11 +88,18 @@ jobs:
         # Inputs go through env rather than being interpolated into the script.
         env:
           DRY_RUN: ${{ inputs.dry-run }}
-          FIRST_RELEASE: ${{ inputs.first-release }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # --skip-publish matters. `nx release` publishes on its own:
+        # release.js:261 is
+        # `shouldPublish = !!args.yes && !args.skipPublish && hasNewVersion`,
+        # so without it this step publishes and the Publish step below then
+        # publishes a second time. On the 2.0.0 release that produced
+        # "409 Cannot publish over previously staged version" for the two
+        # packages npm had not finished promoting yet -- everything landed,
+        # but the run failed and the publish step's own dry-run guard was not
+        # what was gating npm access.
         run: |
-          args=()
-          [ "$FIRST_RELEASE" = "true" ] && args+=(--first-release)
+          args=(--skip-publish)
           if [ "$DRY_RUN" = "true" ]; then args+=(--dry-run); else args+=(--yes); fi
           echo "Running: nx release ${args[*]}"
           npx nx release "${args[@]}"
@@ -104,7 +107,6 @@ jobs:
       - name: Publish to npm
         if: ${{ !inputs.dry-run }}
         env:
-          FIRST_RELEASE: ${{ inputs.first-release }}
           # No NODE_AUTH_TOKEN and no NPM_TOKEN, deliberately.
           #
           # The npm CLI detects the GitHub Actions OIDC environment and exchanges
@@ -120,7 +122,4 @@ jobs:
           #
           # Provenance is automatic under trusted publishing, so neither
           # NPM_CONFIG_PROVENANCE nor --provenance is needed.
-        run: |
-          args=()
-          [ "$FIRST_RELEASE" = "true" ] && args+=(--first-release)
-          npx nx release publish "${args[@]}"
+        run: npx nx release publish

--- a/nx.json
+++ b/nx.json
@@ -115,7 +115,6 @@
       "adjustSemverBumpsForZeroMajorVersion": true
     },
     "conventionalCommits": {
-      // TEMPORARY -- deliberate, to be reverted in a follow-up PR.
       //
       // Nx 22.0.x silently made `useCommitScope: true` the default. With it on,
       // a conventional-commit scope is matched against Nx PROJECT NAMES
@@ -139,11 +138,11 @@
       // everything rather than nothing: over-bumping, which is recoverable,
       // instead of under-bumping, which is not.
       //
-      // Turn this back on once (a) this release's tags reset the changelog
-      // range so no `widget`-scoped commit is in range any more, and (b) the
-      // `scope-enum` rule in commitlint.config.js has been enforcing
-      // project-name scopes long enough that history is clean.
-      "useCommitScope": false
+      // Back on as of the 2.0.0 release: its tags reset the changelog range,
+      // so no `widget`-scoped commit is in range any more, and `scope-enum` in
+      // commitlint.config.js now rejects a scope that is not a project name.
+      // Kept on so a root-file commit does not fan out to every package.
+      "useCommitScope": true
     },
     "changelog": {
       "workspaceChangelog": false,


### PR DESCRIPTION
The 2.0.0 release published every package twice. Everything landed correctly, but the run failed and the failure hid the cause.

## The double publish

`release.js:261`:

```js
let shouldPublish = !!args.yes && !args.skipPublish && hasNewVersion;
```

`nx release --yes` publishes on its own. The version step ran that, then the Publish step ran `nx release publish` against the same five packages.

By the time the second pass started, three were already promoted and correctly skipped. compose and urn were still mid-promotion, so npm returned:

```
409 Conflict - Cannot publish over previously staged version "2.0.0"
```

Both completed ~40 seconds after the run ended. All five versions are live and attested.

Timeline from the run and the registry:

```
16:51:07  react-widget 0.2.0 published        <- during "Version, changelog and tag"
16:51:14  "Publish to npm" starts
16:51:22  compose 409, urn 409
16:51:27  run ends (failure)
16:52:03  compose 2.0.0 on the registry
16:52:11  urn 2.0.0 on the registry
```

There is a second consequence worth naming: the `if: ${{ !inputs.dry-run }}` guard on the Publish step was not what gated npm access, because publishing happened before that step ran. `--dry-run` still protected it via `hasNewVersion`, but not by the mechanism the workflow's shape implies.

`--skip-publish` on the version step makes both steps do what their names say.

## first-release removed

Every package has a tag now, and the flag only changes behaviour when a version cannot be resolved. Verified it was already a no-op: a dry run with and without it produced identical versions for all five.

## dry-run label

`'Compute versions and changelogs without publishing anything'` → `'Dry run'`.

## useCommitScope back to true

Turned off for the 2.0.0 release because historical commits used a `widget` scope that never matched `@evanion/react-widget`. Safe to restore now:

- the 2.0.0 tags reset the changelog range, so no `widget`-scoped commit is in range
- `scope-enum` in `commitlint.config.js` rejects a scope that is not a project name

Keeping it on also stops a root-file commit fanning out to every package, which is the cost of file-based attribution.

Verified after the change — all five resolve from the new tags with nothing pending:

```
@evanion/astro-widget           0.2.0
@evanion/compose                2.0.0
@evanion/react-widget           0.2.0
@evanion/urn                    2.0.0
@evanion/nestjs-correlation-id  2.0.0
NOTE: The "dryRun" flag means no changes were made.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019s6FWxb6zpDUvbN4j1XH2B