### PR TITLE
docs(repo): rewrite comments that narrate change history as current-state

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,15 +89,9 @@ jobs:
         env:
           DRY_RUN: ${{ inputs.dry-run }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # --skip-publish matters. `nx release` publishes on its own:
-        # release.js:261 is
-        # `shouldPublish = !!args.yes && !args.skipPublish && hasNewVersion`,
-        # so without it this step publishes and the Publish step below then
-        # publishes a second time. On the 2.0.0 release that produced
-        # "409 Cannot publish over previously staged version" for the two
-        # packages npm had not finished promoting yet -- everything landed,
-        # but the run failed and the publish step's own dry-run guard was not
-        # what was gating npm access.
+        # `nx release` publishes on its own unless told not to, so this step
+        # passes --skip-publish -- without it, the Publish step below would
+        # publish the same version a second time.
         run: |
           args=(--skip-publish)
           if [ "$DRY_RUN" = "true" ]; then args+=(--dry-run); else args+=(--yes); fi

--- a/apps/docs/eslint.config.mjs
+++ b/apps/docs/eslint.config.mjs
@@ -1,6 +1,6 @@
 // eslint-config-next 16 ships native flat config, so it is spread directly.
-// Going through FlatCompat/fixupConfigRules (as this file used to) makes ESLint
-// throw "Converting circular structure to JSON" on the react plugin.
+// Going through FlatCompat/fixupConfigRules makes ESLint throw "Converting
+// circular structure to JSON" on the react plugin.
 // `core-web-vitals` already includes the base `next` and `next/typescript` configs.
 import nextCoreWebVitals from 'eslint-config-next/core-web-vitals';
 import nx from '@nx/eslint-plugin';

--- a/libs/compose/src/Compose.test-d.tsx
+++ b/libs/compose/src/Compose.test-d.tsx
@@ -124,11 +124,10 @@ describe('compose error carriers', () => {
     }>();
   });
 
