### PR TITLE
refactor(luhn)!: the dictionary becomes a constructed value

### DIFF
--- a/libs/luhn/README.md
+++ b/libs/luhn/README.md
@@ -3,9 +3,9 @@
 
 # Luhn Library
 
-A Luhn mod-N library. It generates and validates check characters over any
-dictionary you give it, so the same API covers plain digits and alphanumeric
-strings.
+Generate and validate check characters over any alphabet you choose. A
+dictionary is validated once, at construction, and the object you get back
+carries `generate` and `validate` bound to it.
 
 ```ts
 import { Luhn } from '@evanion/luhn';
@@ -18,17 +18,7 @@ const createToken = () => {
 };
 ```
 
-## What is the Luhn mod-N algorithm?
-
-The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is a
-checksum formula used to validate identification numbers such as credit card
-numbers, IMEI numbers and national identification numbers.
-
-The [mod-N variant](https://en.wikipedia.org/wiki/Luhn_mod_N_algorithm)
-extends it to alphanumeric strings by replacing the ten digits with a
-dictionary of N characters.
-
-## Why should you use it
+## Why use it
 
 A check character lets you reject a mistyped input without a database lookup.
 That is worth having anywhere a person types an identifier by hand: a licence
@@ -52,106 +42,237 @@ Or with pnpm:
 pnpm add @evanion/luhn
 ```
 
-## Generate a checksum
+## Generate a check character
 
 ```ts
-const checked = Luhn.generate('foo'); // -> {phrase: 'foo', checksum: '5'}
+Luhn.generate('foo'); // -> { phrase: 'foo', checksum: '5', filtered: 0 }
+Luhn.generate('FoO'); // -> { phrase: 'foo', checksum: '5', filtered: 0 }
 ```
 
 `generate` returns the filtered phrase alongside the check character, because
 the phrase it computed over is not always the phrase you passed in — see
 [Filtering](#filtering).
 
-### Case-insensitive by default
-
-```ts
-Luhn.generate('FoO'); // -> {phrase: 'foo', checksum: '5'}
-```
-
-### Case-sensitive
-
-Extend the class and override `sensitive`:
-
-```ts
-class SensitiveLuhn extends Luhn {
-  static override readonly sensitive = true;
-}
-```
-
-Or pass it per call:
-
-```ts
-Luhn.generate('FoO', true);
-Luhn.validate('FoO5', true);
-```
-
-TypeScript's `noImplicitOverride` requires the `override` keyword when you
-replace `sensitive` or `dictionary` in a subclass.
-
-### Filtering
-
-Characters outside the dictionary are dropped before the checksum is computed:
-
-```ts
-Luhn.generate('foo-baz'); // -> {phrase: 'foobaz', checksum: 'p'}
-Luhn.generate('fooö-baz'); // -> {phrase: 'foobaz', checksum: 'p'}
-```
+An input with no dictionary code points in it throws `EmptyInputError`. A check
+character over no payload carries no information, and returning one makes
+`generate('')` and `generate('!!!!')` indistinguishable.
 
 ## Validate a string
 
-The last character of the input is the check character.
+The last dictionary code point of the input is the check character.
 
 ```ts
-Luhn.validate('foo5'); // -> {phrase: 'foo5', isValid: true}
-Luhn.validate('FoOö5'); // -> {phrase: 'foo5', isValid: true}
-Luhn.validate('FoO-ö5'); // -> {phrase: 'foo5', isValid: true}
-Luhn.validate('bar5'); // -> {phrase: 'bar5', isValid: false}
+Luhn.validate('foo5'); // -> { phrase: 'foo5', isValid: true, filtered: 0 }
+Luhn.validate('FOO5'); // -> { phrase: 'foo5', isValid: true, filtered: 0 }
+Luhn.validate('FoO-ö5'); // -> { phrase: 'foo5', isValid: true, filtered: 2 }
+Luhn.validate('bar5'); // -> { phrase: 'bar5', isValid: false, filtered: 0 }
 ```
 
-## Dictionary
-
-The default dictionary is `0-9` plus `A-Z` and `a-z`. Override it to widen or
-narrow the character set:
+Fewer than two surviving code points is not valid — a payload and a check
+character is the minimum:
 
 ```ts
-class MyLuhn extends Luhn {
-  static override dictionary =
-    'AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZzÅåÄäÖö';
-}
+Luhn.validate(''); // -> { phrase: '', isValid: false, filtered: 0 }
+Luhn.validate('!!!!0'); // -> { phrase: '0', isValid: false, filtered: 4 }
 ```
 
-The dictionary must have an even number of characters. An odd one throws
-`InvalidDictionaryError`, because the doubling step of mod-N is not a bijection
-over an odd dictionary and the check character would carry less information
-than it appears to.
+## Filtering
 
-## API Reference
+Code points outside the dictionary are dropped before the checksum is computed,
+so a hyphenated or accented rendering of the same token checks the same:
 
-### Static methods
+```ts
+Luhn.generate('foo-baz'); // -> { phrase: 'foobaz', checksum: 'p', filtered: 1 }
+Luhn.generate('fooö-baz'); // -> { phrase: 'foobaz', checksum: 'p', filtered: 2 }
+```
 
-- `Luhn.generate(input, sensitive?)` — returns `{ phrase, checksum }`.
-  `phrase` is `input` with every character outside the dictionary removed.
-- `Luhn.validate(input, sensitive?)` — returns `{ phrase, isValid }`, treating
-  the last character of the filtered phrase as the check character.
+`filtered` counts the dropped code points, so a caller who wants strict input
+can gate on it without reimplementing the filter.
 
-### Class properties
+## The dictionary
 
-- `static sensitive: boolean` — case sensitivity for every call (default
-  `false`).
-- `static dictionary: string` — the character set, which must have even length.
+The default is 36 lowercase alphanumerics, with case folding on:
+
+```ts
+Luhn.dictionary; // -> '0123456789abcdefghijklmnopqrstuvwxyz'
+Luhn.n; // -> 36
+Luhn.caseInsensitive; // -> true
+```
+
+The order of the dictionary decides which index each code point occupies, and
+therefore every check character it produces. Two dictionaries with the same
+characters in a different order are different alphabets.
+
+Build your own with `createLuhn`:
+
+```ts
+import { createLuhn } from '@evanion/luhn';
+
+const hex = createLuhn({ dictionary: '0123456789abcdef' });
+
+hex.generate('cafe'); // -> { phrase: 'cafe', checksum: '3', filtered: 0 }
+hex.validate('cafe3').isValid; // -> true
+```
+
+A dictionary must satisfy all of these, and `createLuhn` throws
+`InvalidDictionaryError` — carrying a `reason` — when it does not:
+
+| `reason`       | Constraint                                                   |
+| -------------- | ------------------------------------------------------------ |
+| `not-a-string` | the dictionary is a string                                   |
+| `too-short`    | at least 2 code points                                       |
+| `odd-length`   | an even number of code points                                |
+| `duplicate`    | no code point appears twice                                  |
+| `case-pairs`   | no two code points are case variants, when `caseInsensitive` |
+
+Everything is checked once, at construction. Nothing is checked at use, so an
+instance you hold cannot produce a token its own `validate` rejects.
+
+Counting is by code point, so an astral dictionary — emoji, or anything outside
+the Basic Multilingual Plane — is measured and indexed as you wrote it.
+
+## Case sensitivity
+
+`caseInsensitive` folds input to lowercase before looking it up. It is a
+property of the dictionary, not of the call: folding is sound only when the
+dictionary contains no case pairs, because otherwise two distinct indices fold
+onto one and the rest become unreachable.
+
+It defaults to `true` when you supply no dictionary and `false` when you do.
+
+```ts
+import { ALTERNATING_CASE_DICTIONARY, createLuhn } from '@evanion/luhn';
+
+const sensitive = createLuhn({ dictionary: ALTERNATING_CASE_DICTIONARY });
+
+sensitive.generate('FoO'); // -> { phrase: 'FoO', checksum: 'K', filtered: 0 }
+sensitive.validate('FoOK').isValid; // -> true
+sensitive.validate('fook').isValid; // -> false
+```
+
+Asking for folding over a dictionary that has case pairs is rejected rather
+than quietly downgraded:
+
+```ts
+createLuhn({
+  dictionary: ALTERNATING_CASE_DICTIONARY,
+  caseInsensitive: true,
+}); // throws InvalidDictionaryError, reason: 'case-pairs'
+```
+
+## Mod-10
+
+With `dictionary: '0123456789'` this library is plain Luhn mod-10:
+
+```ts
+const digits = createLuhn({ dictionary: '0123456789' });
+
+digits.generate('7992739871').checksum; // -> '3'
+digits.validate('4539578763621486').isValid; // -> true
+digits.validate('79927398710').isValid; // -> false
+```
+
+## Modulo bias
+
+The obvious way to use this library is to draw a random string over the
+dictionary and then check-character it. Drawing with `byte % dictionary.length`
+is uniform only when the dictionary size divides 256. The default 36-character
+dictionary does not — `256 % 36` is 4, and the first four characters come up
+about 15% more often than the rest.
+
+This library does not generate random values and will not start; a checksum
+library shipping a CSPRNG sampler acquires a security surface for a problem
+that is not its own. It states the fact instead:
+
+```ts
+Luhn.uniformOverBytes; // -> false
+createLuhn({ dictionary: '0123456789abcdefghjkmnpqrstuvxyz' }).uniformOverBytes; // -> true
+```
+
+`uniformOverBytes` reports that `byte % n` is unbiased. It says nothing about
+the quality of the bytes. If you intend to sample from your dictionary, pick a
+size that divides 256 — 32 is the useful one.
+
+## Standards
+
+**Mod-10 is normative.** Luhn's patent
+[US 2,950,048](https://patents.google.com/patent/US2950048A/en) defines it, and
+ISO/IEC 7812-1 Annex B specifies it for issuer identification numbers, restated
+in 3GPP TS 23.003 Annex B.2 and in the
+[CMS NPI check-digit specification](https://www.cms.gov/Regulations-and-Guidance/Administrative-Simplification/NationalProvIdentStand/Downloads/NPIcheckdigit.pdf).
+With `dictionary: '0123456789'` this library matches the published vectors.
+
+**Mod-N is not.** No RFC, ISO, ITU or ANSI document defines the generalisation
+to an arbitrary alphabet. The `floor(a / n) + (a % n)` formula everyone uses
+traces to
+[Wikipedia revision 74161899](https://en.wikipedia.org/w/index.php?title=Luhn_mod_N_algorithm&oldid=74161899),
+dated 2006-09-06, which was unsourced then and is unsourced now; the
+implementations that exist say in their own comments that they were
+transliterated from that page. With any `n` other than 10, this library
+implements that common generalisation and claims nothing more.
+
+The fold itself is Luhn's original formulation rather than a generalisation of
+"subtract 9". The patent describes "twice the original digit plus an end around
+carry … the addition of any digit standing in the tens position to the digit
+standing in the units position". Subtract-9 is the decimal shortcut for it.
+
+## API reference
+
+### `createLuhn(options?)`
+
+Validates the dictionary and returns a frozen `Luhn`.
+
+- `options.dictionary` — the alphabet. Defaults to `DEFAULT_DICTIONARY`.
+- `options.caseInsensitive` — fold input to lowercase. Defaults to `true` when
+  `dictionary` is omitted, `false` when it is given.
+
+### The returned object
+
+- `dictionary: string`
+- `n: number` — the modulus, counted by code point.
+- `caseInsensitive: boolean`
+- `uniformOverBytes: boolean` — whether `n` divides 256.
+- `generate(input): { phrase, checksum, filtered }` — throws `EmptyInputError`
+  when nothing survives the filter.
+- `validate(input): { phrase, isValid, filtered }`
+
+### Constants
+
+- `Luhn` — `createLuhn()`, frozen. `Luhn.dictionary = x` throws a `TypeError`.
+- `DEFAULT_DICTIONARY` — 36 lowercase alphanumerics.
+- `ALTERNATING_CASE_DICTIONARY` — 62 characters, `0-9` then `Aa Bb … Zz`.
 
 ### Errors
 
-- `ValidationError` — base class for everything this library throws. Catch this
-  to handle any failure from it.
-- `InvalidDictionaryError extends ValidationError` — the dictionary in use has
-  an odd number of characters. Carries `dictionary`, the value that was
-  rejected.
+- `LuhnError` — base class for everything this library throws.
+- `InvalidDictionaryError extends LuhnError` — carries `reason`, `dictionary`,
+  and `offending` (the repeated code points, or the case pairs).
+- `EmptyInputError extends LuhnError` — `generate` had nothing to work with.
 
-## Breaking changes
+## Migrating from 2.x
 
-Version 1.x computed checksums incorrectly. A value generated by 1.x does not
-validate under 2.x.
+**Every check character changes.** The default dictionary goes from 62
+characters to 36, so every index changes. Tokens minted by 2.x do not validate
+under 3.x.
+
+| 2.x                                                | 3.x                                                                       |
+| -------------------------------------------------- | -------------------------------------------------------------------------- |
+| `Luhn.generate(input)`                             | unchanged call, new value                                                  |
+| `Luhn.validate(input)`                             | unchanged call; it now accepts every token `generate` produces             |
+| `Luhn.generate(input, true)`                       | `createLuhn({ dictionary: ALTERNATING_CASE_DICTIONARY }).generate(input)`  |
+| `class X extends Luhn { static dictionary = d }`   | `createLuhn({ dictionary: d, caseInsensitive: true })`                     |
+| `class X extends Luhn { static sensitive = true }` | `createLuhn({ dictionary: ALTERNATING_CASE_DICTIONARY })` — same values    |
+| `Luhn.dictionary = d`                              | `TypeError`; the default instance is frozen                                |
+| `Luhn.sensitive`                                   | `Luhn.caseInsensitive`                                                     |
+| `Luhn.lowercaseOnly(d)`                            | removed; nothing folds a dictionary any more                               |
+| the `protected static` helpers                     | removed; they were arrow fields bound to `Luhn` and never overridable      |
+| `ValidationError`                                  | `LuhnError`                                                                |
+| `validate('')` → `isValid: true`                   | `isValid: false`                                                           |
+| `generate('')` → `{ checksum: '0' }`               | throws `EmptyInputError`                                                   |
+| an odd dictionary throws at the first call         | throws at `createLuhn`                                                     |
+
+A per-request dictionary is a per-request instance. That is one pass over the
+dictionary, which is the pass that would have happened anyway.
 
 ## Testing
 

--- a/libs/luhn/src/lib/docs.spec.ts
+++ b/libs/luhn/src/lib/docs.spec.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from 'vitest';
+
+import { EmptyInputError, InvalidDictionaryError } from './exceptions.js';
+import {
+  ALTERNATING_CASE_DICTIONARY,
+  DEFAULT_DICTIONARY,
+  Luhn,
+  createLuhn,
+} from './luhn.js';
+
+/**
+ * Every worked example in README.md and in the doc comments, as an assertion.
+ *
+ * 2.0.0 changed the arithmetic and left the documented numbers at their 1.x
+ * values, so the docs were wrong for two releases with nothing failing. A
+ * number that appears in prose appears here too, and CI is what keeps the two
+ * the same.
+ */
+describe('the documented examples', () => {
+  describe('README: quick start', () => {
+    it('createToken', () => {
+      const randomString = 'justarandomstringofletters';
+      const { checksum } = Luhn.generate(randomString);
+
+      expect(`${randomString}-${checksum}`).toBe(
+        'justarandomstringofletters-k',
+      );
+    });
+  });
+
+  describe('README: generate a checksum', () => {
+    it('Luhn.generate("foo")', () => {
+      expect(Luhn.generate('foo')).toEqual({
+        phrase: 'foo',
+        checksum: '5',
+        filtered: 0,
+      });
+    });
+
+    it('Luhn.generate("FoO")', () => {
+      expect(Luhn.generate('FoO')).toEqual({
+        phrase: 'foo',
+        checksum: '5',
+        filtered: 0,
+      });
+    });
+
+    it('Luhn.generate("") throws', () => {
+      expect(() => Luhn.generate('')).toThrow(EmptyInputError);
+    });
+  });
+
+  describe('README: filtering', () => {
+    it('Luhn.generate("foo-baz")', () => {
+      expect(Luhn.generate('foo-baz')).toEqual({
+        phrase: 'foobaz',
+        checksum: 'p',
+        filtered: 1,
+      });
+    });
+
+    it('Luhn.generate("fooö-baz")', () => {
+      expect(Luhn.generate('fooö-baz')).toEqual({
+        phrase: 'foobaz',
+        checksum: 'p',
+        filtered: 2,
+      });
+    });
+  });
+
+  describe('README: validate a string', () => {
+    it('Luhn.validate("foo5")', () => {
+      expect(Luhn.validate('foo5')).toEqual({
+        phrase: 'foo5',
+        isValid: true,
+        filtered: 0,
+      });
+    });
+
+    it('Luhn.validate("FOO5")', () => {
+      expect(Luhn.validate('FOO5')).toEqual({
+        phrase: 'foo5',
+        isValid: true,
+        filtered: 0,
+      });
+    });
+
+    it('Luhn.validate("FoO-ö5")', () => {
+      expect(Luhn.validate('FoO-ö5')).toEqual({
+        phrase: 'foo5',
+        isValid: true,
+        filtered: 2,
+      });
+    });
+
+    it('Luhn.validate("bar5")', () => {
+      expect(Luhn.validate('bar5')).toEqual({
+        phrase: 'bar5',
+        isValid: false,
+        filtered: 0,
+      });
+    });
+
+    it('Luhn.validate("") and friends', () => {
+      expect(Luhn.validate('')).toEqual({
+        phrase: '',
+        isValid: false,
+        filtered: 0,
+      });
+      expect(Luhn.validate('!!!!0')).toEqual({
+        phrase: '0',
+        isValid: false,
+        filtered: 4,
+      });
+    });
+  });
+
+  describe('README: the dictionary', () => {
+    it('the default', () => {
+      expect(Luhn.dictionary).toBe('0123456789abcdefghijklmnopqrstuvwxyz');
+      expect(Luhn.n).toBe(36);
+      expect(Luhn.caseInsensitive).toBe(true);
+      expect(Luhn.uniformOverBytes).toBe(false);
+    });
+
+    it('a custom dictionary', () => {
+      const hex = createLuhn({ dictionary: '0123456789abcdef' });
+
+      expect(hex.generate('cafe')).toEqual({
+        phrase: 'cafe',
+        checksum: '3',
+        filtered: 0,
+      });
+      expect(hex.validate('cafe3').isValid).toBe(true);
+    });
+
+    it('an odd dictionary is rejected at construction', () => {
+      expect(() => createLuhn({ dictionary: 'abc' })).toThrow(
+        InvalidDictionaryError,
+      );
+    });
+
+    it('a duplicate code point is rejected at construction', () => {
+      expect(() => createLuhn({ dictionary: 'aabbccdd' })).toThrow(
+        /repeated/,
+      );
+    });
+  });
+
+  describe('README: case sensitivity', () => {
+    it('the alternating-case dictionary', () => {
+      const sensitive = createLuhn({
+        dictionary: ALTERNATING_CASE_DICTIONARY,
+      });
+
+      expect(sensitive.caseInsensitive).toBe(false);
+      expect(sensitive.generate('FoO')).toEqual({
+        phrase: 'FoO',
+        checksum: 'K',
+        filtered: 0,
+      });
+      expect(sensitive.validate('FoOK').isValid).toBe(true);
+      expect(sensitive.validate('fook').isValid).toBe(false);
+    });
+
+    it('folding over a dictionary with case pairs is rejected', () => {
+      expect(() =>
+        createLuhn({
+          dictionary: ALTERNATING_CASE_DICTIONARY,
+          caseInsensitive: true,
+        }),
+      ).toThrow(/case pairs/);
+    });
+  });
+
+  describe('README: mod-10', () => {
+    const digits = createLuhn({ dictionary: '0123456789' });
+
+    it('generates the textbook check digit', () => {
+      expect(digits.generate('7992739871').checksum).toBe('3');
+    });
+
+    it('validates a card number', () => {
+      expect(digits.validate('4539578763621486').isValid).toBe(true);
+      expect(digits.validate('79927398710').isValid).toBe(false);
+    });
+  });
+
+  describe('README: modulo bias', () => {
+    it('the default dictionary is not uniform over bytes', () => {
+      expect(Luhn.uniformOverBytes).toBe(false);
+      expect(256 % Luhn.n).toBe(4);
+    });
+
+    it('a 32-character dictionary is', () => {
+      expect(
+        createLuhn({ dictionary: '0123456789abcdefghjkmnpqrstuvxyz' })
+          .uniformOverBytes,
+      ).toBe(true);
+    });
+  });
+
+  describe('README: migration', () => {
+    it('assignment to the default instance throws', () => {
+      expect(() => {
+        (Luhn as { dictionary: string }).dictionary = DEFAULT_DICTIONARY;
+      }).toThrow(TypeError);
+    });
+
+    it('destructuring works', () => {
+      const { generate } = Luhn;
+
+      expect(generate('foo').checksum).toBe('5');
+    });
+  });
+
+  describe('doc comments', () => {
+    it('createLuhn', () => {
+      const luhn = createLuhn({ dictionary: '0123456789' });
+
+      expect(luhn.generate('7992739871')).toEqual({
+        phrase: '7992739871',
+        checksum: '3',
+        filtered: 0,
+      });
+    });
+  });
+});

--- a/libs/luhn/src/lib/exceptions.spec.ts
+++ b/libs/luhn/src/lib/exceptions.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  EmptyInputError,
+  InvalidDictionaryError,
+  LuhnError,
+} from './exceptions.js';
+
+describe('LuhnError', () => {
+  it('should be an Error', () => {
+    const error = new LuhnError('boom');
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe('boom');
+    expect(error.name).toBe('LuhnError');
+  });
+});
+
+describe('InvalidDictionaryError', () => {
+  it('should carry a name matching the class', () => {
+    const error = new InvalidDictionaryError('odd-length', 'abc', []);
+
+    expect(error.name).toBe('InvalidDictionaryError');
+    expect(error.constructor.name).toBe('InvalidDictionaryError');
+  });
+
+  it('should be a LuhnError', () => {
+    expect(new InvalidDictionaryError('odd-length', 'abc', [])).toBeInstanceOf(
+      LuhnError,
+    );
+  });
+
+  it('should keep the fields it was constructed with', () => {
+    const error = new InvalidDictionaryError('duplicate', 'aabbccdd', [
+      'a',
+      'b',
+      'c',
+      'd',
+    ]);
+
+    expect(error.reason).toBe('duplicate');
+    expect(error.dictionary).toBe('aabbccdd');
+    expect(error.offending).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('should say dictionary in the message', () => {
+    const error = new InvalidDictionaryError('odd-length', 'abc', []);
+
+    expect(error.message).toContain('dictionary');
+    expect(error.message).not.toContain('directory');
+  });
+
+  it('should name the offending code points in the message', () => {
+    const error = new InvalidDictionaryError('duplicate', 'aabb', ['a', 'b']);
+
+    expect(error.message).toContain('a');
+    expect(error.message).toContain('b');
+  });
+});
+
+describe('EmptyInputError', () => {
+  it('should be a LuhnError with a name matching the class', () => {
+    const error = new EmptyInputError('nothing to check');
+
+    expect(error).toBeInstanceOf(LuhnError);
+    expect(error.name).toBe('EmptyInputError');
+    expect(error.message).toBe('nothing to check');
+  });
+});

--- a/libs/luhn/src/lib/exceptions.ts
+++ b/libs/luhn/src/lib/exceptions.ts
@@ -1,39 +1,94 @@
+const messageFor = (
+  reason: InvalidDictionaryReason,
+  dictionary: string,
+  offending: readonly string[],
+): string => {
+  const list = offending.map((entry) => JSON.stringify(entry)).join(', ');
+
+  switch (reason) {
+    case 'not-a-string':
+      return `Luhn dictionary must be a string, received ${typeof dictionary}.`;
+    case 'too-short':
+      return `Luhn dictionary must contain at least 2 code points, received ${[...dictionary].length}.`;
+    case 'odd-length':
+      return `Luhn dictionary must contain an even number of code points, received ${[...dictionary].length}.`;
+    case 'duplicate':
+      return `Luhn dictionary must not repeat a code point; repeated: ${list}.`;
+    case 'case-pairs':
+      return `Luhn dictionary must not contain case pairs when caseInsensitive is set; pairs: ${list}.`;
+  }
+};
+
 /**
  * Base class for every error this library throws.
  *
- * Catch this to handle any validation failure:
- *
  * ```ts
  * try {
- *   Luhn.generate(input);
+ *   createLuhn({ dictionary });
  * } catch (error) {
- *   if (error instanceof ValidationError) {
- *     // the dictionary in use is not usable
+ *   if (error instanceof LuhnError) {
+ *     // the dictionary is unusable, or there was nothing to check
  *   }
  * }
  * ```
+ *
+ * `@evanion/urn` exports an unrelated `ValidationError`; the name here is
+ * package-specific so the two never collide in a consumer's import list.
  */
-export class ValidationError extends Error {
+export class LuhnError extends Error {
   constructor(message: string) {
     super(message);
-    this.name = 'ValidationError';
+    this.name = 'LuhnError';
+  }
+}
+
+/** Which construction constraint the dictionary failed. */
+export type InvalidDictionaryReason =
+  | 'not-a-string'
+  | 'too-short'
+  | 'odd-length'
+  | 'duplicate'
+  | 'case-pairs';
+
+/**
+ * Thrown by `createLuhn` when the dictionary cannot support Luhn mod-N.
+ *
+ * One class carrying a `reason` rather than one class per constraint, so a
+ * caller that only wants to know whether a dictionary is acceptable writes one
+ * `catch` arm instead of five.
+ */
+export class InvalidDictionaryError extends LuhnError {
+  readonly reason: InvalidDictionaryReason;
+  readonly dictionary: string;
+  /**
+   * The code points the constraint named: the repeated ones for `duplicate`,
+   * the case variants for `case-pairs`, empty for the constraints that are
+   * about the dictionary as a whole.
+   */
+  readonly offending: readonly string[];
+
+  constructor(
+    reason: InvalidDictionaryReason,
+    dictionary: string,
+    offending: readonly string[],
+  ) {
+    super(messageFor(reason, dictionary, offending));
+    this.name = 'InvalidDictionaryError';
+    this.reason = reason;
+    this.dictionary = dictionary;
+    this.offending = offending;
   }
 }
 
 /**
- * Thrown when the dictionary in use has an odd number of characters. Luhn
- * mod-N needs an even N, otherwise the doubling step is not a bijection over
- * the dictionary and the check character carries no information.
+ * Thrown by `generate` when no code point of the input is in the dictionary.
+ *
+ * A check character over no payload carries no information, and returning one
+ * makes every all-filtered input produce the same result.
  */
-export class InvalidDictionaryError extends ValidationError {
-  constructor(dictionary: string) {
-    super(
-      `Luhn directory is of invalid length (${dictionary.length}). The directory length needs to be even`,
-    );
-    this.name = 'InvalidError';
-    this.dictionary = dictionary;
+export class EmptyInputError extends LuhnError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'EmptyInputError';
   }
-
-  /** The dictionary that was rejected. */
-  readonly dictionary: string;
 }

--- a/libs/luhn/src/lib/luhn.spec.ts
+++ b/libs/luhn/src/lib/luhn.spec.ts
@@ -1,86 +1,352 @@
 import { describe, expect, it } from 'vitest';
 
-import { InvalidDictionaryError } from './exceptions.js';
-import { Luhn } from './luhn.js';
+import { EmptyInputError, InvalidDictionaryError } from './exceptions.js';
+import {
+  ALTERNATING_CASE_DICTIONARY,
+  DEFAULT_DICTIONARY,
+  Luhn,
+  createLuhn,
+} from './luhn.js';
 
-describe('Luhn', () => {
-  describe('generate', () => {
-    it('should generate a check character', () => {
-      expect(Luhn.generate('justarandomstringofletters').checksum).toBe('e');
+/**
+ * A seeded PRNG, so a property test that fails names a reproducible input set
+ * rather than one that only existed on the run that caught it.
+ */
+const mulberry32 = (seed: number) => () => {
+  seed = (seed + 0x6d2b79f5) | 0;
+  let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+  t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+};
+
+const randomOver = (
+  dictionary: string,
+  length: number,
+  random: () => number,
+) => {
+  const chars = [...dictionary];
+  let out = '';
+  for (let index = 0; index < length; index++) {
+    out += chars[Math.floor(random() * chars.length)] as string;
+  }
+  return out;
+};
+
+const SAMPLES = 2000;
+
+const instances = [
+  ['default', Luhn],
+  [
+    'alternating case, case-sensitive',
+    createLuhn({ dictionary: ALTERNATING_CASE_DICTIONARY }),
+  ],
+  ['digits', createLuhn({ dictionary: '0123456789' })],
+  ['astral', createLuhn({ dictionary: '0123😀😁😂😃ab' })],
+] as const;
+
+describe('createLuhn', () => {
+  describe('the constructed instance', () => {
+    it('should expose the dictionary it was given', () => {
+      const instance = createLuhn({ dictionary: '0123456789' });
+
+      expect(instance.dictionary).toBe('0123456789');
+      expect(instance.n).toBe(10);
+      expect(instance.caseInsensitive).toBe(false);
+      expect(instance.uniformOverBytes).toBe(false);
     });
 
-    it('should filter out characters not in the dictionary', () => {
-      expect(Luhn.generate('just-a-random-string-of-letters')).toEqual({
-        phrase: 'justarandomstringofletters',
-        checksum: 'e',
-      });
+    it('should count n by code point', () => {
+      expect(createLuhn({ dictionary: '0123😀😁😂😃ab' }).n).toBe(10);
     });
 
-    it('should not be case sensitive by default', () => {
-      expect(Luhn.generate('justARandomStringOfLetters').checksum).toBe('e');
+    it('should report uniformOverBytes when the size divides 256', () => {
+      expect(
+        createLuhn({ dictionary: '0123456789abcdefghjkmnpqrstuvxyz' })
+          .uniformOverBytes,
+      ).toBe(true);
+      expect(Luhn.uniformOverBytes).toBe(false);
     });
 
-    it('should be case sensitive when asked', () => {
-      expect(Luhn.generate('JUSTARANDOMSTRINGOFLETTERS', true).checksum).toBe(
-        '0',
-      );
+    it('should be frozen', () => {
+      const instance = createLuhn();
+
+      expect(Object.isFrozen(instance)).toBe(true);
+    });
+
+    it('should default to the 36 lowercase alphanumerics, folding case', () => {
+      expect(Luhn.dictionary).toBe(DEFAULT_DICTIONARY);
+      expect([...Luhn.dictionary]).toHaveLength(36);
+      expect(Luhn.caseInsensitive).toBe(true);
+    });
+
+    it('should leave folding off for a caller-supplied dictionary', () => {
+      expect(
+        createLuhn({ dictionary: ALTERNATING_CASE_DICTIONARY }).caseInsensitive,
+      ).toBe(false);
     });
   });
 
-  describe('validate', () => {
-    it('should validate a string carrying its check character', () => {
-      expect(Luhn.validate('justarandomstringofletterse').isValid).toBe(true);
+  describe('dictionary constraints', () => {
+    const rejection = (options: Parameters<typeof createLuhn>[0]) => {
+      try {
+        createLuhn(options);
+      } catch (error) {
+        return error as InvalidDictionaryError;
+      }
+      throw new Error('expected createLuhn to throw');
+    };
+
+    it('should reject a dictionary that is not a string', () => {
+      const error = rejection({
+        dictionary: (() => 'abcd') as unknown as string,
+      });
+
+      expect(error).toBeInstanceOf(InvalidDictionaryError);
+      expect(error.reason).toBe('not-a-string');
+      expect(error.offending).toEqual([]);
+      expect(error.message).toContain('function');
     });
 
-    it('should not be case sensitive by default', () => {
-      expect(Luhn.validate('JUSTARANDOMSTRINGOFLETTERSe').isValid).toBe(true);
+    it('should reject a dictionary with fewer than 2 code points', () => {
+      expect(rejection({ dictionary: '' }).reason).toBe('too-short');
+      expect(createLuhn({ dictionary: 'ab' }).n).toBe(2);
     });
 
-    it('should be case sensitive when asked', () => {
-      expect(Luhn.validate('JUSTARANDOMSTRINGOFLETTERS0', true).isValid).toBe(
+    it('should reject an odd number of code points', () => {
+      const error = rejection({ dictionary: 'abc' });
+
+      expect(error.reason).toBe('odd-length');
+      expect(error.dictionary).toBe('abc');
+    });
+
+    it('should reject duplicate code points, naming the repeats', () => {
+      const error = rejection({ dictionary: 'aabbccdd' });
+
+      expect(error.reason).toBe('duplicate');
+      expect(error.dictionary).toBe('aabbccdd');
+      expect(error.offending).toEqual(['a', 'b', 'c', 'd']);
+    });
+
+    it('should reject folding over a dictionary with case pairs', () => {
+      const error = rejection({
+        dictionary: ALTERNATING_CASE_DICTIONARY,
+        caseInsensitive: true,
+      });
+
+      expect(error.reason).toBe('case-pairs');
+      expect(error.dictionary).toBe(ALTERNATING_CASE_DICTIONARY);
+      expect(error.offending).toContain('Aa');
+      expect(error.offending).toContain('Zz');
+    });
+
+    it('should accept a dictionary with case pairs when not folding', () => {
+      expect(
+        createLuhn({ dictionary: ALTERNATING_CASE_DICTIONARY }).n,
+      ).toBe(62);
+    });
+
+    it('should count an astral dictionary by code point, not UTF-16 unit', () => {
+      expect(() => createLuhn({ dictionary: '😀😁' })).not.toThrow();
+      expect(rejection({ dictionary: '😀😁😂' }).reason).toBe('odd-length');
+    });
+  });
+});
+
+describe('generate and validate', () => {
+  describe.each(instances)('over the %s instance', (_name, instance) => {
+    it(`should round-trip ${SAMPLES} random inputs without a single failure`, () => {
+      const random = mulberry32(1);
+      const failures: string[] = [];
+
+      for (let sample = 0; sample < SAMPLES; sample++) {
+        const input = randomOver(instance.dictionary, 8, random);
+        const { phrase, checksum } = instance.generate(input);
+        if (!instance.validate(phrase + checksum).isValid) {
+          failures.push(`${input} -> ${checksum}`);
+        }
+      }
+
+      expect(failures).toEqual([]);
+    });
+
+    it('should reach every index in the dictionary as a check character', () => {
+      const random = mulberry32(2);
+      const seen = new Set<string>();
+
+      for (let sample = 0; sample < SAMPLES * 5; sample++) {
+        seen.add(
+          instance.generate(randomOver(instance.dictionary, 6, random))
+            .checksum,
+        );
+      }
+
+      expect(seen.size).toBe(instance.n);
+    });
+
+    it('should detect a single substituted code point', () => {
+      const random = mulberry32(3);
+      const chars = [...instance.dictionary];
+      let missed = 0;
+
+      for (let sample = 0; sample < SAMPLES; sample++) {
+        const { phrase, checksum } = instance.generate(
+          randomOver(instance.dictionary, 8, random),
+        );
+        const token = [...(phrase + checksum)];
+        const position = Math.floor(random() * token.length);
+        const original = token[position] as string;
+        let replacement = original;
+        while (replacement === original) {
+          replacement = chars[Math.floor(random() * chars.length)] as string;
+        }
+        token[position] = replacement;
+
+        if (instance.validate(token.join('')).isValid) missed++;
+      }
+
+      expect(missed).toBe(0);
+    });
+  });
+
+  describe('case folding', () => {
+    it('should give mixed-case input the same result as folded input', () => {
+      const random = mulberry32(4);
+
+      for (let sample = 0; sample < SAMPLES; sample++) {
+        const lower = randomOver(DEFAULT_DICTIONARY, 8, random);
+        const mixed = [...lower]
+          .map((char) => (random() < 0.5 ? char.toUpperCase() : char))
+          .join('');
+
+        expect(Luhn.generate(mixed)).toEqual(Luhn.generate(lower));
+      }
+    });
+
+    it('should validate its own token whatever case it arrives in', () => {
+      const { phrase, checksum } = Luhn.generate('justarandomstringofletters');
+
+      expect(Luhn.validate(phrase + checksum).isValid).toBe(true);
+      expect(Luhn.validate((phrase + checksum).toUpperCase()).isValid).toBe(
         true,
       );
     });
   });
 
-  describe('subclassing', () => {
-    it('should let a subclass turn case sensitivity on globally', () => {
-      class SensitiveLuhn extends Luhn {
-        static override readonly sensitive = true;
-      }
+  describe('mod-10 vectors', () => {
+    const digits = createLuhn({ dictionary: '0123456789' });
 
-      expect(
-        SensitiveLuhn.generate('justARandomStringOfLetters').checksum,
-      ).toBe('J');
-      expect(
-        SensitiveLuhn.validate('justARandomStringOfLettersJ').isValid,
-      ).toBe(true);
+    it.each([
+      '4539578763621486',
+      '79927398713',
+      '4111111111111111',
+      '5500005555555559',
+      '6011000990139424',
+    ])('should accept %s', (vector) => {
+      expect(digits.validate(vector).isValid).toBe(true);
     });
 
-    it('should let a subclass replace the dictionary', () => {
-      class CustomLuhn extends Luhn {
-        static override dictionary = 'abcdefghijklmnopqrstuvwxyz';
-      }
+    it('should reject 79927398710', () => {
+      expect(digits.validate('79927398710').isValid).toBe(false);
+    });
 
-      expect(Luhn.generate('justARandomStringOfLetters123').checksum).toBe('S');
-      expect(
-        CustomLuhn.generate('justARandomStringOfLetters123').checksum,
-      ).toBe('v');
+    it('should generate the textbook check digit', () => {
+      expect(digits.generate('7992739871').checksum).toBe('3');
+    });
+  });
 
-      expect(
-        CustomLuhn.validate('justARandomStringOfLetters123v').isValid,
-      ).toBe(true);
-      expect(CustomLuhn.validate('justARandomStringOfLettersk').isValid).toBe(
-        false,
+  describe('the input floor', () => {
+    it.each(['', '!!!!', '!!!!0', 'åäö0'])(
+      'should not validate %o',
+      (input) => {
+        expect(Luhn.validate(input).isValid).toBe(false);
+      },
+    );
+
+    it('should still validate a two-code-point token', () => {
+      const { phrase, checksum } = Luhn.generate('a');
+
+      expect(Luhn.validate(phrase + checksum).isValid).toBe(true);
+    });
+
+    it.each(['', '!!!!'])('should refuse to generate over %o', (input) => {
+      expect(() => Luhn.generate(input)).toThrow(EmptyInputError);
+    });
+  });
+
+  describe('filtering', () => {
+    it('should drop code points outside the dictionary', () => {
+      const hyphenated = Luhn.generate('foo-baz');
+      const accented = Luhn.generate('fooö-baz');
+
+      expect(accented.phrase).toBe(hyphenated.phrase);
+      expect(accented.checksum).toBe(hyphenated.checksum);
+    });
+
+    it('should count the dropped code points', () => {
+      expect(Luhn.generate('foo-baz').filtered).toBe(1);
+      expect(Luhn.generate('fooö-baz').filtered).toBe(2);
+      expect(Luhn.generate('foobaz').filtered).toBe(0);
+    });
+
+    it('should count an astral code point once', () => {
+      expect(Luhn.generate('foo😀baz').filtered).toBe(1);
+    });
+
+    it('should report the count from validate too', () => {
+      const result = Luhn.validate('FoO-ö5');
+
+      expect(result.phrase).toBe('foo5');
+      expect(result.filtered).toBe(2);
+    });
+  });
+});
+
+describe('the default instance', () => {
+  it('should throw on assignment to dictionary', () => {
+    expect(() => {
+      (Luhn as { dictionary: string }).dictionary = 'x';
+    }).toThrow(TypeError);
+  });
+
+  it('should keep working when its methods are destructured', () => {
+    const { generate, validate } = Luhn;
+    const { phrase, checksum } = generate('foo');
+
+    expect(validate(phrase + checksum).isValid).toBe(true);
+  });
+});
+
+describe('the hazards the class removed', () => {
+  it('should have no helper for a subclass to override', () => {
+    const surface = Object.keys(Luhn).sort();
+
+    expect(surface).toEqual([
+      'caseInsensitive',
+      'dictionary',
+      'generate',
+      'n',
+      'uniformOverBytes',
+      'validate',
+    ]);
+  });
+
+  it('should carry generate and validate on the same object as the dictionary', () => {
+    const other = createLuhn({ dictionary: ALTERNATING_CASE_DICTIONARY });
+    const random = mulberry32(5);
+
+    for (let sample = 0; sample < SAMPLES; sample++) {
+      const input = randomOver(DEFAULT_DICTIONARY, 8, random);
+      const mine = Luhn.generate(input);
+      const theirs = other.generate(input);
+
+      expect(Luhn.validate(mine.phrase + mine.checksum).isValid).toBe(true);
+      expect(other.validate(theirs.phrase + theirs.checksum).isValid).toBe(
+        true,
       );
-    });
+    }
+  });
 
-    it('should reject a dictionary of odd length', () => {
-      class TestLuhn extends Luhn {
-        static override dictionary = 'abcfo';
-      }
-
-      expect(() => TestLuhn.generate('ab')).toThrow(InvalidDictionaryError);
-    });
+  it('should reject the check character 2.0.1 emitted for foo', () => {
+    expect(Luhn.validate('fooI').isValid).toBe(false);
   });
 });

--- a/libs/luhn/src/lib/luhn.ts
+++ b/libs/luhn/src/lib/luhn.ts
@@ -1,174 +1,270 @@
-import { InvalidDictionaryError } from './exceptions.js';
+import { EmptyInputError, InvalidDictionaryError } from './exceptions.js';
 
 /**
- * @typedef {Object} GenerateResult
- * @property {String} phrase The filtered string
- * @property {String} checksum The generated checksum character
+ * 36 lowercase alphanumerics, the dictionary `createLuhn()` uses when the
+ * caller supplies none.
+ *
+ * It contains no case pairs, which is what makes case folding sound over it:
+ * folding maps uppercase input onto a dictionary entry instead of onto a
+ * second entry that is already taken.
  */
+export const DEFAULT_DICTIONARY = '0123456789abcdefghijklmnopqrstuvwxyz';
 
 /**
- * @typedef {Object} ValidateResult
- * @property {String} phrase The filtered string
- * @property {Boolean} isValid True if the string is valid
+ * 62 characters, digits followed by `Aa Bb Cc …`. Case-sensitive only: its
+ * case pairs make it invalid under `caseInsensitive`.
+ *
+ * The alternating order is load-bearing — it decides which index each letter
+ * occupies, and therefore every check character the dictionary produces.
  */
+export const ALTERNATING_CASE_DICTIONARY =
+  '0123456789AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz';
 
-/**
- * Lets you easily generate and validate checksum values based on the Luhn mod-N algorithm
- */
-export class Luhn {
+/** The filtered phrase and its check character. */
+export interface GenerateResult {
+  /** `input` with every code point outside the dictionary removed. */
+  phrase: string;
+  /** The check character, drawn from the dictionary. */
+  checksum: string;
+  /** How many code points of `input` were dropped. */
+  filtered: number;
+}
+
+/** The filtered phrase and whether its last character checks out. */
+export interface ValidateResult {
+  /** `input` with every code point outside the dictionary removed. */
+  phrase: string;
+  isValid: boolean;
+  /** How many code points of `input` were dropped. */
+  filtered: number;
+}
+
+export interface LuhnOptions {
   /**
-   * Toggle if the class should be case sensitive
-   */
-  static sensitive = false;
-
-  /**
-   * Dictionary that contains all valid characters.
-   * Override it if you want to use additional/less characters
-   */
-  static dictionary =
-    '0123456789AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz';
-
-  static lowercaseOnly = (dictionary: string) =>
-    dictionary
-      .toLowerCase()
-      .split('')
-      .filter((char, index, arr) => arr.indexOf(char) === index)
-      .join('');
-
-  /**
-   * Generates a check character for the input string.
-   * @param {String} input The string that should have a check character
-   * @param {Boolean} sensitive Toggle if the function should be case-sensitive or not.
-   * @returns {GenerateResult} The filtered string and checksum character
+   * The alphabet. Must be a string of an even number of distinct code points,
+   * at least two, and must contain no case pairs when `caseInsensitive` is on.
    *
-   * @example
-   * Luhn.generate('foo') // -> {phrase: 'foo', checksum: '5'}
-   * Luhn.generate('FoO') // -> {phrase: 'foo', checksum: '5'}
-   * Luhn.generate('FoO', true) // -> {phrase: 'FoO', checksum: 'n'}
+   * Defaults to {@link DEFAULT_DICTIONARY}.
    */
-  public static generate(input: string, sensitive?: boolean) {
-    const dictionary = sensitive
-      ? this.lowercaseOnly(this.dictionary)
-      : this.dictionary;
+  dictionary?: string;
+  /**
+   * Fold input to lowercase before looking it up, so `FOO` and `foo` check the
+   * same.
+   *
+   * Defaults to `true` when `dictionary` is omitted and `false` when it is
+   * given: the default dictionary is chosen to support folding, a
+   * caller-supplied one has to say whether it does.
+   */
+  caseInsensitive?: boolean;
+}
 
-    const n = this.getN(dictionary);
-    const filteredArr = (
-      sensitive || this.sensitive ? input : input.toLowerCase()
-    )
-      .split('')
-      .filter(this.filterValid(dictionary));
+/** A dictionary with `generate` and `validate` bound to it. */
+export interface Luhn {
+  readonly dictionary: string;
+  /** The modulus: the number of code points in the dictionary. */
+  readonly n: number;
+  readonly caseInsensitive: boolean;
+  /**
+   * Whether `byte % n` draws uniformly from the dictionary, which holds when
+   * `n` divides 256.
+   *
+   * It says nothing about the quality of the bytes. This library does not
+   * generate random values; the flag exists so a caller that does can reject a
+   * dictionary that would bias its output.
+   */
+  readonly uniformOverBytes: boolean;
 
-    const sum = [...filteredArr]
-      .reverse()
-      .reduce(this.reduce(2, dictionary), 0);
+  /**
+   * Computes the check character for `input`.
+   *
+   * @throws {EmptyInputError} when no code point of `input` is in the
+   * dictionary.
+   */
+  generate(input: string): GenerateResult;
 
-    const remainder = sum % n;
-    const checkCodePoint = (n - remainder) % n;
+  /**
+   * Checks `input`, whose last dictionary code point is the check character.
+   *
+   * Fewer than two surviving code points is not valid: a check character over
+   * no payload carries no information.
+   */
+  validate(input: string): ValidateResult;
+}
 
-    return {
-      phrase: filteredArr.join(''),
-      checksum: this.index2char(checkCodePoint, dictionary),
-    };
+/**
+ * Validates `dictionary` and returns its code points.
+ *
+ * Iteration is by code point rather than by UTF-16 unit, so an astral
+ * dictionary counts and indexes as the caller wrote it; `split('')` halves
+ * every surrogate pair.
+ */
+const codePointsOf = (
+  dictionary: string,
+  caseInsensitive: boolean,
+): string[] => {
+  if (typeof dictionary !== 'string') {
+    throw new InvalidDictionaryError('not-a-string', dictionary, []);
   }
 
-  /**
-   * Validates if the given string, matches the calculated checksum.
-   * The last character in the string is considered the checksum.
-   * @param {String} input The string that you want to check,
-   * including the check character in the end of the string
-   * @param {Boolean} sensitive Toggle if the function should be case-sensitive or not.
-   * @returns {ValidateResult} returns if the string is valid or not.
-   * @example
-   * Luhn.validate('foo5') // -> {phrase: 'foo5', isValid: true}
-   * Luhn.validate('FoO5') // -> {phrase: 'foo5', isValid: true}
-   * Luhn.validate('FoOö5') // -> {phrase: 'foo5', isValid: true}
-   * Luhn.validate('FoO5', true) // -> {phrase: 'FoO5', isValid: false}
-   */
-  public static validate(input: string, sensitive?: boolean) {
-    const dictionary = sensitive
-      ? this.lowercaseOnly(this.dictionary)
-      : this.dictionary;
-    const n = this.getN(dictionary);
-    const filteredArr = (
-      sensitive || this.sensitive ? input : input.toLowerCase()
-    )
-      .split('')
-      .filter(this.filterValid(dictionary));
+  const chars = [...dictionary];
 
-    const sum = [...filteredArr]
-      .reverse()
-      .reduce(this.reduce(1, dictionary), 0);
-
-    return {
-      phrase: filteredArr.join(''),
-      isValid: !(sum % n),
-    };
+  if (chars.length < 2) {
+    throw new InvalidDictionaryError('too-short', dictionary, []);
   }
 
-  /**
-   * Looks up an index in the dictionary based on the given character
-   * @param {String} character The character you want to find in the dictionary
-   * @returns {Number} the index of the character in the dictionary
-   */
-  protected static readonly char2index = (
-    character: string,
-    dictionary: string,
-  ) => dictionary.indexOf(character);
+  if (chars.length % 2 !== 0) {
+    throw new InvalidDictionaryError('odd-length', dictionary, []);
+  }
+
+  const seen = new Set<string>();
+  const repeated = new Set<string>();
+  for (const char of chars) {
+    if (seen.has(char)) repeated.add(char);
+    seen.add(char);
+  }
+  if (repeated.size > 0) {
+    throw new InvalidDictionaryError('duplicate', dictionary, [...repeated]);
+  }
+
+  if (caseInsensitive) {
+    const byFold = new Map<string, string[]>();
+    for (const char of chars) {
+      const fold = char.toLowerCase();
+      byFold.set(fold, [...(byFold.get(fold) ?? []), char]);
+    }
+    const pairs = [...byFold.values()]
+      .filter((group) => group.length > 1)
+      .map((group) => group.join(''));
+    if (pairs.length > 0) {
+      throw new InvalidDictionaryError('case-pairs', dictionary, pairs);
+    }
+  }
+
+  return chars;
+};
+
+/**
+ * Validates `options.dictionary` and returns a frozen object carrying it, its
+ * lookup tables, and the two operations bound to them.
+ *
+ * Everything a dictionary has to satisfy is checked here, once. Nothing is
+ * checked at use, so an accepted instance cannot produce a token its own
+ * `validate` rejects.
+ *
+ * @throws {InvalidDictionaryError} when the dictionary fails a constraint.
+ *
+ * @example
+ * const luhn = createLuhn({ dictionary: '0123456789' });
+ * luhn.generate('7992739871'); // -> { phrase: '7992739871', checksum: '3', filtered: 0 }
+ */
+export function createLuhn(options: LuhnOptions = {}): Luhn {
+  const dictionary = options.dictionary ?? DEFAULT_DICTIONARY;
+  const caseInsensitive =
+    options.caseInsensitive ?? options.dictionary === undefined;
+
+  const chars = codePointsOf(dictionary, caseInsensitive);
+  const n = chars.length;
+  const indexOf = new Map(chars.map((char, index) => [char, index]));
 
   /**
-   * Looks up a character in the dictionary based on it's index
-   * @param {Number} codePoint The index you want to find in the dictionary
-   * @returns {String} The character in the dictionary, at the given index
+   * Splits `input` into the dictionary indices it contains, in order, plus the
+   * phrase they spell and the count of what was dropped.
+   *
+   * Folding is applied per code point so that each code point of `input` is
+   * either one index or one drop, which is what makes `filtered` a count of
+   * the caller's own input.
    */
-  protected static readonly index2char = (
-    codePoint: number,
-    dictionary: string,
-  ) => dictionary.charAt(codePoint);
+  const scan = (input: string) => {
+    const indices: number[] = [];
+    let phrase = '';
+    let filtered = 0;
 
-  /**
-   * Filter out any characters that are not in the dictionary.
-   * @param {String} character The character you want to check
-   * @returns {Boolean} True if the character is in the dictionary
-   */
-  protected static readonly filterValid =
-    (dictionary: string) => (character: string) =>
-      dictionary.indexOf(character) !== -1;
-
-  /**
-   * Higher-order function that returns a reducer that calculates the checksum
-   * @param {Number}factor
-   * @returns {reduce~reducer}
-   */
-  protected static readonly reduce =
-    (factor: 1 | 2, dictionary: string) =>
-    /**
-     * Reducer function that is applied on an array of
-     * characters in order to calculate a checksum.
-     * @param {Number} sum current sum of the checksum
-     * @param {String} current current character that is being calculated
-     * @returns {Number} the checksum
-     */
-    (sum: number, current: string) => {
-      const codePoint = this.char2index(current, dictionary);
-      let addend = factor * codePoint;
-
-      factor = factor === 2 ? 1 : 2;
-
-      addend =
-        Math.floor(addend / dictionary.length) + (addend % dictionary.length);
-      return (sum += addend);
-    };
-
-  /**
-   * Checks that the dictionary complies with the requirements,
-   * and returns the N value.
-   * @returns {Number} Length of the dictionary
-   */
-  protected static readonly getN = (dictionary: string) => {
-    if (dictionary.length % 2 !== 0) {
-      throw new InvalidDictionaryError(dictionary);
+    for (const char of input) {
+      const key = caseInsensitive ? char.toLowerCase() : char;
+      const index = indexOf.get(key);
+      if (index === undefined) {
+        filtered++;
+        continue;
+      }
+      indices.push(index);
+      phrase += key;
     }
 
-    return dictionary.length;
+    return { indices, phrase, filtered };
   };
+
+  /**
+   * Luhn's fold, right to left: double every other index, then add the tens
+   * digit to the units digit — `floor(a / n) + (a % n)` over a dictionary of
+   * `n` code points.
+   *
+   * `factor` starts at 2 when a check character is about to be appended and at
+   * 1 when one is already present, which is what puts the doubling on the same
+   * positions in both directions.
+   */
+  const fold = (indices: readonly number[], startFactor: 1 | 2): number => {
+    let factor = startFactor;
+    let sum = 0;
+
+    for (let position = indices.length - 1; position >= 0; position--) {
+      const addend = factor * (indices[position] as number);
+      factor = factor === 2 ? 1 : 2;
+      sum += Math.floor(addend / n) + (addend % n);
+    }
+
+    return sum;
+  };
+
+  const generate = (input: string): GenerateResult => {
+    const { indices, phrase, filtered } = scan(input);
+
+    if (indices.length < 1) {
+      throw new EmptyInputError(
+        `Luhn cannot generate a check character over an input with no dictionary code points (received ${JSON.stringify(input)}).`,
+      );
+    }
+
+    const remainder = fold(indices, 2) % n;
+
+    return {
+      phrase,
+      checksum: chars[(n - remainder) % n] as string,
+      filtered,
+    };
+  };
+
+  const validate = (input: string): ValidateResult => {
+    const { indices, phrase, filtered } = scan(input);
+
+    return {
+      phrase,
+      isValid: indices.length >= 2 && fold(indices, 1) % n === 0,
+      filtered,
+    };
+  };
+
+  return Object.freeze({
+    dictionary,
+    n,
+    caseInsensitive,
+    uniformOverBytes: 256 % n === 0,
+    generate,
+    validate,
+  });
 }
+
+/**
+ * `createLuhn()`: the 36 lowercase alphanumerics, folding case.
+ *
+ * Frozen, so `Luhn.dictionary = x` — the 1.x and 2.x way to configure this
+ * library — throws a `TypeError` in a module rather than being accepted and
+ * ignored. Build a second instance with `createLuhn` instead.
+ */
+/*
+ * `Luhn` names the interface in type space and the default instance in value
+ * space, so `const luhn: Luhn = Luhn` resolves both. no-redeclare's
+ * ignoreDeclarationMerge option covers interface/class and interface/interface
+ * merges, not interface/variable.
+ */
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const Luhn: Luhn = createLuhn();

--- a/scripts/verify-packaging.mjs
+++ b/scripts/verify-packaging.mjs
@@ -171,7 +171,7 @@ import { FeatureProvider, useFeature } from '@evanion/feature/react';
 const missing = Object.entries({
   URN, InvalidError, ValidationError, ComposeProvider, provider,
   createWidgets, DefaultItem, DefaultWrapper, validateItems,
-  defineBlocks, validateBlocks, Luhn, createLuhn, InvalidDictionaryError,
+  defineBlocks, validateBlocks, createLuhn, InvalidDictionaryError,
   createFeatures, FeatureProvider, useFeature,
 }).filter(([, v]) => typeof v !== 'function').map(([k]) => k);
 // Luhn is the default instance rather than a class, and it is frozen so that

--- a/scripts/verify-packaging.mjs
+++ b/scripts/verify-packaging.mjs
@@ -94,9 +94,8 @@ import { CorrelationModule, CorrelationService, withCorrelation } from '@evanion
 import type { CorrelationConfig } from '@evanion/nestjs-correlation-id';
 import { defineBlocks, validateBlocks } from '@evanion/astro-widget';
 import type { BlockItem, BlockRegistry, BlockProblem } from '@evanion/astro-widget';
-// @evanion/luhn exports a ValidationError of its own, unrelated to @evanion/urn's.
-// Aliased here so the collision is explicit rather than a compile error.
-import { Luhn, InvalidDictionaryError, ValidationError as LuhnValidationError } from '@evanion/luhn';
+import { Luhn, createLuhn, InvalidDictionaryError, LuhnError } from '@evanion/luhn';
+import type { LuhnOptions } from '@evanion/luhn';
 import { createFeatures, FeatureCycleError } from '@evanion/feature';
 import type { Decision, FeatureDefinition } from '@evanion/feature';
 // Second entry point, and the only one that may touch React.
@@ -116,7 +115,9 @@ const registry: BlockRegistry = defineBlocks({ hero: 'not-a-real-component' });
 const sections: BlockItem[] = [{ type: 'hero', heading: 'ok' }];
 const problems: BlockProblem[] = validateBlocks(sections, registry, { hero: ['heading'] });
 const checksum: string = Luhn.generate('foo').checksum;
-const luhnErr: LuhnValidationError = new InvalidDictionaryError('abc');
+const luhnOptions: LuhnOptions = { dictionary: '0123456789' };
+const filtered: number = createLuhn(luhnOptions).validate('79927398713').filtered;
+const luhnErr: LuhnError = new InvalidDictionaryError('odd-length', 'abc', []);
 const toggleConfig: FeatureDefinition<'payments-v3' | 'checkout-v2'>[] = [
   { key: 'payments-v3', enabled: true, rules: [{ rollout: { percent: 25 } }] },
   { key: 'checkout-v2', enabled: true, dependsOn: ['payments-v3'] },
@@ -126,7 +127,7 @@ const toggleDecision: Decision<'payments-v3' | 'checkout-v2'> =
   toggles.resolve({ targetingKey: 'acct-1' })['checkout-v2'];
 void [ComposeProvider, provider, parsed, arr, err, items, widgetProblems, DefaultItem, DefaultWrapper,
       CorrelationModule, CorrelationService, withCorrelation, correlation,
-      registry, sections, problems, checksum, luhnErr,
+      registry, sections, problems, checksum, filtered, luhnErr,
       toggleDecision, FeatureCycleError, FeatureProvider, useFeature, useFeatureEnabled, useFeatures];
 `,
   );
@@ -164,15 +165,18 @@ import { URN, InvalidError, ValidationError } from '@evanion/urn';
 import { ComposeProvider, provider } from '@evanion/compose';
 import { createWidgets, DefaultItem, DefaultWrapper, validateItems } from '@evanion/react-widget';
 import { defineBlocks, validateBlocks } from '@evanion/astro-widget';
-import { Luhn, InvalidDictionaryError } from '@evanion/luhn';
+import { Luhn, createLuhn, InvalidDictionaryError } from '@evanion/luhn';
 import { createFeatures } from '@evanion/feature';
 import { FeatureProvider, useFeature } from '@evanion/feature/react';
 const missing = Object.entries({
   URN, InvalidError, ValidationError, ComposeProvider, provider,
   createWidgets, DefaultItem, DefaultWrapper, validateItems,
-  defineBlocks, validateBlocks, Luhn, InvalidDictionaryError,
+  defineBlocks, validateBlocks, Luhn, createLuhn, InvalidDictionaryError,
   createFeatures, FeatureProvider, useFeature,
 }).filter(([, v]) => typeof v !== 'function').map(([k]) => k);
+// Luhn is the default instance rather than a class, and it is frozen so that
+// assigning a dictionary to it throws instead of being silently ignored.
+if (typeof Luhn?.generate !== 'function' || !Object.isFrozen(Luhn)) missing.push('Luhn');
 if (missing.length) { console.error('not exported at runtime:', missing.join(', ')); process.exit(1); }
 `,
   );


### PR DESCRIPTION
Implements `docs/specs/2026-09-12-luhn-dictionary-redesign.md`.

## The public API

```ts
createLuhn(options?: { dictionary?: string; caseInsensitive?: boolean }): Luhn

interface Luhn {
  readonly dictionary: string;
  readonly n: number;
  readonly caseInsensitive: boolean;
  readonly uniformOverBytes: boolean;
  generate(input: string): { phrase: string; checksum: string; filtered: number };
  validate(input: string): { phrase: string; isValid: boolean; filtered: number };
}

const Luhn: Luhn;                        // createLuhn(), frozen
const DEFAULT_DICTIONARY: string;        // 36 lowercase alphanumerics
const ALTERNATING_CASE_DICTIONARY: string; // 62, '0-9' then 'Aa Bb … Zz'

class LuhnError extends Error {}
class InvalidDictionaryError extends LuhnError {
  readonly reason: 'not-a-string' | 'too-short' | 'odd-length' | 'duplicate' | 'case-pairs';
  readonly dictionary: string;
  readonly offending: readonly string[];
}
class EmptyInputError extends LuhnError {}
```

`caseInsensitive` defaults to `true` when `dictionary` is omitted and `false`
when it is given. The spec requires both `Luhn === createLuhn()` with folding on
and `createLuhn({ dictionary: ALTERNATING_CASE_DICTIONARY })` to be the
case-sensitive replacement for `static sensitive = true`, and a dictionary-
dependent default is the only rule that satisfies both without silently
enabling folding on a caseless dictionary.

## The four issues that dissolved

Measured against the 2.0.1 sources and the build, 5000 seeded samples:

| | 2.0.1 | 3.0.0 |
| --- | --- | --- |
| #85 default round-trip | 2123/5000 FAIL (42.5%) | 0/5000 |
| #89 subclass helper override | called = `false`, a silent no-op | no helpers on the surface |
| #89 destructured `generate` | `TypeError` | works, round-trips |
| #89 cross-alphabet validate | 1954/2000 disagreements | generate and validate are on the same object; 0/2000 |
| #91 `lowercaseOnly` + cache | exported, recomputed per call | gone; tables built once in `createLuhn` |

## Migration table, verified against the build

| | 2.0.1 | 3.0.0 |
| --- | --- | --- |
| `Luhn.generate('foo')` | `{ phrase: 'foo', checksum: 'I' }` | `{ phrase: 'foo', checksum: '5', filtered: 0 }` |
| `Luhn.dictionary` length | 62 | 36 |
| `Luhn.dictionary = 'x'` | accepted | `TypeError` |
| `static sensitive = true`, `generate('justARandomStringOfLetters')` | `'J'` | `createLuhn({ dictionary: ALTERNATING_CASE_DICTIONARY })` → `'J'` |
| `validate('')` | `isValid: true` | `isValid: false` |
| `generate('')` | `{ phrase: '', checksum: '0' }` | throws `EmptyInputError` |
| `generate('JUSTARANDOM…', true)` | `{ phrase: '', checksum: '0' }` | `{ phrase: 'justarandom…', checksum: 'k', filtered: 0 }` |

The `static sensitive = true` row is the load-bearing one: that path was the
only correct one in 2.0.1, and the replacement reproduces it exactly.

## Docs

Every worked example in the README and in the doc comments is an assertion in
`docs.spec.ts`. It earned its keep on the first run by rejecting a check
character I had guessed rather than computed.

The standards section now says that mod-10 is normative (the patent, ISO/IEC
7812-1 Annex B, 3GPP TS 23.003 B.2, the CMS NPI spec) and that mod-N is not,
with the 2006 Wikipedia revision the formula actually comes from.

## Verification

- `npx nx run-many -t lint test build typecheck check` — 11 projects, all green.
- `npm run verify:packaging` — passes. `Luhn` is checked as a frozen object
  with a `generate` method rather than as a function, and the
  `ValidationError as LuhnValidationError` alias is deleted with the collision.
- 81 tests: round-trip, reachability and single-substitution over four
  dictionaries including an astral one, case folding, mod-10 vectors, one case
  per rejection `reason`, the input floor, the `filtered` count, and the frozen
  default.

The arithmetic is untouched.

Closes #85
Closes #86
Closes #87
Closes #88
Closes #89
Closes #90
Closes #91
Closes #92
Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019s6FWxb6zpDUvbN4j1XH2B
