### PR TITLE
chore: document version-bump mapping, add tools/* to workspaces

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,32 @@ releasable project is added without a matching entry.
 Scopes drive the per-package changelogs, so keep library changes scoped to the
 library they touch.
 
+### Version Bumps
+
+Not every type bumps a version. Nx's conventional-commits config
+(`node_modules/nx/dist/src/command-line/release/config/conventional-commits.js`)
+maps each type to a `semverBump`:
+
+- **feat** -- minor
+- **fix** -- patch
+- Everything else (**perf**, **refactor**, **docs**, **build**, **types**,
+  **chore**, **examples**, **test**, **style**, **ci**, **revert**) -- none
+
+Only `feat` and `fix` move a version. A `perf` or `refactor` commit still
+shows up in the changelog; it just bumps nothing.
+
+This compounds with the scope rule above in the worst possible way. A `fix`
+whose scope isn't a project name isn't rejected and isn't ignored -- Nx falls
+back to attributing it by the files it touched, and an infrastructure commit
+almost always touches root files (`package.json`, workflow configs,
+`nx.json`). Root files belong to every package, so the patch bump lands on
+all of them, not none of them. `fix(release): stop the version step
+publishing` is the commit that did this: `release` matches no project, so a
+one-line release-tooling fix now wants to patch-bump four unrelated packages.
+
+Use `ci` or `chore` for workflow, tooling and repo-config changes, never
+`fix`, unless the change is actually scoped to one package.
+
 ### Examples
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "workspaces": [
         "libs/*",
         "apps/*",
-        "nest/*"
+        "nest/*",
+        "tools/*"
       ],
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
@@ -3163,8 +3164,16 @@
       "resolved": "nest/correlation-id",
       "link": true
     },
+    "node_modules/@evanion/nx-astro": {
+      "resolved": "tools/nx-astro",
+      "link": true
+    },
     "node_modules/@evanion/react-widget": {
       "resolved": "libs/widget",
+      "link": true
+    },
+    "node_modules/@evanion/repo-checks": {
+      "resolved": "tools/repo-checks",
       "link": true
     },
     "node_modules/@evanion/urn": {
@@ -36774,6 +36783,14 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "tools/nx-astro": {
+      "name": "@evanion/nx-astro",
+      "version": "0.0.0"
+    },
+    "tools/repo-checks": {
+      "name": "@evanion/repo-checks",
+      "version": "0.0.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
   "workspaces": [
     "libs/*",
     "apps/*",
-    "nest/*"
+    "nest/*",
+    "tools/*"
   ],
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",

--- a/tools/repo-checks/src/commitlint-scope-enum.test.ts
+++ b/tools/repo-checks/src/commitlint-scope-enum.test.ts
@@ -1,5 +1,5 @@
-import { parseJson, workspaceRoot } from '@nx/devkit';
-import { execFileSync } from 'node:child_process';
+import { createProjectGraphAsync, parseJson, workspaceRoot } from '@nx/devkit';
+import { findMatchingProjects } from 'nx/src/devkit-internals';
 import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { join } from 'node:path';
@@ -58,51 +58,18 @@ function readReleaseProjectPatterns(): string[] {
   return Array.isArray(patterns) ? patterns : [patterns as string];
 }
 
-/**
- * Resolves nx.json's `release.projects` patterns through Nx itself, so the
- * matching semantics here are the ones `nx release` uses.
- *
- * This shells out rather than calling `createProjectGraphAsync()` in-process.
- * Building the graph from inside a running Nx task fails when the daemon is
- * off -- which is exactly how CI runs it:
- *
- *   ProjectGraphError: Failed to process project graph.
- *   ProjectsWithNoNameError: The projects in the following directories have
- *   no name provided: tools/nx-astro, tools/repo-checks
- *
- * Root `package.json` has no `tools/*` workspace entry, so on a nested graph
- * build those two are seen only through their vitest configs and come out
- * unnamed. A fresh `nx` process resolves them correctly.
- */
-function releaseProjectNames(): string[] {
-  const args = ['nx', 'show', 'projects', '--json'];
-  for (const pattern of readReleaseProjectPatterns()) {
-    args.push('--projects', pattern);
-  }
-
-  // Strip the NX_* task variables so the child does not believe it is nested.
-  const env = Object.fromEntries(
-    Object.entries(process.env).filter(([key]) => !key.startsWith('NX_')),
-  );
-
-  const stdout = execFileSync('npx', args, {
-    cwd: workspaceRoot,
-    encoding: 'utf-8',
-    env,
-    stdio: ['ignore', 'pipe', 'ignore'],
-  });
-
-  return JSON.parse(stdout) as string[];
-}
-
 /** `@evanion/react-widget` -> `react-widget`. This is what Nx matches a scope against. */
 function bareName(projectName: string): string {
   return projectName.replace(/^@[^/]+\//, '');
 }
 
 describe('commitlint scope-enum', () => {
-  it('covers every project nx.json releases', () => {
-    const releaseProjects = releaseProjectNames();
+  it('covers every project nx.json releases', async () => {
+    const projectGraph = await createProjectGraphAsync({ exitOnError: false });
+    const releaseProjects = findMatchingProjects(
+      readReleaseProjectPatterns(),
+      projectGraph.nodes,
+    );
 
     expect(
       releaseProjects.length,


### PR DESCRIPTION
## Summary

Two independent housekeeping changes.

- Document Nx's commit-type to version-bump mapping in `CONTRIBUTING.md`, next to the Scopes section. Only `feat` and `fix` bump a version; everything else is `none`. A `fix` with a non-project scope falls back to file attribution and patch-bumps every package touching root files — which is exactly what `02d96f4 fix(release): stop the version step publishing` did. Use `ci`/`chore` for infra changes instead.
- Add `tools/*` to the root `package.json` workspaces. Previously `tools/nx-astro` and `tools/repo-checks` were invisible to npm workspaces, so an in-process `createProjectGraphAsync()` came out with both projects unnamed whenever the Nx daemon was off (`ProjectsWithNoNameError`) — which is how CI runs it. `tools/repo-checks` worked around this by shelling out to `nx show projects` with `NX_*` stripped from the child env. With `tools/*` added, both projects are correctly named under `NX_DAEMON=false` too, so the workaround is reverted back to the in-process `createProjectGraphAsync()` + `findMatchingProjects()` call `nx release` itself uses.

## Verification

Before/after comparison for the workspaces change:

- `node_modules/@evanion/`: `nx-astro` and `repo-checks` are now symlinked in (previously absent)
- `npm ls --workspaces --depth=0`: both now listed as top-level workspace packages
- `npx nx show projects` / `NX_DAEMON=false npx nx show projects`: same 10 projects resolved before and after, but `nx-astro`/`repo-checks` now carry `isInPackageManagerWorkspaces: true`
- Reproduced the original `ProjectGraphError` with a temporary in-process test run via `NX_DAEMON=false npx nx run @evanion/repo-checks:test` before the workspaces change; confirmed it's gone after
- `tools/nx-astro` is consumed by `nx.json` as a plugin at `./tools/nx-astro/src/index.ts`, not as a package import — confirmed this still resolves (`storefront` still infers its `check` target from it)

Full suite, clean install:

- `npm ci`
- `npx nx run-many -t lint test build typecheck check` — all pass (`@evanion/astro-widget:typecheck` flaked once cold per issue #96, passed on retry with no edit)
- `NX_DAEMON=false npx nx run-many -t lint test build typecheck check --skip-nx-cache` — all pass
- `npm run verify:packaging` — pass

## Test plan

- [x] `npm ci`
- [x] `npx nx run-many -t lint test build typecheck check`
- [x] `NX_DAEMON=false npx nx run-many -t lint test build typecheck check`
- [x] `npm run verify:packaging`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019s6FWxb6zpDUvbN4j1XH2B