-  // #20's headline case. A component whose props are all optional is a "weak
-  // type", so an object of only unknown keys is not assignable to it -- which
-  // used to route this through the repaired-shape branch and, from there, into
-  // a structural comparison of `Array.prototype.every`. The excess-key check
-  // has to run first for the prop to get named.
+  // Guards #20: a component whose props are all optional is a "weak type", so
+  // an object of only unknown keys is structurally assignable to it. The
+  // excess-key check must run before that structural comparison, or the
+  // excess prop goes unnamed.
   it('names an excess prop on an all-optional-props component', () => {
     expectTypeOf<
       ValidateProvider<readonly [OptProvider, { b: number }]>

--- a/libs/compose/src/Compose.test.tsx
+++ b/libs/compose/src/Compose.test.tsx
@@ -7,11 +7,12 @@ import { __resetWarningsForTests } from './Compose.js';
 import type { ComposeProviderProps, ProviderArray } from './index.js';
 
 /**
- * `ComposeProvider` is now generic and overloaded, so props built dynamically
- * (a union, or an object missing `providers` entirely) no longer resolve
- * against either overload -- which is the point. These tests exercise the
- * runtime guards for input a JavaScript consumer can still produce, so they go
- * through a deliberately loosened alias.
+ * `ComposeProvider` is generic and overloaded, so props built dynamically (a
+ * union, or an object missing `providers` entirely) do not resolve against
+ * either overload -- by design, it forces callers onto a shape TypeScript can
+ * check statically. These tests exercise the runtime guards for input a
+ * JavaScript consumer can still produce, through a deliberately loosened
+ * alias.
  */
 const LooseComposeProvider = ComposeProvider as unknown as React.FC<
   Record<string, unknown>

--- a/libs/compose/src/Compose.tsx
+++ b/libs/compose/src/Compose.tsx
@@ -18,16 +18,17 @@ const isDevelopment =
 /**
  * Messages already emitted, so a warning fires once rather than on every render.
  *
- * This is deliberately a module-level set rather than a hook. An earlier version
- * used `useEffect`, which meant the component required hooks -- and under
- * React's `react-server` condition `useEffect` is `undefined`, so
- * `ComposeProvider` threw on first render in any React Server Component. A Next.js
- * root `app/layout.tsx` is exactly that. Keeping the component hook-free is what
- * lets it be imported from the server graph without a `'use client'` boundary.
+ * This is deliberately a module-level set rather than a hook: a `useEffect`
+ * would require the component to use hooks, and React's `react-server`
+ * condition leaves `useEffect` `undefined`, so `ComposeProvider` would throw on
+ * first render in any React Server Component -- a Next.js root
+ * `app/layout.tsx` included. Keeping the component hook-free is what lets it
+ * be imported from the server graph without a `'use client'` boundary.
  *
- * The effect version also did not achieve what it claimed: its dependency was the
- * caller's array, and a JSX literal is a fresh identity every render, so the
- * warning re-fired on every render for the most common call style.
+ * A `useEffect`-based version also would not do what it looks like it does:
+ * its dependency would be the caller's array, and a JSX literal is a fresh
+ * identity every render, so the warning would re-fire on every render for the
+ * most common call style.
  */
 const warnedMessages = new Set<string>();
 
@@ -84,9 +85,9 @@ export interface ComposeProviderProps<T extends ProviderArray = ProviderArray> {
 export function ComposeProvider<const T extends ProviderArray>(
   props: ComposeProviderProps<T>,
 ): React.ReactElement {
-  // A JavaScript consumer, or one upgrading from 1.x, can still reach this with
-  // the removed `components` prop. Refusing by name beats silently accepting a
-  // prop the types no longer describe.
+  // A JavaScript consumer can still reach this with the removed `components`
+  // prop. Refusing by name beats silently accepting a prop the types do not
+  // describe.
   if (!('providers' in props) && 'components' in props) {
     throw new TypeError(
       'ComposeProvider: `components` was removed in v2.0 \u2014 rename it to `providers`.',

--- a/libs/urn/src/lib/urn.test-d.ts
+++ b/libs/urn/src/lib/urn.test-d.ts
@@ -13,8 +13,8 @@ describe('urn types', () => {
   });
 
   it('does not let a caller assert the parsed shape', () => {
-    // parse used to declare three free type parameters that nothing verified,
-    // so this claimed a shape the runtime never guaranteed.
+    // parse takes no type arguments: accepting them would let a caller assert
+    // a shape nothing verifies, which the runtime does not guarantee.
     // @ts-expect-error parse takes no type arguments
     URN.parse<'urn', 'user', '123'>('urn:user:123');
   });
@@ -83,8 +83,8 @@ describe('urn types', () => {
       static override readonly nid = 'bar';
     }
 
-    // These used to require `(TRN as typeof URN)` because the free type
-    // parameters on parse broke static inheritance.
+    // Guards inherited statics from requiring a cast to `typeof URN`: free
+    // type parameters on parse would otherwise break variance for subclasses.
     expectTypeOf(TRN.stringify('foo')).toEqualTypeOf<string>();
     expectTypeOf(TRN.parse('trn:bar:foo')).toEqualTypeOf<ParsedURN>();
     expectTypeOf(

--- a/libs/urn/src/lib/urn.ts
+++ b/libs/urn/src/lib/urn.ts
@@ -320,9 +320,9 @@ export class URN {
     const [urn, nid, ...rest] = urnString.split(this.separator);
 
     // The undefined checks are what narrow urn and nid to string under
-    // noUncheckedIndexedAccess. They are also the real guard: destructuring a
-    // short split is exactly how this method used to produce the literal string
-    // "undefined:".
+    // noUncheckedIndexedAccess. They are also the real guard: without them, a
+    // short split silently produces the literal string "undefined:" instead of
+    // throwing.
     if (urn === undefined || nid === undefined || rest.length === 0) {
       throw new ValidationError(
         `Invalid URN format: '${urnString}'. Expected at least three non-empty parts separated by '${this.separator}', e.g. '${this.urn}${this.separator}${this.nid}${this.separator}id'.`,

--- a/libs/widget/src/regressions.test.tsx
+++ b/libs/widget/src/regressions.test.tsx
@@ -72,9 +72,9 @@ describe('widget regressions', () => {
 
       expect(screen.getByTestId('box-a')).toBeInTheDocument();
       expect(screen.getByTestId('box-b')).toBeInTheDocument();
-      // This is the level that used to be silently dropped: Output rendered
-      // grandchildren without passing an Output of their own. Direct recursion
-      // has no equivalent hazard, and this locks that in.
+      // Guards against grandchildren silently not rendering: Output must pass
+      // itself down at every nesting level, not just the first, or deeper
+      // content renders without any Output wrapping it.
       expect(screen.getByTestId('leaf-c')).toBeInTheDocument();
     });
 
@@ -232,9 +232,9 @@ describe('widget regressions', () => {
         />,
       );
 
-      // Output used to fall back to the factory-level chrome, so nested items
-      // silently lost the instance override. renderWidget now threads the
-      // resolved chrome through the recursion instead.
+      // Guards against nested items falling back to the factory-level chrome:
+      // renderWidget threads the resolved chrome through the recursion, so a
+      // nested item gets the instance-level override too.
       expect(
         container.querySelectorAll('[data-custom-item="yes"]'),
       ).toHaveLength(2);
@@ -262,10 +262,11 @@ describe('widget regressions', () => {
       fireEvent.click(screen.getByTestId('inc'));
       expect(screen.getByTestId('inc')).toHaveTextContent('count:2');
 
-      // A fresh array identity forces Widgets to re-render. The injected Output
-      // used to be a brand-new component type each time, so React remounted the
-      // nested subtree and the counter reset to 0. Nothing mounts a synthetic
-      // component any more, but the property still has to hold.
+      // A fresh array identity forces Widgets to re-render. This guards
+      // against React remounting the nested subtree when that happens: the
+      // injected Output component keeps a stable identity across renders
+      // rather than a new type each time, so nested state -- the counter here
+      // -- survives.
       rerender(<Widgets items={[...items]} />);
 
       expect(screen.getByTestId('inc')).toHaveTextContent('count:2');

--- a/libs/widget/vite.config.ts
+++ b/libs/widget/vite.config.ts
@@ -71,12 +71,12 @@ export default defineConfig(() => ({
           exclude: ['**/*.server.{test,spec}.{ts,tsx}'],
         },
       },
-      // The whole point of this package no longer carrying 'use client' is that
-      // it can be imported from a React Server Component. React's `react-server`
-      // export condition omits createContext, useContext, Component and every
-      // stateful hook, so a single reintroduced import breaks that silently:
-      // the build succeeds and every jsdom test still passes. This project
-      // resolves react under that condition so the failure surfaces here.
+      // This package is importable from a React Server Component because it
+      // never carries 'use client'. React's `react-server` export condition
+      // omits createContext, useContext, Component and every stateful hook, so
+      // a reintroduced import breaks that silently: the build succeeds and
+      // every jsdom test still passes. This project resolves react under that
+      // condition so the failure surfaces here.
       {
         extends: true,
         resolve: { conditions: ['react-server'] },

--- a/nest/correlation-id/src/correlation.service.ts
+++ b/nest/correlation-id/src/correlation.service.ts
@@ -10,13 +10,11 @@ interface CorrelationStore {
 }
 
 /**
- * A plain singleton over AsyncLocalStorage.
- *
- * It used to be `@Injectable({ scope: Scope.REQUEST })`. Nest propagates scope
- * upward through the injection graph, so every provider that reached this one
- * -- including `HttpService`, via `withCorrelation` -- silently became
+ * A plain singleton over AsyncLocalStorage. AsyncLocalStorage gives per-request
+ * isolation without Nest's request scope: request-scoping this provider would
+ * propagate upward through the injection graph, making every provider that
+ * depends on it -- including `HttpService`, via `withCorrelation` -- also
  * request-scoped: re-instantiated per request, and never given `onModuleInit`.
- * AsyncLocalStorage gives the same per-request isolation with none of that.
  */
 @Injectable()
 export class CorrelationService {

--- a/nest/correlation-id/src/withCorrelation.function.ts
+++ b/nest/correlation-id/src/withCorrelation.function.ts
@@ -26,10 +26,10 @@ const AXIOS_INSTANCE_TOKEN = 'AXIOS_INSTANCE_TOKEN';
  * global module, so importing it once in the root module is enough; without it
  * Nest fails with `Nest can't resolve dependencies of the HTTP_MODULE_OPTIONS`.
  *
- * The id is read by an axios request interceptor, at the moment the request is
- * made. It used to be baked into the options object by a factory injecting the
- * then request-scoped `CorrelationService`, which made `HttpService` -- and
- * every provider holding it -- request-scoped too.
+ * The id is read by an axios request interceptor at the moment the request is
+ * made, not baked into the options object at factory time: that keeps
+ * `CorrelationService` a singleton, so `HttpService` -- and every provider
+ * holding it -- stays a singleton too.
  */
 export const withCorrelation = (
   config?: HttpModuleOptions,

--- a/nest/correlation-id/vite.config.ts
+++ b/nest/correlation-id/vite.config.ts
@@ -5,11 +5,10 @@ export default defineConfig(() => ({
   root: import.meta.dirname,
   cacheDir: '../../node_modules/.vite/libs/nestjs-correlation-id',
   test: {
-    // No vitest `typecheck` block: there are no *.test-d.ts files here, and the
-    // glob that used to be configured matched none of them, so the check was
-    // vacuous. `nx typecheck` builds tsconfig.json, which references both
-    // tsconfig.lib.json and tsconfig.spec.json, so sources and specs are both
-    // typechecked there.
+    // No vitest `typecheck` block: there are no *.test-d.ts files here for a
+    // glob to match. `nx typecheck` builds tsconfig.json, which references
+    // both tsconfig.lib.json and tsconfig.spec.json, so sources and specs are
+    // both typechecked there.
     watch: false,
     globals: true,
     environment: 'node',

--- a/nx.json
+++ b/nx.json
@@ -115,33 +115,12 @@
       "adjustSemverBumpsForZeroMajorVersion": true
     },
     "conventionalCommits": {
-      //
-      // Nx 22.0.x silently made `useCommitScope: true` the default. With it on,
-      // a conventional-commit scope is matched against Nx PROJECT NAMES
-      // (getCommitsRelevantToProjects in
-      // nx/src/command-line/release/utils/shared.js) with
-      // /(?<![@a-zA-Z0-9-])<scope>(?![@a-zA-Z0-9-])/. The scope this repo
-      // documented for @evanion/react-widget was `widget`, and the hyphen in
-      // `react-widget` makes that regex fail, so every `widget`-scoped commit
-      // was attributed to no project at all. semver.js:29
-      // (`if (config.useCommitScope && !isProjectScopedCommit)`) then downgrades
-      // those commits to `patch`, so `feat(widget)!:` with a BREAKING CHANGE
-      // footer resolved as 0.1.1 instead of 0.2.0. Nothing errors, the version
-      // is just wrong, and published npm versions are immutable.
-      //
-      // Turning it off restores attribution by CHANGED FILES, which is what
-      // Nx's published release guide still describes.
-      //
-      // The tradeoff: with attribution by files, a commit touching a root file
-      // fans out to every project -- `nx show projects --affected
-      // --files=package-lock.json` returns all of them. A `deps` commit bumps
-      // everything rather than nothing: over-bumping, which is recoverable,
-      // instead of under-bumping, which is not.
-      //
-      // Back on as of the 2.0.0 release: its tags reset the changelog range,
-      // so no `widget`-scoped commit is in range any more, and `scope-enum` in
-      // commitlint.config.js now rejects a scope that is not a project name.
-      // Kept on so a root-file commit does not fan out to every package.
+      // A conventional-commit scope is matched against Nx project names. A
+      // scope that matches no project is not an error: it silently downgrades
+      // the bump to patch, so `feat(scope)!:` with a BREAKING CHANGE footer can
+      // resolve as a patch release. `scope-enum` in commitlint.config.js
+      // enforces that every scope used here is a real project name, which is
+      // what this setting requires.
       "useCommitScope": true
     },
     "changelog": {

--- a/scripts/verify-packaging.mjs
+++ b/scripts/verify-packaging.mjs
@@ -163,12 +163,10 @@ if (missing.length) { console.error('not exported at runtime:', missing.join(', 
   run('node', ['runtime.mjs'], dir);
   console.log('  ✓ every package imports cleanly as ESM');
 
-  // nestjs-correlation-id used to ship a dual build, which handed Nest two
-  // unrelated CorrelationService class objects whenever one copy was require()d
-  // and the other imported -- and CorrelationService is a DI token. It is now
-  // ESM only. Assert that positively: exactly one build in the tarball, no
-  // `require` condition in the exports map. A reintroduced CJS half would
-  // otherwise go unnoticed until someone hit the dual load.
+  // nestjs-correlation-id ships ESM only: exactly one build in the tarball,
+  // no `require` condition in the exports map. A `require` condition would
+  // let one copy be require()d and another imported, handing Nest two
+  // unrelated CorrelationService class objects for what is a DI token.
   const nestPkg = JSON.parse(
     readFileSync(
       join(


### PR DESCRIPTION
## Summary
- Comments across nx.json, release.yml, verify-packaging.mjs, the correlation-id package, compose, urn, and widget rewrite the code's history (an incident, a former shape, a past bug) instead of describing what the code does now.
- Rewrote each to state the current behaviour and, where the file was a regression test, the property/bug the test guards (kept in present tense, no narration of what changed).
- No code was touched — comments only. `git diff` for every changed file is comment-lines-only.

## Test plan
- [x] `npx nx run-many -t lint test build typecheck check` — all affected unit tests, lint, typecheck pass; `storefront:build` and `docs:build` fail for pre-existing environment reasons unrelated to this change (missing `next`/`cookie` packages in this worktree's `node_modules`, confirmed via `git diff` touching no code in either app); Nx Cloud 401 is expected.
- [x] `git diff --stat` touches only the 14 intended files; no file in `libs/feature` or `apps/shop-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019s6FWxb6zpDUvbN4j1XH2B