### PR TITLE
feat(feature): add dependency-aware feature toggles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,7 @@ Package scopes:
 - **compose**: Changes to the `@evanion/compose` library
 - **urn**: Changes to the `@evanion/urn` library
 - **luhn**: Changes to the `@evanion/luhn` library
+- **feature**: Changes to the `@evanion/feature` library
 - **react-widget**: Changes to the `@evanion/react-widget` library
 - **astro-widget**: Changes to the `@evanion/astro-widget` library
 - **nestjs-correlation-id**: Changes to the `@evanion/nestjs-correlation-id` library

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -36,6 +36,7 @@ module.exports = {
         'astro-widget',
         'compose',
         'docs',
+        'feature',
         'luhn',
         'nestjs-correlation-id',
         'nx-astro',

--- a/libs/feature/LICENSE
+++ b/libs/feature/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Mikael Pettersson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/libs/feature/README.md
+++ b/libs/feature/README.md
@@ -1,0 +1,256 @@
+![CI](https://github.com/Evanion/libraries/actions/workflows/ci.yml/badge.svg)
+![npm (scoped)](https://img.shields.io/npm/v/@evanion/feature)
+
+# Feature Toggles
+
+Feature toggles where one flag can depend on another. A parent that resolves off
+takes its dependants with it, transitively, and it does that without writing
+anything back into the configuration.
+
+```ts
+import { createFeatures } from '@evanion/feature';
+
+const features = createFeatures([
+  {
+    key: 'payments-v3',
+    enabled: true,
+    rules: [
+      {
+        id: 'window-q4',
+        when: [{ field: 'now', op: 'after', value: '2026-10-01T00:00:00Z' }],
+        rollout: { percent: 25, by: 'targetingKey' },
+      },
+    ],
+  },
+  { key: 'checkout-v2', enabled: true, dependsOn: ['payments-v3'] },
+]);
+
+features.isEnabled('checkout-v2', { targetingKey: 'acct-42' });
+```
+
+`checkout-v2` is on only when `payments-v3` resolves on for that same account.
+Without the cascade, a 25% rollout on the parent would leak to 100% of the
+dependant's users.
+
+## Installation
+
+```bash
+npm install @evanion/feature
+```
+
+Two entry points. `@evanion/feature` is the core and imports no framework, so it
+runs in an API, in a script, or at build time. `@evanion/feature/react` carries
+the provider and hooks and is client code.
+
+## Configuration
+
+A feature is stored intent:
+
+| Field | Meaning |
+| --- | --- |
+| `key` | The identifier. `string` or `number`. |
+| `enabled` | The maintainer wants this on. |
+| `dependsOn` | Features that must resolve on for this one to. |
+| `rules` | Activation rules. OR-ed. |
+| `seed` | Bucketing seed for this feature's rollouts. Defaults to the key. |
+| `freezeTimeAtBuild` | Let `plan()` resolve this feature's time windows at build. |
+
+`enabled` is intent, not the answer. `rules` decide whether it resolves on for a
+given context.
+
+## Precedence
+
+- `enabled === false` short-circuits. Rules never run.
+- A parent that resolved off short-circuits. Rules never run.
+- `enabled === true` with no rules means on.
+- Rules are OR-ed; the `when` conditions inside one rule are AND-ed. A rollout
+  is one more conjunct of the rule that carries it.
+
+Not first-match. Rule order never changes the outcome.
+
+Toggling `enabled` on for a feature whose rules do not match changes stored
+intent, and the feature still resolves off. It is a kill switch in one direction
+only; it is not a force-on.
+
+## Conditions
+
+```ts
+{ field: 'now', op: 'before' | 'after', value: '2026-10-01T00:00:00Z' }
+{ field: 'now', op: 'day-of-week', zone: 'Europe/Stockholm', value: ['mon', 'fri'] }
+{ field: 'plan', op: 'eq' | 'ne' | 'in' | 'not-in' | 'contains', value: 'pro' }
+```
+
+`now` comes from the evaluation context and defaults to `new Date()` at the
+call. It is injected, never read from an ambient clock, which is what makes
+build-time evaluation honest and tests trivial.
+
+A day-of-week condition must name an IANA zone. UTC day-of-week is wrong for
+every business rule anyone writes.
+
+A condition over a field the context does not carry never holds -- including the
+negative operators. `ne` on an absent field is unevaluable, not true.
+
+## Results
+
+`resolve(context)` returns one decision per feature. `enabled` is the decision;
+everything else explains it.
+
+| `reason` | meaning |
+| --- | --- |
+| `default-on` | enabled, no rules |
+| `rule-match` | enabled, a rule matched; carries `rule` |
+| `explicitly-off` | `enabled === false` |
+| `no-rule-matched` | enabled, rules present, none passed; carries a per-rule breakdown |
+| `dependency-off` | a parent resolved off; carries `blockedBy` and `cause` |
+
+```ts
+{
+  key: 'checkout-v2',
+  enabled: false,
+  reason: 'dependency-off',
+  blockedBy: 'payments-v3',
+  cause: { key: 'payments-v3', reason: 'no-rule-matched', rule: 'window-q4' },
+}
+```
+
+`blockedBy` is the edge, for a graph view. `cause` is the first ancestor off for
+a reason of its own, for an operator who wants to know what to fix.
+
+`reason` is output only. Nothing in this library reads it back to decide
+anything, so deleting it changes no decision.
+
+## Rollouts
+
+```ts
+{ rollout: { percent: 25, by: 'targetingKey', seed: 'q4-cohort' } }
+```
+
+The bucket is a MurmurHash3 of the seed and the bucketing value, normalised over
+2^32 buckets. The seed defaults to the feature key, which is what decorrelates a
+user's bucket across features -- with a shared seed, someone is in every rollout
+or none. Set `seed` explicitly only to correlate two features deliberately.
+
+The bucket does not depend on the percentage, so raising a percentage only adds
+members and never moves one out. Lowering it removes the highest buckets.
+
+A context with no value for `by` does not match the rollout.
+
+## The store never writes
+
+The only writers are `toggle()` and editing the configuration. `resolve()` and
+`plan()` are pure functions of `(config, context, now)`.
+
+When a parent's window expires nothing changes in the store; `resolve()` starts
+returning false for the dependant. When the window reopens it returns true
+again. The dependant's `enabled` was `true` throughout, because that field means
+"the maintainer wants this on", which stayed true.
+
+Writing resolved values back would put entries in an audit log that nobody
+performed, make a process that slept through a window boundary disagree with one
+that was awake, and destroy the difference between "someone turned this off" and
+"the system turned it off".
+
+## Toggling
+
+```ts
+features.toggle('payments-v3', false);
+// { ok: true, key: 'payments-v3', enabled: false, willDisable: ['checkout-v2', 'checkout-express'] }
+```
+
+Dependencies cascade one way only -- a dependant never blocks its parent -- but
+the information that blocking existed to provide is kept. `willDisable` lists
+the transitive dependants that resolve on now and will not after the toggle. A UI
+can confirm before applying; a script can ignore it.
+
+An unknown key returns `{ ok: false, error: 'unknown-feature' }` rather than
+throwing.
+
+## Static and runtime evaluation
+
+```ts
+features.plan({ now: new Date() });
+// { 'checkout-v2': { resolved: 'deferred', needs: ['targetingKey'] }, … }
+```
+
+`plan()` partitions rules by the context they require. A rule needing only `now`
+is resolvable for a known instant; a rule needing `targetingKey` is not. A static
+site emits only the deferred set and resolves that per request; an API calls
+`resolve()` per request. One engine, not a second code path.
+
+Freezing a date window into a build is a deploy-cadence decision, so `plan()`
+defers time-dependent rules unless the feature sets `freezeTimeAtBuild`.
+
+## Cycles
+
+A dependency cycle is rejected by `createFeatures`, with the path in the error:
+
+```
+FeatureCycleError: feature dependency cycle: a -> b -> c -> a
+```
+
+So is a `dependsOn` naming a feature that is not configured, and a duplicate
+key. All three are configuration errors, and a cycle has no defined resolution
+order at all, so none of them is left for evaluation to trip over.
+
+## React
+
+```tsx
+'use client';
+import { FeatureProvider, useFeature, useFeatureEnabled } from '@evanion/feature/react';
+
+const features = createFeatures(config);
+const context = { targetingKey: user.id, now: new Date() };
+
+<FeatureProvider features={features} context={context}>
+  <Checkout />
+</FeatureProvider>;
+
+function Checkout() {
+  if (!useFeatureEnabled('checkout-v2')) return <LegacyCheckout />;
+  return <NewCheckout />;
+}
+```
+
+- `useFeatures()` -- every decision.
+- `useFeature(key)` -- one decision, explanation included. Throws for a key that
+  is not configured: a silent `false` makes a typo indistinguishable from a
+  feature that is off.
+- `useFeatureEnabled(key)` -- the boolean.
+
+Resolution is memoised on the `context` object's identity, so keep that
+reference stable. Pass `decisions` to hand the provider results resolved
+elsewhere -- a server render, or a `plan()` snapshot.
+
+## Typed keys
+
+```ts
+type Flag = 'payments-v3' | 'checkout-v2';
+const features = createFeatures<Flag>(config);
+
+features.resolve()['checkout-v2'].enabled; // Decision, not Decision | undefined
+features.isEnabled('checkout-v3'); // compile error: not a Flag
+```
+
+Passing a literal key union makes the decision record exact, so a typo is a
+compile error instead of an `undefined` at runtime.
+
+## API
+
+| Export | |
+| --- | --- |
+| `createFeatures(definitions)` | Builds the store. Validates the graph. |
+| `.resolve(context?)` | A decision per feature. |
+| `.isEnabled(key, context?)` | One boolean. |
+| `.plan(context?)` | Build-time partition. |
+| `.toggle(key, enabled, context?)` | Writes intent, reports `willDisable`. |
+| `.config` | The stored intent, deeply frozen. |
+| `.definition(key)` | One stored definition. |
+| `.dependants(key)` | Transitive dependants, in dependency order. |
+| `.keys` | Every key, in configuration order. |
+| `bucketOf(value, seed)`, `inRollout(value, percent, seed)`, `murmur3(input)` | The bucketing primitives, exported for snapshot tooling and tests. |
+| `evaluateCondition(condition, context)` | One condition, for the same reason. |
+| `FeatureCycleError`, `UnknownDependencyError`, `DuplicateFeatureError`, `FeatureConfigError` | Construction errors. |
+
+## License
+
+MIT

--- a/libs/feature/eslint.config.mjs
+++ b/libs/feature/eslint.config.mjs
@@ -1,0 +1,28 @@
+import nx from '@nx/eslint-plugin';
+import baseConfig, { sharedRules } from '../../eslint.config.mjs';
+
+export default [
+  ...baseConfig,
+  ...nx.configs['flat/react'],
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    rules: sharedRules,
+  },
+  {
+    files: ['**/*.json'],
+    rules: {
+      '@nx/dependency-checks': [
+        'error',
+        {
+          ignoredFiles: [
+            '{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}',
+            '{projectRoot}/vite.config.{js,ts,mjs,mts}',
+          ],
+        },
+      ],
+    },
+    languageOptions: {
+      parser: await import('jsonc-eslint-parser'),
+    },
+  },
+];

--- a/libs/feature/package.json
+++ b/libs/feature/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@evanion/feature",
+  "version": "0.0.1",
+  "description": "Dependency-aware feature toggles. Cascading prerequisites, rule-based activation and deterministic rollout bucketing, with a framework-free core.",
+  "keywords": [
+    "feature-flags",
+    "feature-toggles",
+    "rollout",
+    "targeting",
+    "dependencies",
+    "react",
+    "typescript"
+  ],
+  "homepage": "https://github.com/Evanion/libraries/tree/main/libs/feature#readme",
+  "bugs": {
+    "url": "https://github.com/Evanion/libraries/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Evanion/libraries.git",
+    "directory": "libs/feature"
+  },
+  "license": "MIT",
+  "author": "Mikael Pettersson",
+  "type": "module",
+  "sideEffects": false,
+  "engines": {
+    "node": ">=20"
+  },
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "@evanion/source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./react": {
+      "@evanion/source": "./src/react/index.tsx",
+      "types": "./dist/react/index.d.ts",
+      "import": "./dist/react/index.js",
+      "default": "./dist/react/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "!dist/**/*.tsbuildinfo",
+    "src",
+    "!src/**/*.test.*",
+    "!src/**/*.spec.*",
+    "!src/**/*.test-d.*",
+    "!src/test-setup.ts",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "dependencies": {
+    "tslib": "^2.8.1"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
+  }
+}

--- a/libs/feature/src/index.ts
+++ b/libs/feature/src/index.ts
@@ -1,0 +1,41 @@
+/**
+ * `@evanion/feature` -- dependency-aware feature toggles.
+ *
+ * This entry is the core and imports no framework. It is what the API and the
+ * build-time pass use. The React provider and hooks live on `@evanion/feature/react`.
+ */
+export { createFeatures } from './lib/features.js';
+export type { Features } from './lib/features.js';
+
+export { bucketOf, inRollout, murmur3 } from './lib/bucketing.js';
+export { evaluateCondition } from './lib/conditions.js';
+export { DEFAULT_ROLLOUT_FIELD } from './lib/evaluate.js';
+
+export {
+  DuplicateFeatureError,
+  FeatureConfigError,
+  FeatureCycleError,
+  UnknownDependencyError,
+} from './lib/errors.js';
+
+export type {
+  AttributeCondition,
+  Cause,
+  Condition,
+  DayOfWeekCondition,
+  Decision,
+  Decisions,
+  EvaluationContext,
+  FeatureDefinition,
+  FeatureKey,
+  Instant,
+  Plan,
+  PlanEntry,
+  Reason,
+  RolloutSpec,
+  Rule,
+  RuleOutcome,
+  ToggleResult,
+  Weekday,
+  WindowCondition,
+} from './lib/types.js';

--- a/libs/feature/src/lib/bucketing.spec.ts
+++ b/libs/feature/src/lib/bucketing.spec.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { bucketOf, inRollout, murmur3 } from './bucketing.js';
+
+/**
+ * The three properties the spec requires of bucketing, each written so it fails
+ * on the naive implementation it warns about
+ * (`hashFnv32a(value + seed) % 1000`, GrowthBook pre-v2).
+ */
+
+const members = (keys: readonly string[], percent: number, seed: string) =>
+  keys.filter((key) => inRollout(key, percent, seed));
+
+const users = Array.from({ length: 5000 }, (_, i) => `user-${i}`);
+
+describe('bucketOf', () => {
+  it('returns a value in [0, 1)', () => {
+    for (const user of users.slice(0, 200)) {
+      const bucket = bucketOf(user, 'checkout-v2');
+      expect(bucket).toBeGreaterThanOrEqual(0);
+      expect(bucket).toBeLessThan(1);
+    }
+  });
+
+  it('is stable across evaluations', () => {
+    const first = users.map((user) => bucketOf(user, 'checkout-v2'));
+    const second = users.map((user) => bucketOf(user, 'checkout-v2'));
+
+    expect(second).toEqual(first);
+  });
+
+  it('is stable across processes', () => {
+    // Pinned literals, not a recomputation: a hash that changed between
+    // releases would still agree with itself inside one process. This is the
+    // only assertion that catches a changed hash, which would silently
+    // rebucket every user of every deployed flag.
+    expect(bucketOf('user-1', 'checkout-v2').toFixed(9)).toBe('0.550397675');
+    expect(bucketOf('user-1', 'payments-v3').toFixed(9)).toBe('0.649353779');
+    expect(bucketOf('', '').toFixed(9)).toBe('0.016881907');
+  });
+
+  it('hashes with a real MurmurHash3, x86 32-bit', () => {
+    // The canonical test vectors. Pinning only the bucket values above would
+    // also be satisfied by a private hash of my own invention, which is not
+    // something anyone else can reproduce or audit.
+    expect(murmur3('')).toBe(0);
+    expect(murmur3('a').toString(16)).toBe('3c2569b2');
+    expect(murmur3('abc').toString(16)).toBe('b3dd93fa');
+    expect(murmur3('hello').toString(16)).toBe('248bfa47');
+  });
+
+  it('separates the seed from the value, so seed+value concatenation cannot collide', () => {
+    // The naive `value + seed` concatenation hashes ('ab', 'c') and ('a', 'bc')
+    // identically, which correlates flags whose keys share a prefix.
+    expect(bucketOf('ab', 'c')).not.toBe(bucketOf('a', 'bc'));
+  });
+});
+
+describe('inRollout', () => {
+  it('is decorrelated across features', () => {
+    // A user in the 10% of one feature must not be meaningfully more likely to
+    // be in the 10% of another. Measured as overlap against the independent
+    // expectation: 10% of the 10% cohort.
+    const a = new Set(members(users, 10, 'checkout-v2'));
+    const b = new Set(members(users, 10, 'payments-v3'));
+    const overlap = [...a].filter((user) => b.has(user)).length;
+
+    expect(a.size).toBeGreaterThan(users.length * 0.08);
+    expect(b.size).toBeGreaterThan(users.length * 0.08);
+    // Independent would be ~50 of 5000. A shared seed would make it ~500.
+    expect(overlap).toBeLessThan(a.size * 0.25);
+  });
+
+  it('never moves an existing member out when the percentage is raised', () => {
+    let previous = members(users, 1, 'checkout-v2');
+
+    for (const percent of [2, 5, 10, 25, 50, 75, 99, 100]) {
+      const next = new Set(members(users, percent, 'checkout-v2'));
+      const dropped = previous.filter((user) => !next.has(user));
+
+      expect(dropped, `raising to ${percent}% dropped members`).toEqual([]);
+      expect(next.size).toBeGreaterThanOrEqual(previous.length);
+      previous = [...next];
+    }
+  });
+
+  it('includes nobody at 0% and everybody at 100%', () => {
+    expect(members(users, 0, 'checkout-v2')).toEqual([]);
+    expect(members(users, 100, 'checkout-v2')).toEqual(users);
+  });
+
+  it('lands within a point of the requested percentage', () => {
+    for (const percent of [10, 25, 50]) {
+      const share = (members(users, percent, 'checkout-v2').length / users.length) * 100;
+      expect(Math.abs(share - percent)).toBeLessThan(1.5);
+    }
+  });
+});

--- a/libs/feature/src/lib/bucketing.ts
+++ b/libs/feature/src/lib/bucketing.ts
@@ -1,0 +1,125 @@
+/**
+ * Deterministic rollout bucketing.
+ *
+ * Three properties are required of this, and all three come from how the bucket
+ * is derived rather than from how it is compared:
+ *
+ * 1. Stable. The bucket is a pure hash of the (seed, value) pair. No randomness,
+ *    no clock, no process state, so it agrees across evaluations and processes.
+ * 2. Decorrelated across features. The seed defaults to the feature key, so the
+ *    same user hashes to an unrelated bucket per feature. Seeding with a
+ *    constant is what puts a user in every rollout or none.
+ * 3. Monotonic in the percentage. The bucket does not depend on the percentage
+ *    at all; the percentage is only a threshold on it. Raising a percentage can
+ *    therefore only add members, never move one out.
+ *
+ * The naive version the spec warns about -- GrowthBook's pre-v2
+ * `hashFnv32a(value + seed) % 1000` -- fails (2) for two separate reasons, and
+ * this implementation departs on both:
+ *
+ * - Concatenating value and seed with no unambiguous boundary makes the pairs
+ *   ('ab', 'c') and ('a', 'bc') the same input, so flags whose keys share a
+ *   prefix share buckets. The seed is length-prefixed here, which is
+ *   unambiguous for every possible input -- no separator character can be,
+ *   since any separator may itself occur in a key or a targeting value.
+ * - FNV-1a has weak avalanche in its low bits, and a modulus reads exactly
+ *   those. MurmurHash3's finalisation mixes the whole word, and the bucket is
+ *   taken from all 32 bits rather than a modulus, which is also what makes the
+ *   granularity (2^32 buckets) fine enough that a percentage change adds
+ *   buckets instead of reshuffling them.
+ *
+ * MurmurHash3 over a normalised 32-bit space is Unleash's approach
+ * (`normalizedValue(groupId, stickiness)`), with `groupId` defaulting to the
+ * flag name -- the same defaulting as `seed` here.
+ */
+
+const TWO_32 = 0x100000000;
+
+const C1 = 0xcc9e2d51;
+const C2 = 0x1b873593;
+
+function rotl32(value: number, shift: number): number {
+  return (value << shift) | (value >>> (32 - shift));
+}
+
+/** Encodes the pair so that no two distinct pairs produce the same string. */
+function encodePair(seed: string, value: string): string {
+  return `${seed.length}:${seed}${value}`;
+}
+
+/**
+ * MurmurHash3, x86 32-bit, over the UTF-8 bytes of `input`. Returns an unsigned
+ * 32-bit integer. `Math.imul` is used throughout because a 32-bit product does
+ * not fit a float64 mantissa.
+ */
+export function murmur3(input: string, seed = 0): number {
+  const bytes = new TextEncoder().encode(input);
+  const blocks = bytes.length & ~3;
+
+  let hash = seed >>> 0;
+
+  for (let i = 0; i < blocks; i += 4) {
+    let k =
+      (bytes[i] as number) |
+      ((bytes[i + 1] as number) << 8) |
+      ((bytes[i + 2] as number) << 16) |
+      ((bytes[i + 3] as number) << 24);
+
+    k = Math.imul(k, C1);
+    k = rotl32(k, 15);
+    k = Math.imul(k, C2);
+
+    hash ^= k;
+    hash = rotl32(hash, 13);
+    hash = (Math.imul(hash, 5) + 0xe6546b64) | 0;
+  }
+
+  // The reference implementation writes the tail as a fallthrough switch.
+  // `noFallthroughCasesInSwitch` is on here, so it is spelled as the loop it is.
+  const remaining = bytes.length & 3;
+  if (remaining > 0) {
+    let tail = 0;
+    for (let i = remaining - 1; i >= 0; i--) {
+      tail ^= (bytes[blocks + i] as number) << (8 * i);
+    }
+    tail = Math.imul(tail, C1);
+    tail = rotl32(tail, 15);
+    tail = Math.imul(tail, C2);
+    hash ^= tail;
+  }
+
+  hash ^= bytes.length;
+  hash ^= hash >>> 16;
+  hash = Math.imul(hash, 0x85ebca6b);
+  hash ^= hash >>> 13;
+  hash = Math.imul(hash, 0xc2b2ae35);
+  hash ^= hash >>> 16;
+
+  return hash >>> 0;
+}
+
+/**
+ * The bucket `value` falls in for a rollout seeded with `seed`, in [0, 1).
+ *
+ * 2^32 buckets, and independent of any percentage, which is what makes raising
+ * one purely additive.
+ */
+export function bucketOf(value: string, seed: string): number {
+  return murmur3(encodePair(seed, value)) / TWO_32;
+}
+
+/**
+ * Whether `value` is inside a `percent` rollout seeded with `seed`.
+ *
+ * Strictly below the threshold, so 0% includes nobody; every bucket is below 1,
+ * so 100% includes everybody.
+ */
+export function inRollout(
+  value: string,
+  percent: number,
+  seed: string,
+): boolean {
+  if (!(percent > 0)) return false;
+  if (percent >= 100) return true;
+  return bucketOf(value, seed) * 100 < percent;
+}

--- a/libs/feature/src/lib/conditions.spec.ts
+++ b/libs/feature/src/lib/conditions.spec.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+import { conditionFields, evaluateCondition } from './conditions.js';
+import type { Condition } from './types.js';
+
+const at = (iso: string) => ({ now: new Date(iso) });
+
+describe('evaluateCondition', () => {
+  describe('window', () => {
+    const before: Condition = {
+      field: 'now',
+      op: 'before',
+      value: '2026-10-01T00:00:00Z',
+    };
+
+    it('holds strictly before the instant', () => {
+      expect(evaluateCondition(before, at('2026-09-30T23:59:59Z'))).toBe(true);
+      expect(evaluateCondition(before, at('2026-10-01T00:00:00Z'))).toBe(false);
+      expect(evaluateCondition(before, at('2026-10-02T00:00:00Z'))).toBe(false);
+    });
+
+    it('holds strictly after the instant', () => {
+      const after: Condition = {
+        field: 'now',
+        op: 'after',
+        value: '2026-10-01T00:00:00Z',
+      };
+
+      expect(evaluateCondition(after, at('2026-10-01T00:00:01Z'))).toBe(true);
+      expect(evaluateCondition(after, at('2026-10-01T00:00:00Z'))).toBe(false);
+    });
+
+    it('accepts epoch milliseconds and a Date', () => {
+      const value = Date.UTC(2026, 9, 1);
+      expect(
+        evaluateCondition(
+          { field: 'now', op: 'before', value },
+          at('2026-09-30T00:00:00Z'),
+        ),
+      ).toBe(true);
+      expect(
+        evaluateCondition(
+          { field: 'now', op: 'before', value: new Date(value) },
+          at('2026-09-30T00:00:00Z'),
+        ),
+      ).toBe(true);
+    });
+
+    it('does not hold when the instant cannot be parsed', () => {
+      expect(
+        evaluateCondition(
+          { field: 'now', op: 'before', value: 'not-a-date' },
+          at('2026-09-30T00:00:00Z'),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe('day-of-week', () => {
+    // 2026-10-01T03:00Z is Thursday in UTC and still Wednesday in New York.
+    // UTC day-of-week is wrong for every business rule anyone writes, which is
+    // why the zone is required rather than defaulted.
+    const instant = at('2026-10-01T03:00:00Z');
+
+    it('reads the weekday in the zone the condition names', () => {
+      const condition = (zone: string): Condition => ({
+        field: 'now',
+        op: 'day-of-week',
+        zone,
+        value: ['wed'],
+      });
+
+      expect(evaluateCondition(condition('America/New_York'), instant)).toBe(
+        true,
+      );
+      expect(evaluateCondition(condition('UTC'), instant)).toBe(false);
+      expect(evaluateCondition(condition('Europe/Stockholm'), instant)).toBe(
+        false,
+      );
+    });
+
+    it('matches any of the listed days', () => {
+      expect(
+        evaluateCondition(
+          {
+            field: 'now',
+            op: 'day-of-week',
+            zone: 'UTC',
+            value: ['mon', 'thu'],
+          },
+          instant,
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe('attributes', () => {
+    const context = { plan: 'pro', regions: ['eu', 'us'], seats: 10 };
+
+    it('compares with eq and ne', () => {
+      expect(
+        evaluateCondition({ field: 'plan', op: 'eq', value: 'pro' }, context),
+      ).toBe(true);
+      expect(
+        evaluateCondition({ field: 'plan', op: 'ne', value: 'pro' }, context),
+      ).toBe(false);
+    });
+
+    it('compares with in and not-in', () => {
+      expect(
+        evaluateCondition(
+          { field: 'plan', op: 'in', value: ['pro', 'team'] },
+          context,
+        ),
+      ).toBe(true);
+      expect(
+        evaluateCondition(
+          { field: 'plan', op: 'not-in', value: ['pro', 'team'] },
+          context,
+        ),
+      ).toBe(false);
+    });
+
+    it('tests membership of an array-valued attribute with contains', () => {
+      expect(
+        evaluateCondition(
+          { field: 'regions', op: 'contains', value: 'eu' },
+          context,
+        ),
+      ).toBe(true);
+      expect(
+        evaluateCondition(
+          { field: 'regions', op: 'contains', value: 'apac' },
+          context,
+        ),
+      ).toBe(false);
+    });
+
+    it('does not hold when the field is absent from the context', () => {
+      expect(
+        evaluateCondition({ field: 'plan', op: 'eq', value: 'pro' }, {})
+      ).toBe(false);
+      expect(
+        evaluateCondition({ field: 'plan', op: 'ne', value: 'pro' }, {}),
+      ).toBe(false);
+      expect(
+        evaluateCondition({ field: 'plan', op: 'not-in', value: [] }, {}),
+      ).toBe(false);
+    });
+  });
+});
+
+describe('conditionFields', () => {
+  it('names the context field a condition reads', () => {
+    expect(
+      conditionFields({ field: 'now', op: 'before', value: 0 }),
+    ).toEqual(['now']);
+    expect(conditionFields({ field: 'plan', op: 'eq', value: 'pro' })).toEqual([
+      'plan',
+    ]);
+  });
+});

--- a/libs/feature/src/lib/conditions.ts
+++ b/libs/feature/src/lib/conditions.ts
@@ -1,0 +1,101 @@
+import type {
+  Condition,
+  EvaluationContext,
+  Instant,
+  Weekday,
+} from './types.js';
+
+const WEEKDAYS: readonly Weekday[] = [
+  'sun',
+  'mon',
+  'tue',
+  'wed',
+  'thu',
+  'fri',
+  'sat',
+];
+
+function toEpoch(value: Instant): number {
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === 'number') return value;
+  return new Date(value).getTime();
+}
+
+/**
+ * The weekday `instant` falls on in `zone`.
+ *
+ * Derived through `Intl`, not through an offset calculation: the zone's rules,
+ * including its DST transitions, are the runtime's to know and not this
+ * library's to model.
+ */
+function weekdayIn(instant: Date, zone: string): Weekday | undefined {
+  const formatted = new Intl.DateTimeFormat('en-US', {
+    timeZone: zone,
+    weekday: 'short',
+  })
+    .format(instant)
+    .toLowerCase();
+
+  return WEEKDAYS.find((day) => day === formatted);
+}
+
+/**
+ * The context fields a condition reads. Used by `plan()` to decide what it can
+ * resolve at build time and what it has to defer.
+ */
+export function conditionFields(condition: Condition): readonly string[] {
+  return [condition.field];
+}
+
+/**
+ * Whether a condition holds for a context.
+ *
+ * A condition over a field the context does not carry never holds -- including
+ * the negative operators. `ne` on an absent field is not "true because it is not
+ * equal"; it is unevaluable, and treating it as true would switch features on
+ * for exactly the contexts that carry the least information.
+ */
+export function evaluateCondition(
+  condition: Condition,
+  context: EvaluationContext,
+): boolean {
+  if (condition.op === 'day-of-week') {
+    const now = context.now;
+    if (!(now instanceof Date) || Number.isNaN(now.getTime())) return false;
+    const day = weekdayIn(now, condition.zone);
+    return day !== undefined && condition.value.includes(day);
+  }
+
+  if (condition.op === 'before' || condition.op === 'after') {
+    const now = context.now;
+    if (!(now instanceof Date) || Number.isNaN(now.getTime())) return false;
+    const boundary = toEpoch(condition.value);
+    if (Number.isNaN(boundary)) return false;
+    return condition.op === 'before'
+      ? now.getTime() < boundary
+      : now.getTime() > boundary;
+  }
+
+  if (!(condition.field in context)) return false;
+  const actual = context[condition.field];
+  if (actual === undefined) return false;
+
+  switch (condition.op) {
+    case 'eq':
+      return actual === condition.value;
+    case 'ne':
+      return actual !== condition.value;
+    case 'in':
+      return (
+        Array.isArray(condition.value) && condition.value.includes(actual)
+      );
+    case 'not-in':
+      return (
+        Array.isArray(condition.value) && !condition.value.includes(actual)
+      );
+    case 'contains':
+      return Array.isArray(actual) && actual.includes(condition.value);
+    default:
+      return false;
+  }
+}

--- a/libs/feature/src/lib/errors.ts
+++ b/libs/feature/src/lib/errors.ts
@@ -1,0 +1,58 @@
+import type { FeatureKey } from './types.js';
+
+/**
+ * Configuration errors, all thrown at construction.
+ *
+ * This follows the lesson from the luhn audit: reference implementations enforce
+ * their constraints when the configuration is supplied, not when it is used.
+ * Checking at use is how `@evanion/luhn` ended up with issue #87.
+ */
+export class FeatureConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'FeatureConfigError';
+  }
+}
+
+/**
+ * A dependency cycle. Resolution order is undefined for a cycle, so this is
+ * rejected rather than broken arbitrarily.
+ */
+export class FeatureCycleError extends FeatureConfigError {
+  /** The closed walk, ending where it starts, so the closing edge is visible. */
+  readonly path: readonly FeatureKey[];
+
+  constructor(path: readonly FeatureKey[]) {
+    super(`feature dependency cycle: ${path.join(' -> ')}`);
+    this.name = 'FeatureCycleError';
+    this.path = path;
+  }
+}
+
+/** A `dependsOn` naming a feature that is not in the configuration. */
+export class UnknownDependencyError extends FeatureConfigError {
+  readonly key: FeatureKey;
+  readonly dependency: FeatureKey;
+
+  constructor(key: FeatureKey, dependency: FeatureKey) {
+    super(
+      `feature "${String(key)}" depends on "${String(
+        dependency,
+      )}", which is not configured`,
+    );
+    this.name = 'UnknownDependencyError';
+    this.key = key;
+    this.dependency = dependency;
+  }
+}
+
+/** Two definitions with the same key. */
+export class DuplicateFeatureError extends FeatureConfigError {
+  readonly key: FeatureKey;
+
+  constructor(key: FeatureKey) {
+    super(`duplicate feature key "${String(key)}"`);
+    this.name = 'DuplicateFeatureError';
+    this.key = key;
+  }
+}

--- a/libs/feature/src/lib/evaluate.ts
+++ b/libs/feature/src/lib/evaluate.ts
@@ -1,0 +1,282 @@
+import { inRollout } from './bucketing.js';
+import { conditionFields, evaluateCondition } from './conditions.js';
+import type {
+  Cause,
+  Decision,
+  EvaluationContext,
+  FeatureDefinition,
+  FeatureKey,
+  PlanEntry,
+  Rule,
+  RuleOutcome,
+} from './types.js';
+
+/** The default context field a rollout buckets on. */
+export const DEFAULT_ROLLOUT_FIELD = 'targetingKey';
+
+function ruleId(rule: Rule, index: number): string {
+  return rule.id ?? `#${index}`;
+}
+
+function rolloutField(rule: Rule): string {
+  return rule.rollout?.by ?? DEFAULT_ROLLOUT_FIELD;
+}
+
+function rolloutSeed<F extends FeatureKey>(
+  definition: FeatureDefinition<F>,
+  rule: Rule,
+): string {
+  return rule.rollout?.seed ?? definition.seed ?? String(definition.key);
+}
+
+/** The context fields a rule reads, sorted and deduplicated. */
+export function ruleFields(rule: Rule): readonly string[] {
+  const fields = new Set<string>();
+  for (const condition of rule.when ?? []) {
+    for (const field of conditionFields(condition)) fields.add(field);
+  }
+  if (rule.rollout) fields.add(rolloutField(rule));
+  return [...fields].sort();
+}
+
+/**
+ * Evaluates one rule. Conditions are AND-ed, and a rollout is one more
+ * conjunct -- a rule with both matches only for a context that satisfies the
+ * conditions *and* falls in the bucket range.
+ */
+export function evaluateRule<F extends FeatureKey>(
+  definition: FeatureDefinition<F>,
+  rule: Rule,
+  index: number,
+  context: EvaluationContext,
+): RuleOutcome {
+  const id = ruleId(rule, index);
+
+  for (const condition of rule.when ?? []) {
+    if (!evaluateCondition(condition, context)) {
+      return { rule: id, matched: false, failed: condition };
+    }
+  }
+
+  const rollout = rule.rollout;
+  if (!rollout) return { rule: id, matched: true };
+
+  const by = rolloutField(rule);
+  const value = context[by];
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    // No bucketing value, so the rollout cannot be evaluated and does not
+    // match. Defaulting it to "in" would ramp a rollout to everyone whose
+    // context happens to be incomplete.
+    return {
+      rule: id,
+      matched: false,
+      rollout: { percent: rollout.percent, by, member: false },
+    };
+  }
+
+  const member = inRollout(
+    String(value),
+    rollout.percent,
+    rolloutSeed(definition, rule),
+  );
+
+  return {
+    rule: id,
+    matched: member,
+    rollout: { percent: rollout.percent, by, member },
+  };
+}
+
+/**
+ * The first parent that resolved off, or `undefined`.
+ *
+ * The parameter type is the narrowest thing the cascade is allowed to see: an
+ * `enabled` flag and nothing else. That `reason` is output only is enforced here
+ * by the type system, not only by convention.
+ */
+function blockingParent<F extends FeatureKey>(
+  definition: FeatureDefinition<F>,
+  resolved: ReadonlyMap<F, { readonly enabled: boolean }>,
+): F | undefined {
+  for (const parent of definition.dependsOn ?? []) {
+    const decision = resolved.get(parent);
+    // An unresolved parent cannot happen for a validated graph evaluated in
+    // dependency order, and is treated as blocking rather than ignored.
+    if (!decision || !decision.enabled) return parent;
+  }
+  return undefined;
+}
+
+/**
+ * Walks to the first ancestor that is off for a reason of its own.
+ *
+ * Explanation only. A UI wants the root cause; a graph view wants the edge, so
+ * both are reported.
+ */
+function rootCause<F extends FeatureKey>(
+  parent: F,
+  resolved: ReadonlyMap<F, Decision<F>>,
+): Cause<F> {
+  let at = parent;
+  const seen = new Set<F>([at]);
+
+  for (;;) {
+    const decision = resolved.get(at);
+    if (!decision) return { key: at, reason: 'explicitly-off' };
+    if (decision.reason !== 'dependency-off' || decision.blockedBy === undefined) {
+      const cause: Cause<F> = { key: at, reason: decision.reason };
+      // The rule is named when there is exactly one to name: the matching rule,
+      // or the single rule that failed. With several rules and none matching
+      // there is no one rule to blame, and the full breakdown is on the
+      // ancestor's own decision.
+      const rule =
+        decision.rule ??
+        (decision.rules?.length === 1 ? decision.rules[0]?.rule : undefined);
+      if (rule !== undefined) cause.rule = rule;
+      return cause;
+    }
+    at = decision.blockedBy;
+    // The graph is acyclic, so this cannot loop; the guard keeps a malformed
+    // decision map from hanging a caller rather than trusting that.
+    if (seen.has(at)) return { key: at, reason: decision.reason };
+    seen.add(at);
+  }
+}
+
+/**
+ * Decides one feature, given the already-resolved decisions of everything it
+ * depends on. Pure in `(definition, context, resolved)`.
+ *
+ * Precedence, defined once:
+ *
+ * 1. `enabled === false` short-circuits. Rules never run.
+ * 2. A parent that resolved off short-circuits. Rules never run.
+ * 3. No rules means on.
+ * 4. Rules are OR-ed, and the conditions within one rule are AND-ed.
+ */
+export function decide<F extends FeatureKey>(
+  definition: FeatureDefinition<F>,
+  context: EvaluationContext,
+  resolved: ReadonlyMap<F, Decision<F>>,
+): Decision<F> {
+  if (!definition.enabled) {
+    return { key: definition.key, enabled: false, reason: 'explicitly-off' };
+  }
+
+  const blocked = blockingParent(definition, resolved);
+  if (blocked !== undefined) {
+    return {
+      key: definition.key,
+      enabled: false,
+      reason: 'dependency-off',
+      blockedBy: blocked,
+      cause: rootCause(blocked, resolved),
+    };
+  }
+
+  const rules = definition.rules ?? [];
+  if (rules.length === 0) {
+    return { key: definition.key, enabled: true, reason: 'default-on' };
+  }
+
+  const outcomes: RuleOutcome[] = [];
+  for (const [index, rule] of rules.entries()) {
+    const outcome = evaluateRule(definition, rule, index, context);
+    if (outcome.matched) {
+      return {
+        key: definition.key,
+        enabled: true,
+        reason: 'rule-match',
+        rule: outcome.rule,
+      };
+    }
+    outcomes.push(outcome);
+  }
+
+  return {
+    key: definition.key,
+    enabled: false,
+    reason: 'no-rule-matched',
+    rules: outcomes,
+  };
+}
+
+/**
+ * Plans one feature for a partially known context.
+ *
+ * The line is context-free versus context-dependent: a rule whose fields are all
+ * present can be decided now, and one that still needs a field cannot. `now` is
+ * present only for a feature that opted into freezing its windows at build time,
+ * because baking a date window into a build is a deploy-cadence decision.
+ */
+export function planFeature<F extends FeatureKey>(
+  definition: FeatureDefinition<F>,
+  context: EvaluationContext,
+  plans: ReadonlyMap<F, PlanEntry<F>>,
+  resolved: ReadonlyMap<F, Decision<F>>,
+): PlanEntry<F> {
+  const key = definition.key;
+
+  if (!definition.enabled) {
+    return {
+      key,
+      resolved: false,
+      needs: [],
+      decision: decide(definition, context, resolved),
+    };
+  }
+
+  const deferredNeeds = new Set<string>();
+  for (const parent of definition.dependsOn ?? []) {
+    const parentPlan = plans.get(parent);
+    if (!parentPlan || parentPlan.resolved === false) {
+      return {
+        key,
+        resolved: false,
+        needs: [],
+        decision: decide(definition, context, resolved),
+      };
+    }
+    if (parentPlan.resolved === 'deferred') {
+      for (const need of parentPlan.needs) deferredNeeds.add(need);
+    }
+  }
+
+  const available = new Set(
+    Object.keys(context).filter(
+      (field) => field !== 'now' && context[field] !== undefined,
+    ),
+  );
+  if (definition.freezeTimeAtBuild) available.add('now');
+
+  const rules = definition.rules ?? [];
+  const ownNeeds = new Set<string>();
+
+  if (deferredNeeds.size === 0) {
+    for (const [index, rule] of rules.entries()) {
+      const missing = ruleFields(rule).filter((field) => !available.has(field));
+      if (missing.length) {
+        for (const field of missing) ownNeeds.add(field);
+        continue;
+      }
+      if (evaluateRule(definition, rule, index, context).matched) {
+        return {
+          key,
+          resolved: true,
+          needs: [],
+          decision: decide(definition, context, resolved),
+        };
+      }
+    }
+  }
+
+  const needs = [...deferredNeeds, ...ownNeeds].sort();
+  if (needs.length) return { key, resolved: 'deferred', needs };
+
+  return {
+    key,
+    resolved: rules.length === 0,
+    needs: [],
+    decision: decide(definition, context, resolved),
+  };
+}

--- a/libs/feature/src/lib/features.spec.ts
+++ b/libs/feature/src/lib/features.spec.ts
@@ -1,0 +1,599 @@
+import { describe, expect, it } from 'vitest';
+import { FeatureCycleError } from './errors.js';
+import { createFeatures } from './features.js';
+import type { Decision, FeatureDefinition } from './types.js';
+
+const WINDOW = '2026-10-01T00:00:00Z';
+
+/**
+ * A -> B -> C -> D -> E. Five levels: two would prove nothing about cascading.
+ *
+ * Typed on a literal key union, which is how a consumer gets exact decision
+ * records -- `decisions.e` is a `Decision`, not `Decision | undefined`.
+ */
+type Link = 'a' | 'b' | 'c' | 'd' | 'e';
+
+const chain = (): FeatureDefinition<Link>[] => [
+  { key: 'a', enabled: true },
+  { key: 'b', enabled: true, dependsOn: ['a'] },
+  { key: 'c', enabled: true, dependsOn: ['b'] },
+  { key: 'd', enabled: true, dependsOn: ['c'] },
+  { key: 'e', enabled: true, dependsOn: ['d'] },
+];
+
+const enabledOf = (decisions: Record<string, Decision>) =>
+  Object.fromEntries(
+    Object.entries(decisions).map(([key, decision]) => [key, decision.enabled]),
+  );
+
+describe('createFeatures', () => {
+  it('rejects a cycle at construction, naming the path', () => {
+    expect(() =>
+      createFeatures([
+        { key: 'a', enabled: true, dependsOn: ['c'] },
+        { key: 'b', enabled: true, dependsOn: ['a'] },
+        { key: 'c', enabled: true, dependsOn: ['b'] },
+      ]),
+    ).toThrow(FeatureCycleError);
+  });
+});
+
+describe('precedence', () => {
+  it('short-circuits on enabled === false without running the rules', () => {
+    const features = createFeatures([
+      {
+        key: 'off',
+        enabled: false,
+        // A rule that would match if it ran. The reason proves it did not.
+        rules: [{ id: 'always', when: [] }],
+      },
+    ]);
+
+    const decision = features.resolve().off;
+
+    expect(decision.enabled).toBe(false);
+    expect(decision.reason).toBe('explicitly-off');
+    expect(decision.rules).toBeUndefined();
+  });
+
+  it('resolves on when enabled and no rules are present', () => {
+    const features = createFeatures([{ key: 'plain', enabled: true }]);
+
+    expect(features.resolve().plain).toMatchObject({
+      enabled: true,
+      reason: 'default-on',
+    });
+  });
+
+  it('ORs the rules: one matching rule is enough', () => {
+    const features = createFeatures([
+      {
+        key: 'either',
+        enabled: true,
+        rules: [
+          { id: 'eu', when: [{ field: 'region', op: 'eq', value: 'eu' }] },
+          { id: 'beta', when: [{ field: 'beta', op: 'eq', value: true }] },
+        ],
+      },
+    ]);
+
+    const decision = features.resolve({ beta: true }).either;
+
+    expect(decision.enabled).toBe(true);
+    expect(decision.reason).toBe('rule-match');
+    expect(decision.rule).toBe('beta');
+  });
+
+  it('ANDs the conditions within one rule', () => {
+    const features = createFeatures([
+      {
+        key: 'both',
+        enabled: true,
+        rules: [
+          {
+            id: 'eu-beta',
+            when: [
+              { field: 'region', op: 'eq', value: 'eu' },
+              { field: 'beta', op: 'eq', value: true },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    expect(features.resolve({ region: 'eu', beta: true }).both.enabled).toBe(
+      true,
+    );
+    expect(features.resolve({ region: 'eu' }).both.enabled).toBe(false);
+  });
+
+  it('is not first-match: a later rule matches even when an earlier one fails', () => {
+    const features = createFeatures([
+      {
+        key: 'late',
+        enabled: true,
+        rules: [
+          { id: 'first', when: [{ field: 'region', op: 'eq', value: 'us' }] },
+          { id: 'second', when: [{ field: 'region', op: 'eq', value: 'eu' }] },
+        ],
+      },
+    ]);
+
+    expect(features.resolve({ region: 'eu' }).late).toMatchObject({
+      enabled: true,
+      rule: 'second',
+    });
+  });
+
+  it('reports a per-rule breakdown naming the failed condition', () => {
+    const features = createFeatures([
+      {
+        key: 'windowed',
+        enabled: true,
+        rules: [
+          {
+            id: 'window-q4',
+            when: [{ field: 'now', op: 'after', value: WINDOW }],
+          },
+        ],
+      },
+    ]);
+
+    const decision = features.resolve({
+      now: new Date('2026-09-01T00:00:00Z'),
+    }).windowed;
+
+    expect(decision).toMatchObject({
+      enabled: false,
+      reason: 'no-rule-matched',
+    });
+    expect(decision.rules).toEqual([
+      {
+        rule: 'window-q4',
+        matched: false,
+        failed: { field: 'now', op: 'after', value: WINDOW },
+      },
+    ]);
+  });
+
+  it('buckets a rollout on the context field the rule names', () => {
+    const features = createFeatures([
+      {
+        key: 'checkout-v2',
+        enabled: true,
+        rules: [{ id: 'ramp', rollout: { percent: 100, by: 'accountId' } }],
+      },
+    ]);
+
+    expect(features.resolve({ accountId: 'acct-1' })['checkout-v2']).toMatchObject(
+      { enabled: true, rule: 'ramp' },
+    );
+    // No bucketing field in the context: the rule cannot be evaluated, so it
+    // does not match.
+    expect(features.resolve()['checkout-v2']).toMatchObject({
+      enabled: false,
+      reason: 'no-rule-matched',
+    });
+  });
+
+  it('ANDs a rollout with the rule conditions', () => {
+    const features = createFeatures([
+      {
+        key: 'gated',
+        enabled: true,
+        rules: [
+          {
+            id: 'eu-ramp',
+            when: [{ field: 'region', op: 'eq', value: 'eu' }],
+            rollout: { percent: 100, by: 'accountId' },
+          },
+        ],
+      },
+    ]);
+
+    expect(
+      features.resolve({ region: 'eu', accountId: 'acct-1' }).gated.enabled,
+    ).toBe(true);
+    expect(
+      features.resolve({ region: 'us', accountId: 'acct-1' }).gated.enabled,
+    ).toBe(false);
+  });
+
+  it('defaults the bucketing seed to the feature key', () => {
+    // Same rollout, same user, two features: the cohorts must differ. A shared
+    // seed would make every 5% rollout contain the same users.
+    const definitions = (key: string): FeatureDefinition[] => [
+      { key, enabled: true, rules: [{ rollout: { percent: 5 } }] },
+    ];
+    const a = createFeatures(definitions('checkout-v2'));
+    const b = createFeatures(definitions('payments-v3'));
+
+    const differing = Array.from({ length: 500 }, (_, i) => `user-${i}`).filter(
+      (targetingKey) =>
+        a.isEnabled('checkout-v2', { targetingKey }) !==
+        b.isEnabled('payments-v3', { targetingKey }),
+    );
+
+    expect(differing.length).toBeGreaterThan(0);
+  });
+
+  it('correlates two features deliberately when they share an explicit seed', () => {
+    const seed = 'q4-cohort';
+    const a = createFeatures([
+      { key: 'a', enabled: true, rules: [{ rollout: { percent: 5, seed } }] },
+    ]);
+    const b = createFeatures([
+      { key: 'b', enabled: true, rules: [{ rollout: { percent: 5, seed } }] },
+    ]);
+
+    for (let i = 0; i < 200; i++) {
+      const targetingKey = `user-${i}`;
+      expect(a.isEnabled('a', { targetingKey })).toBe(
+        b.isEnabled('b', { targetingKey }),
+      );
+    }
+  });
+});
+
+describe('cascade', () => {
+  it('cascades transitively down a five-level chain', () => {
+    const features = createFeatures(chain());
+
+    expect(enabledOf(features.resolve())).toEqual({
+      a: true,
+      b: true,
+      c: true,
+      d: true,
+      e: true,
+    });
+
+    features.toggle('a', false);
+
+    // The 2022 sketch's bug stops here: with the parent's *stored* value read
+    // instead of its resolved one, b goes off and c, d, e stay on.
+    expect(enabledOf(features.resolve())).toEqual({
+      a: false,
+      b: false,
+      c: false,
+      d: false,
+      e: false,
+    });
+  });
+
+  it('names the immediate parent and the root cause at every depth', () => {
+    const features = createFeatures(chain());
+    features.toggle('a', false);
+
+    const decisions = features.resolve();
+
+    expect(decisions.e).toMatchObject({
+      enabled: false,
+      reason: 'dependency-off',
+      blockedBy: 'd',
+      cause: { key: 'a', reason: 'explicitly-off' },
+    });
+    expect(decisions.c).toMatchObject({
+      blockedBy: 'b',
+      cause: { key: 'a', reason: 'explicitly-off' },
+    });
+  });
+
+  it('carries the rule through the root cause when a parent is off by a rule', () => {
+    const features = createFeatures([
+      {
+        key: 'payments-v3',
+        enabled: true,
+        rules: [
+          {
+            id: 'window-q4',
+            when: [{ field: 'now', op: 'after', value: WINDOW }],
+          },
+        ],
+      },
+      { key: 'checkout-v2', enabled: true, dependsOn: ['payments-v3'] },
+      { key: 'checkout-express', enabled: true, dependsOn: ['checkout-v2'] },
+    ]);
+
+    const decisions = features.resolve({
+      now: new Date('2026-09-01T00:00:00Z'),
+    });
+
+    expect(decisions['checkout-express']).toMatchObject({
+      enabled: false,
+      reason: 'dependency-off',
+      blockedBy: 'checkout-v2',
+      cause: {
+        key: 'payments-v3',
+        reason: 'no-rule-matched',
+        rule: 'window-q4',
+      },
+    });
+  });
+
+  it('does not run a dependant rules once a parent is off', () => {
+    const features = createFeatures([
+      { key: 'parent', enabled: false },
+      {
+        key: 'child',
+        enabled: true,
+        dependsOn: ['parent'],
+        rules: [{ id: 'always', when: [] }],
+      },
+    ]);
+
+    const decision = features.resolve().child;
+
+    expect(decision.reason).toBe('dependency-off');
+    expect(decision.rules).toBeUndefined();
+  });
+
+  it('cascades from a parent inside a rollout, so the rollout does not leak', () => {
+    const features = createFeatures([
+      {
+        key: 'payments-v3',
+        enabled: true,
+        rules: [{ id: 'ramp', rollout: { percent: 25 } }],
+      },
+      { key: 'checkout-v2', enabled: true, dependsOn: ['payments-v3'] },
+    ]);
+
+    const users = Array.from({ length: 1000 }, (_, i) => `user-${i}`);
+    const parentOn = users.filter((targetingKey) =>
+      features.isEnabled('payments-v3', { targetingKey }),
+    );
+    const childOn = users.filter((targetingKey) =>
+      features.isEnabled('checkout-v2', { targetingKey }),
+    );
+
+    expect(childOn).toEqual(parentOn);
+    expect(parentOn.length).toBeGreaterThan(0);
+    expect(parentOn.length).toBeLessThan(users.length);
+  });
+
+  it('blocks downwards only: a dependant being off leaves its parent on', () => {
+    const features = createFeatures([
+      { key: 'parent', enabled: true },
+      { key: 'child', enabled: false, dependsOn: ['parent'] },
+    ]);
+
+    expect(features.resolve().parent.enabled).toBe(true);
+  });
+});
+
+describe('the store holds intent', () => {
+  it('leaves the config byte-identical across a resolve that cascades', () => {
+    const definitions = chain();
+    definitions[0] = { key: 'a', enabled: false };
+    const before = JSON.stringify(definitions);
+
+    const features = createFeatures(definitions);
+    const decisions = features.resolve();
+
+    expect(decisions.e.reason).toBe('dependency-off');
+    expect(JSON.stringify(definitions)).toBe(before);
+    expect(JSON.stringify(features.config)).toBe(before);
+  });
+
+  it('restores a dependant when a window reopens, with no write in between', () => {
+    const definitions: FeatureDefinition<'parent' | 'child'>[] = [
+      {
+        key: 'parent',
+        enabled: true,
+        rules: [
+          {
+            id: 'window',
+            when: [
+              { field: 'now', op: 'after', value: '2026-10-01T00:00:00Z' },
+              { field: 'now', op: 'before', value: '2026-11-01T00:00:00Z' },
+            ],
+          },
+        ],
+      },
+      { key: 'child', enabled: true, dependsOn: ['parent'] },
+    ];
+    const features = createFeatures(definitions);
+    const snapshot = JSON.stringify(definitions);
+    const childAt = (iso: string) =>
+      features.resolve({ now: new Date(iso) }).child.enabled;
+
+    expect(childAt('2026-10-15T00:00:00Z')).toBe(true);
+    expect(childAt('2026-11-15T00:00:00Z')).toBe(false);
+    // Same config, later clock, and the window is open again.
+    expect(childAt('2026-10-15T00:00:00Z')).toBe(true);
+
+    expect(JSON.stringify(definitions)).toBe(snapshot);
+    expect(JSON.stringify(features.config)).toBe(snapshot);
+    // `enabled` meant "the maintainer wants this on" throughout, and that did
+    // not change when the window closed.
+    expect(features.definition('child')?.enabled).toBe(true);
+  });
+
+  it('refuses to mutate the stored definitions in place', () => {
+    const features = createFeatures([{ key: 'a', enabled: true }]);
+    const stored = features.definition('a') as FeatureDefinition;
+
+    expect(Object.isFrozen(stored)).toBe(true);
+    expect(() => {
+      (stored as { enabled: boolean }).enabled = false;
+    }).toThrow(TypeError);
+  });
+});
+
+describe('toggle', () => {
+  it('reports the transitive dependants that will go off with a parent', () => {
+    const features = createFeatures(chain());
+
+    const result = features.toggle('a', false);
+
+    expect(result).toEqual({
+      ok: true,
+      key: 'a',
+      enabled: false,
+      willDisable: ['b', 'c', 'd', 'e'],
+    });
+  });
+
+  it('omits a dependant that is already off for its own reason', () => {
+    const features = createFeatures([
+      { key: 'parent', enabled: true },
+      { key: 'live', enabled: true, dependsOn: ['parent'] },
+      { key: 'already-off', enabled: false, dependsOn: ['parent'] },
+    ]);
+
+    expect(features.toggle('parent', false)).toMatchObject({
+      willDisable: ['live'],
+    });
+  });
+
+  it('reports nothing to disable when enabling', () => {
+    const features = createFeatures([
+      { key: 'parent', enabled: false },
+      { key: 'child', enabled: true, dependsOn: ['parent'] },
+    ]);
+
+    expect(features.toggle('parent', true)).toMatchObject({ willDisable: [] });
+    expect(features.resolve().child.enabled).toBe(true);
+  });
+
+  it('returns a structured failure for an unknown feature rather than throwing', () => {
+    const features = createFeatures([{ key: 'a', enabled: true }]);
+
+    expect(features.toggle('nope' as 'a', false)).toEqual({
+      ok: false,
+      key: 'nope',
+      error: 'unknown-feature',
+    });
+  });
+
+  it('replaces the definition instead of mutating it', () => {
+    const definitions: FeatureDefinition[] = [{ key: 'a', enabled: true }];
+    const features = createFeatures(definitions);
+
+    features.toggle('a', false);
+
+    expect(definitions[0]?.enabled).toBe(true);
+    expect(features.definition('a')?.enabled).toBe(false);
+  });
+});
+
+describe('plan', () => {
+  it('resolves a context-free feature and defers one needing context', () => {
+    const features = createFeatures([
+      { key: 'plain', enabled: true },
+      {
+        key: 'targeted',
+        enabled: true,
+        rules: [{ rollout: { percent: 25, by: 'targetingKey' } }],
+      },
+    ]);
+
+    const plan = features.plan();
+
+    expect(plan.plain).toMatchObject({ resolved: true, needs: [] });
+    expect(plan.targeted).toMatchObject({
+      resolved: 'deferred',
+      needs: ['targetingKey'],
+    });
+  });
+
+  it('defers exactly the rules needing context and no others', () => {
+    const features = createFeatures([
+      {
+        key: 'mixed',
+        enabled: true,
+        rules: [
+          { id: 'region', when: [{ field: 'region', op: 'eq', value: 'eu' }] },
+          { id: 'plan', when: [{ field: 'plan', op: 'eq', value: 'pro' }] },
+        ],
+      },
+    ]);
+
+    expect(features.plan({ region: 'us' }).mixed).toMatchObject({
+      // `region` was supplied and did not match; `plan` was not supplied, so it
+      // is the only thing still outstanding.
+      resolved: 'deferred',
+      needs: ['plan'],
+    });
+  });
+
+  it('stops deferring once a context-free rule matches', () => {
+    const features = createFeatures([
+      {
+        key: 'mixed',
+        enabled: true,
+        rules: [
+          { id: 'region', when: [{ field: 'region', op: 'eq', value: 'eu' }] },
+          { id: 'targeted', rollout: { percent: 25 } },
+        ],
+      },
+    ]);
+
+    expect(features.plan({ region: 'eu' }).mixed).toMatchObject({
+      resolved: true,
+      needs: [],
+    });
+  });
+
+  it('defers a time window unless the feature opts into freezing it', () => {
+    const definitions = (freezeTimeAtBuild: boolean): FeatureDefinition[] => [
+      {
+        key: 'windowed',
+        enabled: true,
+        freezeTimeAtBuild,
+        rules: [
+          { id: 'window', when: [{ field: 'now', op: 'after', value: WINDOW }] },
+        ],
+      },
+    ];
+    const now = new Date('2026-10-15T00:00:00Z');
+
+    expect(createFeatures(definitions(false)).plan({ now }).windowed).toMatchObject({
+      resolved: 'deferred',
+      needs: ['now'],
+    });
+    expect(createFeatures(definitions(true)).plan({ now }).windowed).toMatchObject({
+      resolved: true,
+    });
+  });
+
+  it('resolves a feature off at build time without deferring it', () => {
+    const features = createFeatures([
+      { key: 'off', enabled: false, rules: [{ rollout: { percent: 50 } }] },
+    ]);
+
+    expect(features.plan().off).toMatchObject({ resolved: false, needs: [] });
+  });
+
+  it('defers a dependant whose parent is deferred, carrying its needs', () => {
+    const features = createFeatures([
+      {
+        key: 'parent',
+        enabled: true,
+        rules: [{ rollout: { percent: 25, by: 'accountId' } }],
+      },
+      { key: 'child', enabled: true, dependsOn: ['parent'] },
+    ]);
+
+    expect(features.plan().child).toMatchObject({
+      resolved: 'deferred',
+      needs: ['accountId'],
+    });
+  });
+
+  it('resolves a dependant off at build time when its parent is off', () => {
+    const features = createFeatures([
+      { key: 'parent', enabled: false },
+      {
+        key: 'child',
+        enabled: true,
+        dependsOn: ['parent'],
+        rules: [{ rollout: { percent: 25 } }],
+      },
+    ]);
+
+    expect(features.plan().child).toMatchObject({
+      resolved: false,
+      needs: [],
+    });
+  });
+});

--- a/libs/feature/src/lib/features.ts
+++ b/libs/feature/src/lib/features.ts
@@ -1,0 +1,170 @@
+import { decide, planFeature } from './evaluate.js';
+import { buildGraph } from './graph.js';
+import type {
+  Decision,
+  Decisions,
+  EvaluationContext,
+  FeatureDefinition,
+  FeatureKey,
+  Plan,
+  PlanEntry,
+  ToggleResult,
+} from './types.js';
+
+/**
+ * The store. It holds intent -- `enabled`, dependencies and rules -- and nothing
+ * evaluated.
+ *
+ * The only writers are `toggle` and editing the configuration. `resolve` and
+ * `plan` are pure functions of `(config, context, now)`. Writing a resolved
+ * value back would put entries in an audit log that nobody performed, make the
+ * store disagree between a process that slept through a window boundary and one
+ * that did not, and destroy the distinction between "someone turned this off"
+ * and "the system turned it off" -- the one an operator needs at 3am.
+ */
+export interface Features<F extends FeatureKey = string> {
+  /** Every key, in the order the definitions were supplied. */
+  readonly keys: readonly F[];
+  /** The stored intent, deeply frozen, in the order it was supplied. */
+  readonly config: readonly FeatureDefinition<F>[];
+  definition(key: F): FeatureDefinition<F> | undefined;
+  /** Transitive dependants of `key`, in dependency order. */
+  dependants(key: F): readonly F[];
+  /** Resolves every feature for one context. Writes nothing. */
+  resolve(context?: EvaluationContext): Decisions<F>;
+  isEnabled(key: F, context?: EvaluationContext): boolean;
+  /**
+   * Partitions every feature into resolvable now and deferred, for build-time
+   * evaluation. One engine, not a second code path: the resolvable cases go
+   * through the same `decide` as `resolve`.
+   */
+  plan(context?: EvaluationContext): Plan<F>;
+  /**
+   * Writes intent, and reports which dependants go off with it.
+   *
+   * Dependencies cascade one way only, so there is no upward blocking -- but the
+   * information that blocking existed to provide is kept: a UI can confirm
+   * before applying, a script can ignore it.
+   */
+  toggle(key: F, enabled: boolean, context?: EvaluationContext): ToggleResult<F>;
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value === null || typeof value !== 'object') return value;
+  if (value instanceof Date) return Object.freeze(value);
+  for (const nested of Object.values(value)) deepFreeze(nested);
+  return Object.freeze(value);
+}
+
+/**
+ * Creates a feature store from its configuration.
+ *
+ * Validates the dependency graph here rather than at evaluation: a cycle, a
+ * dependency on a feature that does not exist and a duplicate key are all
+ * configuration errors, and a cycle has no defined resolution order at all.
+ * Checking at use is the mistake `@evanion/luhn` made with its alphabet.
+ */
+export function createFeatures<F extends FeatureKey>(
+  definitions: readonly FeatureDefinition<F>[],
+): Features<F> {
+  // Cloned so the store cannot be edited behind its own back, then frozen so an
+  // attempt to do so fails loudly instead of silently diverging from what was
+  // resolved.
+  const config: FeatureDefinition<F>[] = definitions.map((definition) =>
+    deepFreeze(structuredClone(definition)),
+  );
+  const graph = buildGraph(config);
+  const index = new Map<F, number>(config.map((d, i) => [d.key, i]));
+  const keys = config.map((definition) => definition.key);
+
+  const definitionOf = (key: F): FeatureDefinition<F> | undefined => {
+    const at = index.get(key);
+    return at === undefined ? undefined : config[at];
+  };
+
+  const withNow = (context: EvaluationContext = {}): EvaluationContext => ({
+    ...context,
+    now: context.now ?? new Date(),
+  });
+
+  const resolve = (context?: EvaluationContext): Decisions<F> => {
+    const evaluationContext = withNow(context);
+    const resolved = new Map<F, Decision<F>>();
+
+    // Dependency order, so a parent's *resolved* value exists before any
+    // dependant reads it. This is what makes the cascade transitive through a
+    // chain of any depth.
+    for (const key of graph.order) {
+      const definition = definitionOf(key);
+      if (!definition) continue;
+      resolved.set(key, decide(definition, evaluationContext, resolved));
+    }
+
+    // Record<F, ...> cannot be built incrementally without a cast; the keys are
+    // exactly `keys`, which are F by construction.
+    return Object.fromEntries(resolved) as Decisions<F>;
+  };
+
+  const plan = (context?: EvaluationContext): Plan<F> => {
+    const evaluationContext = withNow(context);
+    const plans = new Map<F, PlanEntry<F>>();
+    const resolved = new Map<F, Decision<F>>();
+
+    for (const key of graph.order) {
+      const definition = definitionOf(key);
+      if (!definition) continue;
+      const entry = planFeature(
+        definition,
+        evaluationContext,
+        plans,
+        resolved,
+      );
+      plans.set(key, entry);
+      if (entry.decision) resolved.set(key, entry.decision);
+    }
+
+    return Object.fromEntries(plans) as Plan<F>;
+  };
+
+  const toggle = (
+    key: F,
+    enabled: boolean,
+    context?: EvaluationContext,
+  ): ToggleResult<F> => {
+    const at = index.get(key);
+    const current = at === undefined ? undefined : config[at];
+    if (at === undefined || !current) {
+      return { ok: false, key, error: 'unknown-feature' };
+    }
+
+    // One context for both sides of the comparison, so `willDisable` is not an
+    // artefact of the clock moving between the two evaluations.
+    const evaluationContext = withNow(context);
+    const before = resolve(evaluationContext);
+
+    config[at] = deepFreeze({ ...current, enabled });
+
+    const after = resolve(evaluationContext);
+    const willDisable = graph
+      .dependants(key)
+      .filter(
+        (dependant) =>
+          before[dependant].enabled && !after[dependant].enabled,
+      );
+
+    return { ok: true, key, enabled, willDisable };
+  };
+
+  return {
+    keys,
+    get config() {
+      return config as readonly FeatureDefinition<F>[];
+    },
+    definition: definitionOf,
+    dependants: graph.dependants,
+    resolve,
+    isEnabled: (key, context) => resolve(context)[key]?.enabled ?? false,
+    plan,
+    toggle,
+  };
+}

--- a/libs/feature/src/lib/graph.spec.ts
+++ b/libs/feature/src/lib/graph.spec.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { FeatureCycleError, UnknownDependencyError } from './errors.js';
+import { buildGraph } from './graph.js';
+
+const def = (key: string, dependsOn: string[] = []) => ({
+  key,
+  enabled: true,
+  dependsOn,
+});
+
+describe('buildGraph', () => {
+  it('orders every feature after the features it depends on', () => {
+    const { order } = buildGraph([def('c', ['b']), def('a'), def('b', ['a'])]);
+
+    expect(order).toEqual(['a', 'b', 'c']);
+  });
+
+  it('orders a diamond so both parents precede the child', () => {
+    const { order } = buildGraph([
+      def('child', ['left', 'right']),
+      def('left', ['root']),
+      def('right', ['root']),
+      def('root'),
+    ]);
+
+    expect(order.indexOf('root')).toBeLessThan(order.indexOf('left'));
+    expect(order.indexOf('root')).toBeLessThan(order.indexOf('right'));
+    expect(order.indexOf('left')).toBeLessThan(order.indexOf('child'));
+    expect(order.indexOf('right')).toBeLessThan(order.indexOf('child'));
+  });
+
+  it('rejects a cycle at construction, with the path in the message', () => {
+    let error: unknown;
+    try {
+      buildGraph([def('a', ['c']), def('b', ['a']), def('c', ['b'])]);
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(FeatureCycleError);
+    const cycle = error as FeatureCycleError;
+    // The path is a closed walk: it ends where it starts, so a reader can see
+    // the edge that closes it.
+    expect(cycle.path[0]).toBe(cycle.path[cycle.path.length - 1]);
+    expect(new Set(cycle.path)).toEqual(new Set(['a', 'b', 'c']));
+    for (const key of ['a', 'b', 'c']) {
+      expect(cycle.message).toContain(key);
+    }
+    expect(cycle.message).toContain('->');
+  });
+
+  it('rejects a feature that depends on itself', () => {
+    expect(() => buildGraph([def('a', ['a'])])).toThrow(FeatureCycleError);
+  });
+
+  it('rejects a dependency on a feature that does not exist', () => {
+    expect(() => buildGraph([def('a', ['missing'])])).toThrow(
+      UnknownDependencyError,
+    );
+  });
+
+  it('rejects a duplicate key', () => {
+    expect(() => buildGraph([def('a'), def('a')])).toThrow(/duplicate/i);
+  });
+
+  it('indexes dependants transitively, in dependency order', () => {
+    const { dependants } = buildGraph([
+      def('a'),
+      def('b', ['a']),
+      def('c', ['b']),
+      def('d', ['c']),
+      def('unrelated'),
+    ]);
+
+    expect(dependants('a')).toEqual(['b', 'c', 'd']);
+    expect(dependants('c')).toEqual(['d']);
+    expect(dependants('d')).toEqual([]);
+    expect(dependants('unrelated')).toEqual([]);
+  });
+});

--- a/libs/feature/src/lib/graph.ts
+++ b/libs/feature/src/lib/graph.ts
@@ -1,0 +1,100 @@
+import {
+  DuplicateFeatureError,
+  FeatureCycleError,
+  UnknownDependencyError,
+} from './errors.js';
+import type { FeatureDefinition, FeatureKey } from './types.js';
+
+export interface FeatureGraph<F extends FeatureKey> {
+  /**
+   * Every key, ordered so a feature always follows the features it depends on.
+   *
+   * This ordering is what makes the cascade transitive. The 2022 sketch folded
+   * over the features in declaration order and read each parent's stored
+   * `active` rather than its computed result, so a chain A -> B -> C never
+   * cascaded past one level. Resolving in this order means a parent's result
+   * always exists by the time its dependants are evaluated, for a chain of any
+   * depth.
+   */
+  readonly order: readonly F[];
+  /** Transitive dependants of `key`, in dependency order. */
+  dependants(key: F): readonly F[];
+}
+
+/**
+ * Validates the dependency graph and returns a resolution order.
+ *
+ * Throws on a duplicate key, a dependency on an unconfigured feature, or a
+ * cycle. All three are configuration errors, and all three are rejected here
+ * rather than at evaluation.
+ */
+export function buildGraph<F extends FeatureKey>(
+  definitions: readonly FeatureDefinition<F>[],
+): FeatureGraph<F> {
+  const parents = new Map<F, readonly F[]>();
+
+  for (const definition of definitions) {
+    if (parents.has(definition.key)) {
+      throw new DuplicateFeatureError(definition.key);
+    }
+    parents.set(definition.key, definition.dependsOn ?? []);
+  }
+
+  for (const [key, dependsOn] of parents) {
+    for (const parent of dependsOn) {
+      if (!parents.has(parent)) {
+        throw new UnknownDependencyError(key, parent);
+      }
+    }
+  }
+
+  const order: F[] = [];
+  const finished = new Set<F>();
+  const onPath = new Set<F>();
+  const path: F[] = [];
+
+  const visit = (key: F): void => {
+    if (finished.has(key)) return;
+    if (onPath.has(key)) {
+      // Trim the walk to the cycle itself and close it, so the message shows
+      // the edge that closes the loop rather than the route taken to reach it.
+      const start = path.indexOf(key);
+      throw new FeatureCycleError([...path.slice(start), key]);
+    }
+
+    onPath.add(key);
+    path.push(key);
+    for (const parent of parents.get(key) ?? []) visit(parent);
+    path.pop();
+    onPath.delete(key);
+
+    finished.add(key);
+    order.push(key);
+  };
+
+  for (const key of parents.keys()) visit(key);
+
+  const position = new Map<F, number>(order.map((key, i) => [key, i]));
+  const children = new Map<F, F[]>(order.map((key) => [key, []]));
+  for (const [key, dependsOn] of parents) {
+    for (const parent of dependsOn) children.get(parent)?.push(key);
+  }
+
+  const dependants = (key: F): readonly F[] => {
+    const seen = new Set<F>();
+    const queue = [...(children.get(key) ?? [])];
+
+    while (queue.length) {
+      const next = queue.shift() as F;
+      if (seen.has(next)) continue;
+      seen.add(next);
+      queue.push(...(children.get(next) ?? []));
+    }
+
+    return [...seen].sort(
+      (a, b) => (position.get(a) ?? 0) - (position.get(b) ?? 0),
+    );
+  };
+
+  return { order, dependants };
+}

--- a/libs/feature/src/lib/reason-is-output-only.spec.ts
+++ b/libs/feature/src/lib/reason-is-output-only.spec.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import { decide } from './evaluate.js';
+import { createFeatures } from './features.js';
+import { buildGraph } from './graph.js';
+import type { Decision, EvaluationContext, FeatureDefinition } from './types.js';
+
+/**
+ * The spec's invariant: `reason` is output only. The cascade reads `enabled`
+ * from a parent's result and nothing else, so deleting the reason field must
+ * change no decision anywhere.
+ *
+ * Asserting that the engine "does not branch on reason" by reading the source is
+ * not a test. This runs the real per-feature decision function over the real
+ * dependency order, with every explanation field deleted from each parent result
+ * before the next feature sees it, and requires the decisions to come out
+ * identical. Anything that consulted `reason`, `rule`, `rules`, `blockedBy` or
+ * `cause` to decide `enabled` would diverge here -- a comparison against a
+ * deleted field is false, so a cascade keyed on `reason === 'explicitly-off'`
+ * would stop cascading and this would fail.
+ */
+
+/** A parent result with every explanation field removed. */
+function stripExplanation(decision: Decision): Decision {
+  return { key: decision.key, enabled: decision.enabled } as Decision;
+}
+
+/** The engine's own loop, run with reason-blind parent results. */
+function resolveReasonBlind(
+  definitions: readonly FeatureDefinition[],
+  context: EvaluationContext = {},
+): Record<string, boolean> {
+  const graph = buildGraph(definitions);
+  const byKey = new Map(definitions.map((d) => [d.key, d]));
+  const resolved = new Map<string, Decision>();
+  const enabled: Record<string, boolean> = {};
+
+  for (const key of graph.order) {
+    const decision = decide(
+      byKey.get(key) as FeatureDefinition,
+      { now: new Date('2026-09-01T00:00:00Z'), ...context },
+      resolved,
+    );
+    enabled[key] = decision.enabled;
+    resolved.set(key, stripExplanation(decision));
+  }
+
+  return enabled;
+}
+
+function enabledOf(definitions: readonly FeatureDefinition[], context: EvaluationContext = {}) {
+  const decisions = createFeatures(definitions).resolve({
+    now: new Date('2026-09-01T00:00:00Z'),
+    ...context,
+  });
+
+  return Object.fromEntries(
+    Object.entries(decisions).map(([key, decision]) => [key, decision.enabled]),
+  );
+}
+
+const CONFIGS: Record<string, readonly FeatureDefinition[]> = {
+  'chain off at the root': [
+    { key: 'a', enabled: false },
+    { key: 'b', enabled: true, dependsOn: ['a'] },
+    { key: 'c', enabled: true, dependsOn: ['b'] },
+    { key: 'd', enabled: true, dependsOn: ['c'] },
+    { key: 'e', enabled: true, dependsOn: ['d'] },
+  ],
+  'chain off by an unmatched rule': [
+    {
+      key: 'a',
+      enabled: true,
+      rules: [
+        {
+          id: 'window',
+          when: [{ field: 'now', op: 'after', value: '2026-10-01T00:00:00Z' }],
+        },
+      ],
+    },
+    { key: 'b', enabled: true, dependsOn: ['a'] },
+    { key: 'c', enabled: true, dependsOn: ['b'] },
+    { key: 'd', enabled: true, dependsOn: ['c'] },
+  ],
+  'chain off by a rollout': [
+    { key: 'a', enabled: true, rules: [{ rollout: { percent: 0 } }] },
+    { key: 'b', enabled: true, dependsOn: ['a'] },
+    { key: 'c', enabled: true, dependsOn: ['b'] },
+  ],
+  'diamond with one arm off': [
+    { key: 'root', enabled: true },
+    { key: 'left', enabled: false, dependsOn: ['root'] },
+    { key: 'right', enabled: true, dependsOn: ['root'] },
+    { key: 'child', enabled: true, dependsOn: ['left', 'right'] },
+    { key: 'grandchild', enabled: true, dependsOn: ['child'] },
+  ],
+  'everything on': [
+    { key: 'a', enabled: true },
+    { key: 'b', enabled: true, dependsOn: ['a'] },
+    { key: 'c', enabled: true, dependsOn: ['a', 'b'] },
+  ],
+};
+
+describe('reason is output only', () => {
+  for (const [name, definitions] of Object.entries(CONFIGS)) {
+    it(`decides identically with every reason deleted: ${name}`, () => {
+      expect(resolveReasonBlind(definitions)).toEqual(enabledOf(definitions));
+    });
+  }
+
+  it('treats every kind of parent "off" the same way', () => {
+    // explicitly-off, no-rule-matched and dependency-off are three different
+    // reasons and must make no difference to the dependant's decision.
+    type Key = 'child' | 'parent' | 'grandparent';
+    const child = (parents: readonly FeatureDefinition<Key>[]) =>
+      createFeatures<Key>([
+        ...parents,
+        { key: 'child', enabled: true, dependsOn: ['parent'] },
+      ]).resolve({ now: new Date('2026-09-01T00:00:00Z') }).child;
+
+    const byExplicit = child([{ key: 'parent', enabled: false }]);
+    const byRule = child([
+      {
+        key: 'parent',
+        enabled: true,
+        rules: [
+          {
+            id: 'window',
+            when: [{ field: 'now', op: 'after', value: '2026-10-01T00:00:00Z' }],
+          },
+        ],
+      },
+    ]);
+    const byCascade = child([
+      { key: 'grandparent', enabled: false },
+      { key: 'parent', enabled: true, dependsOn: ['grandparent'] },
+    ]);
+
+    for (const decision of [byExplicit, byRule, byCascade]) {
+      expect(decision.enabled).toBe(false);
+      expect(decision.reason).toBe('dependency-off');
+      expect(decision.blockedBy).toBe('parent');
+    }
+    // The only difference between the three is the root cause, which is
+    // explanation.
+    expect(byExplicit.cause?.key).toBe('parent');
+    expect(byRule.cause?.rule).toBe('window');
+    expect(byCascade.cause?.key).toBe('grandparent');
+  });
+});

--- a/libs/feature/src/lib/types.ts
+++ b/libs/feature/src/lib/types.ts
@@ -1,0 +1,200 @@
+/**
+ * A feature identifier. Carried over from the 2022 sketch, which parameterised
+ * on `Feature extends string | number` so a consumer can use a string union or
+ * a numeric enum and keep exhaustiveness.
+ */
+export type FeatureKey = string | number;
+
+/** Weekday names, in the IANA zone a day-of-week condition names. */
+export type Weekday = 'sun' | 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat';
+
+/**
+ * A point in time a window condition compares against. A string is parsed as
+ * ISO 8601, a number as epoch milliseconds.
+ */
+export type Instant = string | number | Date;
+
+/** `now` is before / after a fixed instant. */
+export interface WindowCondition {
+  field: 'now';
+  op: 'before' | 'after';
+  value: Instant;
+}
+
+/**
+ * `now` falls on one of these weekdays, in an explicit IANA zone.
+ *
+ * The zone is required, not defaulted: UTC day-of-week is wrong for every
+ * business rule anyone writes.
+ */
+export interface DayOfWeekCondition {
+  field: 'now';
+  op: 'day-of-week';
+  zone: string;
+  value: readonly Weekday[];
+}
+
+/** A context attribute compared against a literal. */
+export interface AttributeCondition {
+  field: string;
+  op: 'eq' | 'ne' | 'in' | 'not-in' | 'contains';
+  value: unknown;
+}
+
+export type Condition =
+  | WindowCondition
+  | DayOfWeekCondition
+  | AttributeCondition;
+
+/**
+ * A percentage rollout.
+ *
+ * `by` names the context field to bucket on, defaulting to `targetingKey`.
+ * `seed` overrides the bucketing seed, which otherwise is the feature key --
+ * the defaulting that decorrelates a user's bucket across features. Override it
+ * only to deliberately correlate two features, e.g. to keep a pair of flags
+ * rolling out to the same cohort.
+ */
+export interface RolloutSpec {
+  percent: number;
+  by?: string;
+  seed?: string;
+}
+
+/**
+ * One activation rule. Matches when every `when` condition holds AND, if a
+ * `rollout` is present, the bucketed value falls inside it.
+ */
+export interface Rule {
+  /** Used in `reason`. Defaults to the rule's index, as `#0`, `#1`, ... */
+  id?: string;
+  when?: readonly Condition[];
+  rollout?: RolloutSpec;
+}
+
+/**
+ * Stored intent for one feature. This is configuration: evaluation never writes
+ * to it.
+ */
+export interface FeatureDefinition<F extends FeatureKey = string> {
+  key: F;
+  /**
+   * The maintainer wants this on. `false` short-circuits -- rules never run.
+   * `true` hands the decision to the rules, and no rules means on.
+   *
+   * It is a kill switch in one direction only: turning it on for a feature
+   * whose rules do not match changes intent and the feature still resolves off.
+   */
+  enabled: boolean;
+  /**
+   * Features that must resolve on for this one to resolve on. Cascades
+   * transitively and one way only -- a dependant never blocks its parent.
+   */
+  dependsOn?: readonly F[];
+  /** OR-ed. No rules means on (given `enabled`). */
+  rules?: readonly Rule[];
+  /** Bucketing seed for every rollout in this feature. Defaults to the key. */
+  seed?: string;
+  /**
+   * Opt in to resolving `now`-dependent rules during `plan()`, freezing the
+   * window at build time. Off by default: whether a date window may be frozen
+   * into a build is a deploy-cadence decision and belongs to whoever owns the
+   * feature.
+   */
+  freezeTimeAtBuild?: boolean;
+}
+
+/**
+ * Evaluation context. `now` is injected rather than read from an ambient clock,
+ * defaulting to `new Date()` at the call.
+ */
+export interface EvaluationContext {
+  now?: Date;
+  /** The default rollout bucketing field. */
+  targetingKey?: string;
+  [field: string]: unknown;
+}
+
+export type Reason =
+  /** Enabled, no rules. */
+  | 'default-on'
+  /** Enabled, a rule matched. Carries the rule id. */
+  | 'rule-match'
+  /** `enabled === false`. */
+  | 'explicitly-off'
+  /** Enabled, rules present, none passed. Carries the per-rule breakdown. */
+  | 'no-rule-matched'
+  /** A parent resolved off. Carries the blocking edge and the root cause. */
+  | 'dependency-off';
+
+/** Why one rule did not match. */
+export interface RuleOutcome {
+  rule: string;
+  matched: boolean;
+  /** The first condition that failed, so a UI can name it. */
+  failed?: Condition;
+  /** Present when the rule's rollout was the reason it did not match. */
+  rollout?: {
+    percent: number;
+    by: string;
+    /** Absent when the context did not carry the bucketing field. */
+    bucket?: number;
+    member: boolean;
+  };
+}
+
+/** The root cause of a cascade: the first ancestor off for a non-dependency reason. */
+export interface Cause<F extends FeatureKey = string> {
+  key: F;
+  reason: Reason;
+  rule?: string;
+}
+
+/**
+ * One feature's decision.
+ *
+ * `enabled` is the decision. Everything else is explanation, and is output
+ * only -- nothing in this library reads `reason`, `rule`, `rules`, `blockedBy`
+ * or `cause` back to decide anything.
+ */
+export interface Decision<F extends FeatureKey = string> {
+  key: F;
+  enabled: boolean;
+  reason: Reason;
+  /** The matching rule, on `rule-match`. */
+  rule?: string;
+  /** Per-rule breakdown, on `no-rule-matched`. */
+  rules?: readonly RuleOutcome[];
+  /** The immediate parent that blocked this, on `dependency-off`. */
+  blockedBy?: F;
+  /** The first ancestor off for its own reason, on `dependency-off`. */
+  cause?: Cause<F>;
+}
+
+export type Decisions<F extends FeatureKey = string> = Record<F, Decision<F>>;
+
+/** One feature's build-time plan. */
+export interface PlanEntry<F extends FeatureKey = string> {
+  key: F;
+  /** `'deferred'` when some rule still needs context this plan did not have. */
+  resolved: boolean | 'deferred';
+  /** Context fields still needed, sorted. Empty unless `resolved` is deferred. */
+  needs: readonly string[];
+  /** Present when `resolved` is a boolean: the decision, with its reason. */
+  decision?: Decision<F>;
+}
+
+export type Plan<F extends FeatureKey = string> = Record<F, PlanEntry<F>>;
+
+export type ToggleResult<F extends FeatureKey = string> =
+  | {
+      ok: true;
+      key: F;
+      enabled: boolean;
+      /**
+       * Dependants that resolve on now and will not after this toggle is
+       * applied -- transitive, in dependency order. Empty when enabling.
+       */
+      willDisable: readonly F[];
+    }
+  | { ok: false; key: F; error: 'unknown-feature' };

--- a/libs/feature/src/react/index.tsx
+++ b/libs/feature/src/react/index.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+/**
+ * The React adapter: a provider and three hooks over an already-built store.
+ *
+ * This is its own entry (`@evanion/feature/react`) and its own module for one
+ * reason: `'use client'` is a per-module directive, and a bundle is one module.
+ * `@evanion/react-widget` hit the same constraint from the other side -- its
+ * answer was to have no client code at all, while this layer genuinely is client
+ * code -- so the package is emitted file-per-file by `tsc` and the core entry
+ * stays free of both the directive and any React import.
+ *
+ * Evaluation itself lives in the core. Nothing here decides anything.
+ */
+
+import { createContext, useContext, useMemo } from 'react';
+import type { ReactNode } from 'react';
+import type { Features } from '../lib/features.js';
+import type {
+  Decision,
+  Decisions,
+  EvaluationContext,
+  FeatureKey,
+} from '../lib/types.js';
+
+interface FeatureContextValue {
+  decisions: Decisions<FeatureKey>;
+}
+
+const FeatureContext = createContext<FeatureContextValue | null>(null);
+
+export interface FeatureProviderProps<F extends FeatureKey> {
+  features: Features<F>;
+  /**
+   * The evaluation context. Resolution is memoised on this object's identity, so
+   * pass a stable reference -- an object literal written inline re-resolves on
+   * every render.
+   *
+   * Leaving `now` out means "the clock at the moment this context was first
+   * resolved". A component tree that must agree with a server render should pass
+   * `now` explicitly.
+   */
+  context?: EvaluationContext;
+  /**
+   * Decisions resolved elsewhere -- a server render, or the build-time snapshot
+   * from `plan()`. Supplied decisions are used as they are; `features` and
+   * `context` are then only a fallback for what the snapshot does not cover.
+   */
+  decisions?: Decisions<F>;
+  children?: ReactNode;
+}
+
+export function FeatureProvider<F extends FeatureKey>({
+  features,
+  context,
+  decisions,
+  children,
+}: FeatureProviderProps<F>) {
+  const value = useMemo<FeatureContextValue>(
+    () => ({
+      decisions: (decisions ??
+        features.resolve(context)) as Decisions<FeatureKey>,
+    }),
+    [features, context, decisions],
+  );
+
+  return (
+    <FeatureContext.Provider value={value}>{children}</FeatureContext.Provider>
+  );
+}
+
+/** Every resolved decision. */
+export function useFeatures<F extends FeatureKey = string>(): Decisions<F> {
+  const value = useContext(FeatureContext);
+  if (!value) {
+    throw new Error(
+      'useFeatures must be called inside a <FeatureProvider> (from @evanion/feature/react)',
+    );
+  }
+  return value.decisions as Decisions<F>;
+}
+
+/**
+ * One feature's decision, explanation included.
+ *
+ * Throws for a key that is not configured. A silent `false` would make a typo
+ * indistinguishable from a feature that is off, which is the failure mode flag
+ * systems are worst at.
+ */
+export function useFeature<F extends FeatureKey = string>(
+  key: F,
+): Decision<F> {
+  const decisions = useFeatures<F>();
+  const decision = decisions[key];
+  if (!decision) {
+    throw new Error(
+      `feature "${String(key)}" is not configured in this <FeatureProvider>`,
+    );
+  }
+  return decision;
+}
+
+/** One feature's decision as a boolean. */
+export function useFeatureEnabled<F extends FeatureKey = string>(
+  key: F,
+): boolean {
+  return useFeature<F>(key).enabled;
+}

--- a/libs/feature/src/react/react.spec.tsx
+++ b/libs/feature/src/react/react.spec.tsx
@@ -1,0 +1,181 @@
+import { render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, expect, it } from 'vitest';
+import { createFeatures } from '../lib/features.js';
+import type { Decisions, FeatureDefinition } from '../lib/types.js';
+import {
+  FeatureProvider,
+  useFeature,
+  useFeatureEnabled,
+  useFeatures,
+} from './index.js';
+
+type Key = 'payments-v3' | 'checkout-v2' | 'checkout-express';
+
+const definitions: FeatureDefinition<Key>[] = [
+  {
+    key: 'payments-v3',
+    enabled: true,
+    rules: [
+      {
+        id: 'window-q4',
+        when: [{ field: 'now', op: 'after', value: '2026-10-01T00:00:00Z' }],
+      },
+    ],
+  },
+  { key: 'checkout-v2', enabled: true, dependsOn: ['payments-v3'] },
+  { key: 'checkout-express', enabled: true, dependsOn: ['checkout-v2'] },
+];
+
+const inWindow = { now: new Date('2026-10-15T00:00:00Z') };
+const outsideWindow = { now: new Date('2026-09-01T00:00:00Z') };
+
+function Flag({ name }: { name: Key }) {
+  const decision = useFeature<Key>(name);
+  return (
+    <span data-testid={name}>
+      {decision.enabled ? 'on' : `off:${decision.reason}`}
+    </span>
+  );
+}
+
+describe('FeatureProvider', () => {
+  it('exposes the resolved decision for every feature', () => {
+    render(
+      <FeatureProvider features={createFeatures(definitions)} context={inWindow}>
+        <Flag name="payments-v3" />
+        <Flag name="checkout-express" />
+      </FeatureProvider>,
+    );
+
+    expect(screen.getByTestId('payments-v3')).toHaveTextContent('on');
+    expect(screen.getByTestId('checkout-express')).toHaveTextContent('on');
+  });
+
+  it('cascades through the provider, explanation included', () => {
+    render(
+      <FeatureProvider
+        features={createFeatures(definitions)}
+        context={outsideWindow}
+      >
+        <Flag name="checkout-express" />
+      </FeatureProvider>,
+    );
+
+    expect(screen.getByTestId('checkout-express')).toHaveTextContent(
+      'off:dependency-off',
+    );
+  });
+
+  it('resolves once per context rather than on every render', () => {
+    const features = createFeatures(definitions);
+    let resolves = 0;
+    const counted = {
+      ...features,
+      resolve: (context?: Parameters<typeof features.resolve>[0]) => {
+        resolves++;
+        return features.resolve(context);
+      },
+    };
+
+    function Rerender() {
+      const [count, setCount] = useState(0);
+      return (
+        <FeatureProvider features={counted} context={inWindow}>
+          <button onClick={() => setCount(count + 1)}>render {count}</button>
+          <Flag name="checkout-v2" />
+        </FeatureProvider>
+      );
+    }
+
+    const { rerender } = render(<Rerender />);
+    rerender(<Rerender />);
+    rerender(<Rerender />);
+
+    expect(resolves).toBe(1);
+  });
+
+  it('accepts decisions resolved elsewhere, such as a build snapshot', () => {
+    const snapshot: Decisions<Key> = createFeatures(definitions).resolve(
+      inWindow,
+    );
+
+    render(
+      <FeatureProvider
+        features={createFeatures(definitions)}
+        decisions={snapshot}
+        // A context that would resolve everything off, to prove the supplied
+        // decisions are the ones used.
+        context={outsideWindow}
+      >
+        <Flag name="checkout-express" />
+      </FeatureProvider>,
+    );
+
+    expect(screen.getByTestId('checkout-express')).toHaveTextContent('on');
+  });
+});
+
+describe('useFeatureEnabled', () => {
+  it('returns the boolean decision', () => {
+    function Gate() {
+      return <span>{useFeatureEnabled<Key>('checkout-v2') ? 'on' : 'off'}</span>;
+    }
+
+    render(
+      <FeatureProvider features={createFeatures(definitions)} context={inWindow}>
+        <Gate />
+      </FeatureProvider>,
+    );
+
+    expect(screen.getByText('on')).toBeInTheDocument();
+  });
+});
+
+describe('useFeatures', () => {
+  it('returns every decision at once', () => {
+    function All() {
+      const decisions = useFeatures<Key>();
+      return <span>{Object.keys(decisions).sort().join(',')}</span>;
+    }
+
+    render(
+      <FeatureProvider features={createFeatures(definitions)} context={inWindow}>
+        <All />
+      </FeatureProvider>,
+    );
+
+    expect(
+      screen.getByText('checkout-express,checkout-v2,payments-v3'),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('misuse', () => {
+  it('throws outside a provider', () => {
+    function Orphan() {
+      useFeatures();
+      return null;
+    }
+
+    expect(() => render(<Orphan />)).toThrow(/FeatureProvider/);
+  });
+
+  it('throws for a feature that is not configured', () => {
+    function Unknown() {
+      useFeature('nope' as Key);
+      return null;
+    }
+
+    expect(() =>
+      render(
+        <FeatureProvider
+          features={createFeatures(definitions)}
+          context={inWindow}
+        >
+          <Unknown />
+        </FeatureProvider>,
+      ),
+    ).toThrow(/nope/);
+  });
+});

--- a/libs/feature/src/test-setup.ts
+++ b/libs/feature/src/test-setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/libs/feature/tsconfig.json
+++ b/libs/feature/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "ignoreDeprecations": "6.0"
+  }
+}

--- a/libs/feature/tsconfig.lib.json
+++ b/libs/feature/tsconfig.lib.json
@@ -1,0 +1,33 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react-jsx",
+    "types": ["node", "react"],
+    "ignoreDeprecations": "6.0"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "references": [],
+  "exclude": [
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.test-d.ts",
+    "src/**/*.test-d.tsx",
+    "src/test-setup.ts"
+  ]
+}

--- a/libs/feature/tsconfig.spec.json
+++ b/libs/feature/tsconfig.spec.json
@@ -1,0 +1,43 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/vitest",
+    "types": [
+      "vitest/globals",
+      "vitest/importMeta",
+      "vite/client",
+      "node",
+      "react",
+      "@testing-library/jest-dom"
+    ],
+    "jsx": "react-jsx",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "forceConsistentCasingInFileNames": true,
+    "ignoreDeprecations": "6.0",
+    "rootDir": "."
+  },
+  "include": [
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.test-d.ts",
+    "src/**/*.test-d.tsx",
+    "src/test-setup.ts",
+    "src/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/feature/vite.config.ts
+++ b/libs/feature/vite.config.ts
@@ -1,0 +1,46 @@
+/// <reference types='vitest' />
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// No `build` section on purpose. The package is built by `tsc`
+// (tsconfig.lib.json), not bundled: a bundle is one module and cannot carry a
+// per-module `'use client'` directive, which `src/react/index.tsx` needs and
+// `src/index.ts` must not have. File-per-file emit gives each entry its own
+// module and keeps the directive where it belongs.
+export default defineConfig(() => ({
+  root: import.meta.dirname,
+  cacheDir: '../../node_modules/.vite/libs/feature',
+  plugins: [react()],
+  test: {
+    watch: false,
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: './test-output/vitest/coverage',
+      provider: 'v8' as const,
+    },
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: '@evanion/feature',
+          globals: true,
+          environment: 'node',
+          include: ['src/lib/**/*.{test,spec}.ts'],
+        },
+      },
+      // The React adapter is the only part that needs a DOM. Kept as its own
+      // project so the core suite keeps running in `node`, where an accidental
+      // dependency on a browser global fails instead of passing.
+      {
+        extends: true,
+        test: {
+          name: '@evanion/feature:react',
+          globals: true,
+          environment: 'jsdom',
+          setupFiles: ['./src/test-setup.ts'],
+          include: ['src/react/**/*.{test,spec}.tsx'],
+        },
+      },
+    ],
+  },
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -189,6 +189,13 @@
         "react": "^18.0.0 || ^19.0.0"
       }
     },
+    "libs/feature": {
+      "name": "@evanion/feature",
+      "version": "0.0.1",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
     "libs/luhn": {
       "name": "@evanion/luhn",
       "version": "2.0.1",
@@ -3440,6 +3447,10 @@
     },
     "node_modules/@evanion/docs": {
       "resolved": "apps/docs",
+      "link": true
+    },
+    "node_modules/@evanion/feature": {
+      "resolved": "libs/feature",
       "link": true
     },
     "node_modules/@evanion/luhn": {

--- a/scripts/verify-packaging.mjs
+++ b/scripts/verify-packaging.mjs
@@ -33,6 +33,7 @@ const LIBS = [
   ['nest/correlation-id', '@evanion/nestjs-correlation-id'],
   ['libs/astro-widget', '@evanion/astro-widget'],
   ['libs/luhn', '@evanion/luhn'],
+  ['libs/feature', '@evanion/feature'],
 ];
 
 const run = (cmd, args, cwd) =>
@@ -96,6 +97,10 @@ import type { BlockItem, BlockRegistry, BlockProblem } from '@evanion/astro-widg
 // @evanion/luhn exports a ValidationError of its own, unrelated to @evanion/urn's.
 // Aliased here so the collision is explicit rather than a compile error.
 import { Luhn, InvalidDictionaryError, ValidationError as LuhnValidationError } from '@evanion/luhn';
+import { createFeatures, FeatureCycleError } from '@evanion/feature';
+import type { Decision, FeatureDefinition } from '@evanion/feature';
+// Second entry point, and the only one that may touch React.
+import { FeatureProvider, useFeature, useFeatureEnabled, useFeatures } from '@evanion/feature/react';
 
 const parsed: ParsedURN = URN.parse('urn:user:1');
 const arr: ProviderArray = [];
@@ -112,9 +117,17 @@ const sections: BlockItem[] = [{ type: 'hero', heading: 'ok' }];
 const problems: BlockProblem[] = validateBlocks(sections, registry, { hero: ['heading'] });
 const checksum: string = Luhn.generate('foo').checksum;
 const luhnErr: LuhnValidationError = new InvalidDictionaryError('abc');
+const toggleConfig: FeatureDefinition<'payments-v3' | 'checkout-v2'>[] = [
+  { key: 'payments-v3', enabled: true, rules: [{ rollout: { percent: 25 } }] },
+  { key: 'checkout-v2', enabled: true, dependsOn: ['payments-v3'] },
+];
+const toggles = createFeatures(toggleConfig);
+const toggleDecision: Decision<'payments-v3' | 'checkout-v2'> =
+  toggles.resolve({ targetingKey: 'acct-1' })['checkout-v2'];
 void [ComposeProvider, provider, parsed, arr, err, items, widgetProblems, DefaultItem, DefaultWrapper,
       CorrelationModule, CorrelationService, withCorrelation, correlation,
-      registry, sections, problems, checksum, luhnErr];
+      registry, sections, problems, checksum, luhnErr,
+      toggleDecision, FeatureCycleError, FeatureProvider, useFeature, useFeatureEnabled, useFeatures];
 `,
   );
 
@@ -152,10 +165,13 @@ import { ComposeProvider, provider } from '@evanion/compose';
 import { createWidgets, DefaultItem, DefaultWrapper, validateItems } from '@evanion/react-widget';
 import { defineBlocks, validateBlocks } from '@evanion/astro-widget';
 import { Luhn, InvalidDictionaryError } from '@evanion/luhn';
+import { createFeatures } from '@evanion/feature';
+import { FeatureProvider, useFeature } from '@evanion/feature/react';
 const missing = Object.entries({
   URN, InvalidError, ValidationError, ComposeProvider, provider,
   createWidgets, DefaultItem, DefaultWrapper, validateItems,
   defineBlocks, validateBlocks, Luhn, InvalidDictionaryError,
+  createFeatures, FeatureProvider, useFeature,
 }).filter(([, v]) => typeof v !== 'function').map(([k]) => k);
 if (missing.length) { console.error('not exported at runtime:', missing.join(', ')); process.exit(1); }
 `,
@@ -275,6 +291,88 @@ if (missing.length) { console.error('not exported at runtime:', missing.join(', 
     );
   }
   console.log('  ✓ react-widget imports no client-only React API');
+
+  // @evanion/feature ships two entries for a reason that no in-repo check can
+  // see: `'use client'` is a per-module directive, so the client layer needs its
+  // own module in the published output. Both halves of that break silently. A
+  // directive that migrated onto the core entry makes the whole package
+  // client-only, and a React import that leaked into the core makes it
+  // unimportable from the Nest API and from the build-time pass -- and in both
+  // cases the build succeeds and every test passes.
+  //
+  // The core is emitted file-per-file, so checking the entry alone is not
+  // enough: `dist/index.js` only re-exports, and a React import three files deep
+  // would pass. Every core module is checked.
+  const featureDist = join(dir, 'node_modules', '@evanion', 'feature', 'dist');
+  const coreModules = readdirSync(featureDist, {
+    recursive: true,
+    withFileTypes: true,
+  })
+    .filter(
+      (entry) =>
+        entry.isFile() &&
+        entry.name.endsWith('.js') &&
+        !join(entry.parentPath, entry.name).includes(join(featureDist, 'react')),
+    )
+    .map((entry) => join(entry.parentPath, entry.name));
+
+  if (coreModules.length === 0) {
+    throw new Error('@evanion/feature ships no core modules at all');
+  }
+
+  const reactImporters = coreModules.filter((file) =>
+    /(?:from|import)\s*["']react(?:\/[^"']*)?["']/.test(
+      readFileSync(file, 'utf8'),
+    ),
+  );
+  if (reactImporters.length) {
+    throw new Error(
+      '@evanion/feature core entry imports React: ' +
+        reactImporters
+          .map((file) => file.slice(featureDist.length + 1))
+          .join(', ') +
+        ". The core must be usable from the API and at build time, so nothing under it may import react.",
+    );
+  }
+  console.log('  ✓ feature core imports nothing from react');
+
+  const coreFirstLine = readFileSync(join(featureDist, 'index.js'), 'utf8')
+    .split('\n')[0]
+    .trim();
+  if (/^["']use client["'];?$/.test(coreFirstLine)) {
+    throw new Error(
+      "@evanion/feature dist/index.js must NOT carry a 'use client' directive",
+    );
+  }
+
+  const clientFirstLine = readFileSync(
+    join(featureDist, 'react', 'index.js'),
+    'utf8',
+  )
+    .split('\n')[0]
+    .trim();
+  if (!/^["']use client["'];?$/.test(clientFirstLine)) {
+    throw new Error(
+      "@evanion/feature dist/react/index.js must carry a 'use client' " +
+        'directive as its first line; a bundler that collapsed the two entries ' +
+        'into one module would drop it.',
+    );
+  }
+  console.log("  ✓ feature ships 'use client' on the react entry only");
+
+  const featurePkg = JSON.parse(
+    readFileSync(
+      join(dir, 'node_modules', '@evanion', 'feature', 'package.json'),
+      'utf8',
+    ),
+  );
+  const featureEntries = Object.keys(featurePkg.exports);
+  for (const entry of ['.', './react']) {
+    if (!featureEntries.includes(entry)) {
+      throw new Error(`@evanion/feature stopped exporting "${entry}"`);
+    }
+  }
+  console.log('  ✓ feature exports both entries');
 
   console.log('\nPackaging verified.');
 } catch (error) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,9 @@
     },
     {
       "path": "./apps/shop-api"
+    },
+    {
+      "path": "./libs/feature"
     }
   ],
   "compilerOptions": {


### PR DESCRIPTION
Implements `docs/specs/2026-09-11-feature-toggles.md`. New package `@evanion/feature`, at 0.0.1, unpublished.

A rewrite rather than a port of the 2022 gist. What carries over is the idea and the `Feature extends string | number` parameter.

## Public API

Core (`@evanion/feature`, no framework import):

```ts
const features = createFeatures([
  { key: 'payments-v3', enabled: true, rules: [{ id: 'window-q4', when: [...], rollout: { percent: 25 } }] },
  { key: 'checkout-v2', enabled: true, dependsOn: ['payments-v3'] },
]);

features.resolve(context);              // Decision per feature
features.isEnabled('checkout-v2', ctx); // boolean
features.plan(context);                 // { resolved: boolean | 'deferred', needs: string[] }
features.toggle('payments-v3', false);  // { ok, key, enabled, willDisable }
features.config / .definition(key) / .dependants(key) / .keys
```

Decisions carry `enabled` plus explanation: `reason`, `rule`, the per-rule breakdown on `no-rule-matched`, and `blockedBy` + `cause` on `dependency-off`. Errors: `FeatureCycleError`, `UnknownDependencyError`, `DuplicateFeatureError`, all thrown by `createFeatures`. `bucketOf`, `inRollout`, `murmur3` and `evaluateCondition` are exported for snapshot tooling.

React (`@evanion/feature/react`): `FeatureProvider`, `useFeatures`, `useFeature`, `useFeatureEnabled`. It decides nothing — it resolves through the core, memoised on the `context` object's identity, and accepts pre-resolved `decisions` from a server render or a `plan()` snapshot. `useFeature` throws for an unconfigured key: a silent `false` makes a typo indistinguishable from a feature that is off.

## Bucketing

MurmurHash3 x86 32-bit over a length-prefixed `(seed, value)` pair, normalised over 2^32 buckets. Seed defaults to the feature key and is overridable per feature or per rule.

The naive `hashFnv32a(value + seed) % 1000` the spec cites fails on both halves, and this departs on both: the undelimited concatenation makes `('ab','c')` and `('a','bc')` the same input, so flags with related keys share buckets; and a modulus reads FNV-1a's weakest bits. Length-prefixing is unambiguous for every input, where no separator character can be — any separator can itself occur in a key or a targeting value.

The three required properties are tested, not asserted:

- **Stable** — same buckets across evaluations, and pinned literals for three `(seed, value)` pairs so a changed hash fails rather than agreeing with itself inside one process. The canonical Murmur test vectors (`""`, `"a"`, `"abc"`, `"hello"`) are pinned too, so this is a hash anyone can reproduce and not a private one.
- **Decorrelated** — 5000 users at 10% on two features: measured overlap must stay under a quarter of one cohort, where a shared seed would make it the whole cohort. A separate test proves the seed defaults to the key, and one proves an explicit shared seed correlates two features deliberately.
- **Monotonic** — raises the percentage through 1, 2, 5, 10, 25, 50, 75, 99, 100 and asserts at every step that the previous members are a subset. It holds structurally: the bucket does not depend on the percentage at all.

## Cascade depth

Five levels, A→B→C→D→E, toggling the root off and requiring all four dependants to follow. Two levels would pass on the gist's bug. Also covered: a diamond, `blockedBy` and `cause` checked at every depth, and a parent inside a 25% rollout over 1000 users where the dependant's cohort must equal the parent's exactly — without the cascade the parent's 25% leaks to 100% of the dependant's users.

Resolution walks a topological order, so a parent's resolved value always exists before a dependant reads it, for a chain of any depth.

## `reason` is output only

Enforced by the type system and proved at runtime. The function that finds a blocking parent is handed `ReadonlyMap<F, { enabled: boolean }>` and cannot see a reason at all. `reason-is-output-only.spec.ts` then runs the real decision function over the real dependency order with every explanation field deleted from each parent result before the next feature sees it, over five configurations, and requires the decisions to come out identical — a cascade keyed on `reason === 'explicitly-off'` would stop cascading and fail it. A sixth test puts the three kinds of "off" (explicit, unmatched rule, cascaded) under one dependant and requires identical decisions, differing only in the reported root cause.

## The store never writes

Config JSON compared byte-for-byte across a `resolve()` that cascades, and across a window that expires and reopens with the dependant coming back on. Stored definitions are cloned and deeply frozen, so a write attempt throws rather than silently diverging from what was resolved; `toggle` replaces a definition rather than mutating one.

## Packaging

Two entries: `.` is the core, `./react` is the client layer. A single bundle cannot carry per-module directives, so the package is emitted file-per-file by `tsc` — `bundler=tsc`, as `libs/luhn` — and `'use client'` sits on the React entry and nowhere else.

`scripts/verify-packaging.mjs` gains a case following the existing `libs/widget` pattern: every core module (not just the entry — `dist/index.js` only re-exports, a React import three files down would pass) is checked for a React import, the React entry is required to carry the directive, the core is required not to, and both export paths must exist. Verified by sabotage: an `import 'react'` in `src/lib/graph.ts` is reported as `lib/graph.js`, and stripping the directive fails the other assertion.

## Scaffolding

`nx g @nx/js:library --directory=libs/feature --name=@evanion/feature --bundler=tsc --unitTestRunner=vitest --linter=eslint --publishable --importPath=@evanion/feature --testEnvironment=node --useProjectJson=false`, matching #93. Options checked against the installed `@nx/js` schema first.

Deleted from its output: the stub `src/lib/feature.ts` / `.spec.ts` and `README.md`, and `vitest.config.mts`, replaced with a `vite.config.ts` shaped like `libs/luhn`'s. Reverted, because the generator still rewrites files it should not: `nx.json` (reformatted, the `useCommitScope` comment stripped and a `release.version.preVersionCommand` added), root `package.json` and `.verdaccio/config.yml`. `package-lock.json` was regenerated from the reverted `package.json`, so it carries only the new workspace entry. Kept its `tsconfig.json` reference.

`feature` added to `scope-enum` and to the Scopes list in `CONTRIBUTING.md`, in its own first commit so the rest of the branch can use the scope.

## Decisions the spec left open

Three, all documented in code and README:

1. **A condition over an absent context field never holds, including the negative operators.** `ne` on a field the context does not carry is unevaluable, and treating it as true would switch features on for exactly the contexts carrying the least information.
2. **`freezeTimeAtBuild`** is the per-feature opt-in the spec requires for build-time-resolved date windows; without it `plan()` defers on `now`. The spec asks for the opt-in but does not name it.
3. **`cause.rule`** is populated when there is exactly one rule to name — the matching rule, or the single rule that failed. With several rules and none matching there is no one rule to blame, and the full breakdown is on the ancestor's own decision. The spec's example shows the single-rule case.

An unknown dependency and a duplicate key are also rejected at construction, alongside the cycle the spec names.

## Verification

```
npx nx run-many -t lint test build typecheck check --skip-nx-cache
→ Successfully ran targets lint, test, build, typecheck, check for 11 projects

npx nx run-many -t test -p @evanion/feature @evanion/repo-checks --skip-nx-cache
→ @evanion/feature       73 tests passed (65 core, 8 React)
→ @evanion/repo-checks    3 tests passed

npm run verify:packaging
→ ✓ feature core imports nothing from react
→ ✓ feature ships 'use client' on the react entry only
→ ✓ feature exports both entries
→ Packaging verified.
```

Nx Cloud returns 401 (free plan exhausted). Log noise, not a failure.

## Follow-up, not in this PR

No `@evanion/feature` consumer exists yet — the Astro storefront calling `plan()` at build and the Nest API calling `resolve()` per request are both described in the spec and both untouched here. The OpenFeature provider is a separate package by the spec's own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019s6FWxb6zpDUvbN4j1XH2B
