### PR TITLE
feat(token): add @evanion/token, human-shareable codes with a check character

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,7 @@ Package scopes:
 - **compose**: Changes to the `@evanion/compose` library
 - **urn**: Changes to the `@evanion/urn` library
 - **luhn**: Changes to the `@evanion/luhn` library
+- **token**: Changes to the `@evanion/token` library
 - **feature**: Changes to the `@evanion/feature` library
 - **react-widget**: Changes to the `@evanion/react-widget` library
 - **astro-widget**: Changes to the `@evanion/astro-widget` library

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -44,6 +44,7 @@ module.exports = {
         'repo-checks',
         'shop-api',
         'storefront',
+        'token',
         'urn',
         // Repository scopes -- not projects. Taken from the scopes already in
         // use on main, so existing practice keeps working.

--- a/docs/specs/2026-09-12-token-codes.md
+++ b/docs/specs/2026-09-12-token-codes.md
@@ -55,13 +55,13 @@ None of it carries over. The idea does.
 ```ts
 const token = createToken();                       // defaults
 token.generate()
-// { value: 'a4kp-9mx7', body: 'a4kp9mx', check: '7', prefix: undefined }
+// { value: 'a4kp-9mxa', body: 'a4kp9mx', check: 'a' }
 
 token.generate({ prefix: 'ORD' })
-// { value: 'ORD-a4kp-9mx7', body: 'a4kp9mx', check: '7', prefix: 'ORD' }
+// { value: 'ORD-a4kp-9mxa', body: 'a4kp9mx', check: 'a', prefix: 'ORD' }
 
-token.validate('a4kp-9mx7')       // { valid: true,  body: 'a4kp9mx' }
-token.validate('a4kp-9mx8')       // { valid: false, reason: 'check-failed' }
+token.validate('a4kp-9mxa')       // { valid: true,  body: 'a4kp9mx' }
+token.validate('a4kp-9mxb')       // { valid: false, reason: 'check-failed' }
 token.validate('a4kp-9mxo')       // { valid: false, reason: 'outside-alphabet' }
 ```
 
@@ -90,8 +90,17 @@ it.
 
 A supplied dictionary is validated on all three. luhn already reports the
 second as `too-short`, `odd-length`, `duplicate`, `case-pairs`; token checks
-the first and third and reports its own reasons. It reads
-`createLuhn(...).uniformOverBytes` rather than recomputing `256 % n === 0`.
+the first and third and reports its own reasons, `confusable` and
+`non-uniform`. It reads `createLuhn(...).uniformOverBytes` rather than
+recomputing `256 % n === 0`.
+
+A fourth reason, `unfolded`, rejects a dictionary containing an uppercase
+character. The "no case pairs" constraint is only active under luhn's
+`caseInsensitive`, so token constructs its luhn instance with case folding on
+and folds input before validating. An all-uppercase dictionary satisfies every
+constraint in the table and then matches nothing once folded, which would give
+a construction that succeeds and a `generate` that throws. Construction rejects
+it instead.
 
 Rejection sampling is the alternative to constraining the alphabet. It is not
 used: it makes generation variable-time, and the constraint is satisfiable — the
@@ -99,7 +108,7 @@ default proves it.
 
 ## The prefix sits outside the checksum
 
-`ORD-a4kp-9mx7` checksums `a4kp9mx` only.
+`ORD-a4kp-9mxa` checksums `a4kp9mx` only.
 
 Folding the prefix in requires every prefix character to be in the alphabet.
 `ORD` contains `o`, which is excluded precisely because it is confusable, so
@@ -117,7 +126,7 @@ total, fast and free of side effects. It returns a reason rather than throwing:
 | `reason` | meaning |
 | --- | --- |
 | `outside-alphabet` | a character not in the dictionary, after separators are stripped |
-| `wrong-length` | body length does not match the configured length |
+| `wrong-length` | the token, separators stripped, is not `length` characters |
 | `check-failed` | the check character does not match the body |
 
 `valid: true` means the code is well formed. It does not mean the code exists.
@@ -138,14 +147,95 @@ exists to avoid.
 
 ## Entropy
 
-`length` counts body characters including the check character, so usable
-entropy is `(length - 1) * log2(n)`. At the defaults — length 8, n = 32 —
-that is 35 bits. The README states this next to the default rather than leaving
-it to be derived, because a verification code sized by eye is how a code ends
-up guessable.
+Two words with two meanings, fixed here because the rest of the spec relies on
+the distinction:
 
-`generate` never retries or checks for collisions. Uniqueness is the caller's
-database constraint, not a property a generator can offer.
+- `length` is the whole token, check character included. It is what `validate`
+  measures and what `wrong-length` reports on.
+- `body` is the token without its check character, and is what `generate`
+  returns under that name.
+
+The check character is derived from the body, so it carries no entropy. Usable
+entropy is therefore `(length - 1) * log2(n)`. At the defaults — length 8,
+n = 32 — that is 35 bits. The README states this next to the default rather
+than leaving it to be derived, because a verification code sized by eye is how
+a code ends up guessable.
+
+`generate` never retries or checks for collisions.
+
+## Collisions
+
+At the defaults the space is `32^7` = 34,359,738,368 codes. Two numbers
+follow from that, and they differ by five orders of magnitude:
+
+| Number | Value | What it answers |
+| --- | --- | --- |
+| Space | 34,359,738,368 | How long enumeration takes |
+| 50% birthday threshold | ~218,000 | When a collision becomes likely across the whole set |
+| Per-insert probability at 1M issued | 1 in 34,360 | How often one insert actually fails |
+
+The birthday threshold is the number to quote when codes are generated
+offline in a batch and never checked. With a unique constraint the
+per-insert probability is the one that governs, and at a million issued
+codes an insert retries once in every 34,360 attempts.
+
+So the documented pattern is a unique index and an insert-retry loop:
+
+```ts
+for (;;) {
+  const { value } = token.generate();
+  try {
+    return await orders.insert({ code: value });
+  } catch (error) {
+    if (!isUniqueViolation(error)) throw error;
+  }
+}
+```
+
+This is the only construction that holds under concurrency. Two
+processes can generate the same code in the same instant, and any check
+performed before the insert is a time-of-check-to-time-of-use race. That
+is why `generate` takes no `exists` callback: it would make collisions
+rarer while reading as though they were impossible, and a caller who
+believes that drops the unique constraint.
+
+## Guaranteed uniqueness, not implemented
+
+Random sampling is what produces birthday collisions. A generator that
+enumerated the space under a bijection instead would have none: distinct
+inputs give distinct codes by construction, for all 34,359,738,368 of
+them.
+
+The bijection has to be indistinguishable from random, or codes become
+guessable, which is format-preserving encryption over a domain of
+exactly `32^7`. Encryption is a permutation, so injectivity is free, and
+without the key the output carries nothing about its input. NIST FF1
+(SP 800-38G) standardises this and radix 32 at length 7 is inside its
+domain requirements; a small-domain Feistel network with HMAC-SHA256 as
+the round function is the dependency-free equivalent.
+
+```
+1 -> encode(key, 1) -> a4kp9mx + check
+2 -> encode(key, 2) -> q7t2fbd + check
+3 -> encode(key, 3) -> 3nzhc5r + check
+```
+
+It is not implemented, for one reason: it needs a monotonic counter and
+a secret key. A counter that is correct under concurrency lives in a
+database sequence, so the library would carry a dependency on the
+caller's storage, and this library is self-contained. The shape that
+would preserve that — `createToken({ key })` with
+`token.encode(sequenceNumber)`, the caller passing a value it already
+holds — remains available if the trade is ever worth making.
+
+Key rotation is the sharp edge to design for first. Two keys are two
+permutations, and they can map different counters onto the same code, so
+rotation either returns to birthday-level risk or partitions the space
+by key version.
+
+Uniform random sampling stays the default. Within a stateless generator
+it is already optimal: uniform minimises collision probability over a
+fixed space, so there is nothing in the sampling to tune.
 
 ## Migration
 

--- a/libs/token/LICENSE
+++ b/libs/token/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Mikael Pettersson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/libs/token/README.md
+++ b/libs/token/README.md
@@ -1,0 +1,265 @@
+![CI](https://github.com/Evanion/libraries/actions/workflows/ci.yml/badge.svg)
+![npm (scoped)](https://img.shields.io/npm/v/@evanion/token)
+
+# Token Library
+
+Short codes a person can read aloud, type from a card, or dictate over a
+phone — each carrying a check character, so a mistyped one is rejected before
+you touch the database.
+
+```ts
+import { createToken } from '@evanion/token';
+
+const token = createToken();
+
+token.generate(); // -> { value: 'a4kp-9mxa', body: 'a4kp9mx', check: 'a', prefix: undefined }
+token.validate('a4kp-9mxa'); // -> { valid: true, body: 'a4kp9mx' }
+```
+
+## Why use it
+
+Two properties make a code usable by a human:
+
+- The alphabet leaves out characters that are confused when read or heard.
+  `1`/`l`/`i` and `0`/`o` are the point.
+- A wrong code can be rejected **before** an expensive operation. A database
+  lookup for a code that was mistyped is a lookup that never needed to happen.
+
+The second one is the check character, and it is not optional here. Without it
+this package is three lines of `crypto.randomBytes`.
+
+## Installation
+
+```bash
+npm install @evanion/token
+```
+
+Or with yarn:
+
+```bash
+yarn add @evanion/token
+```
+
+Or with pnpm:
+
+```bash
+pnpm add @evanion/token
+```
+
+## Generate a code
+
+```ts
+const token = createToken();
+
+token.generate();
+// -> { value: 'a4kp-9mxa', body: 'a4kp9mx', check: 'a', prefix: undefined }
+
+token.generate({ prefix: 'ORD' });
+// -> { value: 'ORD-a4kp-9mxa', body: 'a4kp9mx', check: 'a', prefix: 'ORD' }
+```
+
+`value` is the code as a person sees it. `body` is what the check character was
+computed over, unchunked, which is the form to store and index on.
+
+Characters are drawn from `crypto.randomBytes`. `generate` never retries and
+never checks for collisions — see [Entropy](#entropy).
+
+## Validate a code
+
+```ts
+token.validate('a4kp-9mxa'); // -> { valid: true,  body: 'a4kp9mx' }
+token.validate('a4kp-9mx8'); // -> { valid: false, reason: 'check-failed' }
+token.validate('a4kp-9mxo'); // -> { valid: false, reason: 'outside-alphabet' }
+token.validate('a4kp-9mx'); // -> { valid: false, reason: 'wrong-length' }
+```
+
+| `reason`           | Meaning                                                          |
+| ------------------ | ---------------------------------------------------------------- |
+| `outside-alphabet` | a character not in the dictionary, after separators are stripped |
+| `wrong-length`     | the code is not `length` characters long                         |
+| `check-failed`     | the last character does not check out against the ones before it |
+
+`validate` returns a reason rather than throwing, because it is the cheap gate
+in front of a lookup, not an exceptional path. It is total and free of side
+effects.
+
+**`valid: true` does not mean the code exists**, and it is not authentication.
+One code in `n` passes by construction — one in 32 with the default alphabet.
+Treat it as a filter, never as a credential.
+
+### What the check character catches
+
+Luhn's guarantee, over any alphabet:
+
+- Every single-character substitution, at every position, including the check
+  character itself.
+- Every swap of two adjacent characters, except one pair: the first and last
+  entries of the dictionary — `0` and `z` by default.
+
+That one blind spot is structural. With `g(x) = floor(2x / n) + (2x mod n)`, a
+swap of indices `a` and `b` escapes exactly when `a + g(b) ≡ b + g(a)` (mod n),
+which for even `n` has the single non-trivial solution `{0, n - 1}`. It is the
+textbook mod-10 `{0, 9}` case, generalised.
+
+## Separators are presentation
+
+`generate` chunks `value` and leaves `body` unchunked. `validate` strips the
+separator first, so a code typed without it, or grouped differently, still
+validates:
+
+```ts
+token.validate('a4kp9mxa').valid; // -> true
+token.validate('a4-kp-9m-xa').valid; // -> true
+```
+
+Case is folded too, so a code read off a card in capitals validates:
+
+```ts
+token.validate('A4KP-9MXA'); // -> { valid: true, body: 'a4kp9mx' }
+```
+
+`chunkSize` must divide `length`, or `createToken` throws: a trailing chunk of
+one character is exactly the thing this package exists to avoid. Set
+`chunkSize` equal to `length` for an unchunked code.
+
+```ts
+const short = createToken({ length: 6, chunkSize: 3, separator: ' ' });
+
+short.generate(); // -> { value: 'q7t 3n7', body: 'q7t3n', check: '7', prefix: undefined }
+```
+
+## The prefix sits outside the checksum
+
+`ORD-a4kp-9mxa` checksums `a4kp9mx` only, and `validate` takes the code without
+the prefix:
+
+```ts
+const { value } = token.generate({ prefix: 'ORD' });
+
+token.validate(value); // -> { valid: false, reason: 'outside-alphabet' }
+token.validate(value.slice('ORD-'.length)); // -> { valid: true, ... }
+```
+
+Folding the prefix in would require every prefix character to be in the
+alphabet, and `ORD` contains `o`, which is excluded precisely because it is
+confusable. Comparing the prefix is a literal string match, which is what a
+caller writing `value.startsWith('ORD-')` expects. If you want the prefix
+authenticated, put it in the body.
+
+## Entropy
+
+`length` counts the check character, so usable entropy is
+`(length - 1) * log2(n)`. At the defaults — `length: 8`, `n: 32` — that is
+**35 bits**, and `token.entropyBits` reports it.
+
+35 bits is 34,359,738,368 values. Read that as a collision budget rather than
+as a guess-resistance budget:
+
+- A 50% chance of one collision arrives at about **218,000** codes.
+- At 1,000,000 issued codes a collision is effectively certain.
+
+So uniqueness is a unique index on your table, not a property this generator
+offers. Raise `length` if 218,000 is within reach of your volume; five more
+characters buys 25 more bits.
+
+## The alphabet
+
+The default is 32 characters:
+
+```ts
+token.dictionary; // -> '0123456789abcdefghjkmnpqrstuvxyz'
+token.n; // -> 32
+```
+
+It is the lowercase alphanumerics without `i`, `l`, `o` and `w`. The first
+three go because they are read as `1`, `1` and `0`. `w` goes because it is the
+one English letter whose name is polysyllabic and contains another letter's
+name — "double-u" — which is what breaks it when a code is dictated. `1` and
+`0` survive their own groups because a code is as often typed as spoken, and a
+digit is unambiguous on a keypad.
+
+A dictionary you supply has to satisfy three independent constraints at once,
+all checked by `createToken`:
+
+| Constraint                      | Enforced by     | Why                                    |
+| ------------------------------- | --------------- | -------------------------------------- |
+| no confusable characters        | this package    | `1`/`l`/`i` and `0`/`o` are the point  |
+| lowercase                       | this package    | input is case folded before it is read |
+| `256 % n === 0`                 | this package    | otherwise `byte % n` is biased         |
+| even size, no repeats, no pairs | `@evanion/luhn` | a check character has to be definable  |
+
+```ts
+createToken({ dictionary: '0123456789abcdefghijklmnopqrstuvwxyz' });
+// throws InvalidAlphabetError { reason: 'confusable', offending: ['i', 'l', 'o', 'w'] }
+
+createToken({ dictionary: '0123456789abcdefghjkmnpqrstuvx' });
+// throws InvalidAlphabetError { reason: 'non-uniform' } -- 30 does not divide 256
+```
+
+`256 % n === 0` is the constraint that is easy to miss. `crypto.randomBytes`
+yields 0–255, and `byte % n` over-represents the first `256 % n` characters. At
+n = 32 the division is exact. Luhn's own 36-character default is **not**
+uniform — `256 % 36 === 4`, over-representing its first four characters by
+14.3% — which is why this package does not adopt it.
+
+Rejection sampling is the alternative to constraining the alphabet. It is not
+used here: it makes generation variable-time, and the constraint is
+satisfiable — the default proves it.
+
+The order of the dictionary decides which index each character occupies, and
+therefore every check character it produces. Two alphabets with the same
+characters in a different order are different alphabets.
+
+## API reference
+
+### `createToken(options?)`
+
+Validates the options and returns a frozen `Token`.
+
+- `options.length` — total characters, check character included. Defaults to
+  `8`.
+- `options.chunkSize` — characters between separators. Must divide `length`.
+  Defaults to `4`.
+- `options.separator` — placed between chunks and after a prefix. Must share no
+  character with the dictionary. Defaults to `'-'`.
+- `options.dictionary` — the alphabet. Defaults to `DEFAULT_DICTIONARY`.
+
+### The returned object
+
+- `dictionary: string`
+- `n: number` — characters in the dictionary.
+- `length`, `chunkSize`, `separator` — as configured.
+- `entropyBits: number` — `(length - 1) * log2(n)`.
+- `generate(options?): { value, body, check, prefix }`
+- `validate(input): { valid: true, body } | { valid: false, reason }`
+
+### Constants
+
+- `DEFAULT_DICTIONARY` — the 32 characters above.
+- `CONFUSABLE_CHARACTERS` — `'ilow'`, excluded from every alphabet.
+- `DEFAULT_LENGTH`, `DEFAULT_CHUNK_SIZE`, `DEFAULT_SEPARATOR` — `8`, `4`, `-`.
+
+### Errors
+
+- `TokenError` — base class for everything this package throws.
+- `InvalidAlphabetError extends TokenError` — carries `reason`
+  (`confusable | unfolded | non-uniform`), `dictionary` and `offending`.
+- `InvalidShapeError extends TokenError` — carries `reason` and all three of
+  `length`, `chunkSize`, `separator`.
+
+A dictionary that fails one of Luhn's own constraints throws
+`InvalidDictionaryError` from `@evanion/luhn`, which does not extend
+`TokenError`. Catch `Error` to cover both.
+
+Everything is checked at construction. Nothing is checked at use, so an
+instance you hold cannot produce a code its own `validate` rejects.
+
+## Testing
+
+```bash
+npm test
+```
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/libs/token/eslint.config.mjs
+++ b/libs/token/eslint.config.mjs
@@ -1,0 +1,22 @@
+import baseConfig from '../../eslint.config.mjs';
+
+export default [
+  ...baseConfig,
+  {
+    files: ['**/*.json'],
+    rules: {
+      '@nx/dependency-checks': [
+        'error',
+        {
+          ignoredFiles: [
+            '{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}',
+            '{projectRoot}/vite.config.{js,ts,mjs,mts}',
+          ],
+        },
+      ],
+    },
+    languageOptions: {
+      parser: await import('jsonc-eslint-parser'),
+    },
+  },
+];

--- a/libs/token/package.json
+++ b/libs/token/package.json
@@ -54,9 +54,6 @@
     "access": "public",
     "provenance": true
   },
-  "nx": {
-    "name": "token"
-  },
   "dependencies": {
     "@evanion/luhn": "^2.0.1",
     "tslib": "^2.8.1"

--- a/libs/token/package.json
+++ b/libs/token/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@evanion/token",
+  "version": "0.1.0",
+  "description": "Generate and validate short, human-shareable codes: a confusable-free alphabet, a Luhn check character, and chunking you can read aloud.",
+  "keywords": [
+    "token",
+    "code",
+    "verification-code",
+    "referral-code",
+    "check-digit",
+    "luhn",
+    "crockford",
+    "typescript"
+  ],
+  "homepage": "https://github.com/Evanion/libraries/tree/main/libs/token#readme",
+  "bugs": {
+    "url": "https://github.com/Evanion/libraries/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Evanion/libraries.git",
+    "directory": "libs/token"
+  },
+  "license": "MIT",
+  "author": "Mikael Pettersson",
+  "type": "module",
+  "sideEffects": false,
+  "engines": {
+    "node": ">=20"
+  },
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "@evanion/source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "!dist/**/*.tsbuildinfo",
+    "src",
+    "!src/**/*.test.*",
+    "!src/**/*.spec.*",
+    "!src/**/*.test-d.*",
+    "!src/test-setup.ts",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "nx": {
+    "name": "token"
+  },
+  "dependencies": {
+    "@evanion/luhn": "^2.0.1",
+    "tslib": "^2.8.1"
+  }
+}

--- a/libs/token/package.json
+++ b/libs/token/package.json
@@ -55,7 +55,7 @@
     "provenance": true
   },
   "dependencies": {
-    "@evanion/luhn": "^2.0.1",
+    "@evanion/luhn": "^3.0.0",
     "tslib": "^2.8.1"
   }
 }

--- a/libs/token/src/index.ts
+++ b/libs/token/src/index.ts
@@ -1,0 +1,2 @@
+export * from './lib/token.js';
+export * from './lib/exceptions.js';

--- a/libs/token/src/lib/docs.spec.ts
+++ b/libs/token/src/lib/docs.spec.ts
@@ -1,0 +1,295 @@
+import { createLuhn } from '@evanion/luhn';
+import { describe, expect, it } from 'vitest';
+
+import { InvalidAlphabetError, InvalidShapeError } from './exceptions.js';
+import {
+  CONFUSABLE_CHARACTERS,
+  DEFAULT_CHUNK_SIZE,
+  DEFAULT_DICTIONARY,
+  DEFAULT_LENGTH,
+  DEFAULT_SEPARATOR,
+  createToken,
+} from './token.js';
+
+/**
+ * Every worked example in README.md and in the doc comments, as an assertion.
+ *
+ * A check character cannot be read off a page and cannot be guessed — it is
+ * the output of a fold over a specific alphabet in a specific order. A
+ * documented code with a made-up check character is a lie that ships, and this
+ * file is what stops it.
+ *
+ * `generate` is random, so the documented outputs are pinned through
+ * `validate`, which is the half that is deterministic.
+ */
+describe('the documented examples', () => {
+  const token = createToken();
+
+  describe('README: quick start', () => {
+    it("token.validate('a4kp-9mxa')", () => {
+      expect(token.validate('a4kp-9mxa')).toEqual({
+        valid: true,
+        body: 'a4kp9mx',
+      });
+    });
+
+    it('the generate() result shown alongside it', () => {
+      // value 'a4kp-9mxa', body 'a4kp9mx', check 'a'.
+      expect(token.validate('a4kp9mx' + 'a').valid).toBe(true);
+      expect(`${'a4kp9mx'.slice(0, 4)}-${'a4kp9mx'.slice(4)}a`).toBe(
+        'a4kp-9mxa',
+      );
+    });
+  });
+
+  describe('README: generate a code', () => {
+    it("the prefixed form is 'ORD-a4kp-9mxa'", () => {
+      expect(['ORD', 'a4kp-9mxa'].join(DEFAULT_SEPARATOR)).toBe(
+        'ORD-a4kp-9mxa',
+      );
+      expect(token.validate('a4kp-9mxa').valid).toBe(true);
+    });
+  });
+
+  describe('README: validate a code', () => {
+    it('the four documented outcomes', () => {
+      expect(token.validate('a4kp-9mxa')).toEqual({
+        valid: true,
+        body: 'a4kp9mx',
+      });
+      expect(token.validate('a4kp-9mx8')).toEqual({
+        valid: false,
+        reason: 'check-failed',
+      });
+      expect(token.validate('a4kp-9mxo')).toEqual({
+        valid: false,
+        reason: 'outside-alphabet',
+      });
+      expect(token.validate('a4kp-9mx')).toEqual({
+        valid: false,
+        reason: 'wrong-length',
+      });
+    });
+
+    it('one code in n passes by construction', () => {
+      const passing = [...DEFAULT_DICTIONARY].filter(
+        (candidate) => token.validate(`a4kp9mx${candidate}`).valid,
+      );
+
+      expect(passing).toEqual(['a']);
+      expect(token.n).toBe(32);
+    });
+  });
+
+  describe('README: what the check character catches', () => {
+    it('catches every single-character substitution', () => {
+      const code = 'a4kp9mxa';
+
+      for (let at = 0; at < code.length; at++) {
+        for (const replacement of DEFAULT_DICTIONARY) {
+          if (replacement === code[at]) continue;
+
+          expect(
+            token.validate(code.slice(0, at) + replacement + code.slice(at + 1))
+              .valid,
+          ).toBe(false);
+        }
+      }
+    });
+
+    it('misses a swap of `0` and `z`, and nothing else adjacent', () => {
+      const missed = new Set<string>();
+      const digits = [...DEFAULT_DICTIONARY];
+
+      // Every unordered pair, placed adjacent in an otherwise fixed body.
+      for (let left = 0; left < digits.length; left++) {
+        for (let right = left + 1; right < digits.length; right++) {
+          const body = `abc${digits[left]}${digits[right]}de`;
+          const check = digits.find(
+            (candidate) => token.validate(body + candidate).valid,
+          ) as string;
+          const swapped = `abc${digits[right]}${digits[left]}de${check}`;
+
+          if (token.validate(swapped).valid) {
+            missed.add(`${digits[left]}${digits[right]}`);
+          }
+        }
+      }
+
+      expect([...missed]).toEqual(['0z']);
+    });
+
+    it('the first and last dictionary entries are `0` and `z`', () => {
+      expect(DEFAULT_DICTIONARY.at(0)).toBe('0');
+      expect(DEFAULT_DICTIONARY.at(-1)).toBe('z');
+    });
+  });
+
+  describe('README: separators are presentation', () => {
+    it('a code validates however it is grouped, and in capitals', () => {
+      expect(token.validate('a4kp9mxa').valid).toBe(true);
+      expect(token.validate('a4-kp-9m-xa').valid).toBe(true);
+      expect(token.validate('A4KP-9MXA')).toEqual({
+        valid: true,
+        body: 'a4kp9mx',
+      });
+    });
+
+    it("the short configuration produces 'q7t 3n7'", () => {
+      const short = createToken({ length: 6, chunkSize: 3, separator: ' ' });
+
+      expect(short.validate('q7t 3n7')).toEqual({ valid: true, body: 'q7t3n' });
+      expect(`${'q7t3n'.slice(0, 3)} ${'q7t3n'.slice(3)}7`).toBe('q7t 3n7');
+    });
+  });
+
+  describe('README: the prefix sits outside the checksum', () => {
+    it('validate rejects the prefixed value and accepts the stripped one', () => {
+      const value = 'ORD-a4kp-9mxa';
+
+      expect(token.validate(value)).toEqual({
+        valid: false,
+        reason: 'outside-alphabet',
+      });
+      expect(token.validate(value.slice('ORD-'.length))).toEqual({
+        valid: true,
+        body: 'a4kp9mx',
+      });
+    });
+
+    it('`ORD` contains a character the alphabet excludes', () => {
+      expect(DEFAULT_DICTIONARY).not.toContain('o');
+      expect(CONFUSABLE_CHARACTERS).toContain('o');
+    });
+  });
+
+  describe('README: entropy', () => {
+    it('35 bits at the defaults', () => {
+      expect(token.entropyBits).toBe(35);
+      expect((DEFAULT_LENGTH - 1) * Math.log2(32)).toBe(35);
+      expect(2 ** 35).toBe(34_359_738_368);
+    });
+
+    it('a 50% collision chance at about 218,000 codes', () => {
+      const half = Math.sqrt(2 * Math.LN2 * 2 ** 35);
+
+      expect(Math.round(half / 1_000) * 1_000).toBe(218_000);
+    });
+
+    it('a collision is effectively certain at 1,000,000 codes', () => {
+      const certainty = 1 - Math.exp(-(1_000_000 ** 2) / (2 * 2 ** 35));
+
+      expect(certainty).toBeGreaterThan(0.999_999);
+    });
+
+    it('five more characters buys 25 more bits', () => {
+      expect(createToken({ length: 13, chunkSize: 13 }).entropyBits).toBe(60);
+    });
+  });
+
+  describe('README: the alphabet', () => {
+    it('the default', () => {
+      expect(token.dictionary).toBe('0123456789abcdefghjkmnpqrstuvxyz');
+      expect(token.n).toBe(32);
+      expect(DEFAULT_DICTIONARY).toBe('0123456789abcdefghjkmnpqrstuvxyz');
+      expect(CONFUSABLE_CHARACTERS).toBe('ilow');
+    });
+
+    it('the documented defaults', () => {
+      expect([DEFAULT_LENGTH, DEFAULT_CHUNK_SIZE, DEFAULT_SEPARATOR]).toEqual([
+        8,
+        4,
+        '-',
+      ]);
+      expect(token.length).toBe(8);
+      expect(token.chunkSize).toBe(4);
+      expect(token.separator).toBe('-');
+    });
+
+    it('a confusable dictionary is rejected at construction', () => {
+      try {
+        createToken({ dictionary: '0123456789abcdefghijklmnopqrstuvwxyz' });
+        expect.unreachable('the documented call must throw');
+      } catch (error) {
+        expect(error).toBeInstanceOf(InvalidAlphabetError);
+        expect(error).toMatchObject({
+          reason: 'confusable',
+          offending: ['i', 'l', 'o', 'w'],
+        });
+      }
+    });
+
+    it('a 30-character dictionary is rejected as non-uniform', () => {
+      try {
+        createToken({ dictionary: '0123456789abcdefghjkmnpqrstuvx' });
+        expect.unreachable('the documented call must throw');
+      } catch (error) {
+        expect(error).toBeInstanceOf(InvalidAlphabetError);
+        expect(error).toMatchObject({ reason: 'non-uniform' });
+      }
+      expect([...'0123456789abcdefghjkmnpqrstuvx']).toHaveLength(30);
+      expect(256 % 30).not.toBe(0);
+    });
+
+    it("Luhn's 36-character default over-represents four characters by 14.3%", () => {
+      const luhn = createLuhn();
+
+      expect(luhn.uniformOverBytes).toBe(false);
+      expect(256 % luhn.n).toBe(4);
+      // Four indices are hit by 8 of the 256 bytes, the other 32 by 7.
+      expect(Math.round((8 / 7 - 1) * 1000) / 10).toBe(14.3);
+    });
+
+    it('the default alphabet is uniform', () => {
+      expect(256 % token.n).toBe(0);
+      expect(
+        createLuhn({ dictionary: DEFAULT_DICTIONARY }).uniformOverBytes,
+      ).toBe(true);
+    });
+  });
+
+  describe('README: chunking', () => {
+    it('chunkSize must divide length', () => {
+      expect(() => createToken({ length: 6 })).toThrow(InvalidShapeError);
+      expect(() => createToken({ length: 6, chunkSize: 3 })).not.toThrow();
+    });
+
+    it('chunkSize equal to length produces an unchunked code', () => {
+      const unchunked = createToken({ chunkSize: 8 });
+
+      expect(unchunked.generate().value).not.toContain('-');
+    });
+  });
+
+  describe('doc comments', () => {
+    it('createToken', () => {
+      const instance = createToken();
+
+      expect(instance.validate('a4kp-9mxa')).toEqual({
+        valid: true,
+        body: 'a4kp9mx',
+      });
+      expect(instance.validate('a4kp-9mx8')).toEqual({
+        valid: false,
+        reason: 'check-failed',
+      });
+    });
+
+    it('DEFAULT_DICTIONARY is the lowercase alphanumerics less `i`, `l`, `o`, `w`', () => {
+      const removed = [...'0123456789abcdefghijklmnopqrstuvwxyz'].filter(
+        (char) => !DEFAULT_DICTIONARY.includes(char),
+      );
+
+      expect(removed).toEqual(['i', 'l', 'o', 'w']);
+      expect([...DEFAULT_DICTIONARY]).toHaveLength(32);
+    });
+
+    it('Token.entropyBits is (length - 1) * log2(n)', () => {
+      for (const length of [2, 8, 12, 16]) {
+        expect(createToken({ length, chunkSize: length }).entropyBits).toBe(
+          (length - 1) * 5,
+        );
+      }
+    });
+  });
+});

--- a/libs/token/src/lib/exceptions.spec.ts
+++ b/libs/token/src/lib/exceptions.spec.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  InvalidAlphabetError,
+  InvalidShapeError,
+  TokenError,
+} from './exceptions.js';
+
+const SHAPE = { length: 8, chunkSize: 4, separator: '-' };
+
+describe('TokenError', () => {
+  it('should be an Error', () => {
+    const error = new TokenError('boom');
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe('boom');
+    expect(error.name).toBe('TokenError');
+  });
+});
+
+describe('InvalidAlphabetError', () => {
+  it('should be a TokenError carrying a name matching the class', () => {
+    const error = new InvalidAlphabetError('non-uniform', 'abcdef');
+
+    expect(error).toBeInstanceOf(TokenError);
+    expect(error.name).toBe('InvalidAlphabetError');
+    expect(error.constructor.name).toBe('InvalidAlphabetError');
+  });
+
+  it('should carry the reason, the dictionary and the offending code points', () => {
+    const error = new InvalidAlphabetError('confusable', 'abcilo', [
+      'i',
+      'l',
+      'o',
+    ]);
+
+    expect(error.reason).toBe('confusable');
+    expect(error.dictionary).toBe('abcilo');
+    expect(error.offending).toEqual(['i', 'l', 'o']);
+  });
+
+  it('should default offending to empty, for the constraints no character owns', () => {
+    expect(new InvalidAlphabetError('non-uniform', 'abcdef').offending).toEqual(
+      [],
+    );
+  });
+
+  it('should name the offending code points in the message', () => {
+    expect(
+      new InvalidAlphabetError('confusable', 'abcilo', ['i', 'l']).message,
+    ).toContain('"i", "l"');
+    expect(
+      new InvalidAlphabetError('unfolded', 'ABCDEF', ['A']).message,
+    ).toContain('"A"');
+  });
+
+  it('should count the dictionary by code point in the non-uniform message', () => {
+    // 6 code points written as 12 UTF-16 units: the message reports what a
+    // reader would count, not what `String#length` returns.
+    expect(
+      new InvalidAlphabetError('non-uniform', '😀😁😂😃😄😅').message,
+    ).toContain('6 does not');
+  });
+});
+
+describe('InvalidShapeError', () => {
+  it('should be a TokenError carrying a name matching the class', () => {
+    const error = new InvalidShapeError('length', SHAPE);
+
+    expect(error).toBeInstanceOf(TokenError);
+    expect(error.name).toBe('InvalidShapeError');
+    expect(error.constructor.name).toBe('InvalidShapeError');
+  });
+
+  it('should carry all three shape values, not only the one it names', () => {
+    const error = new InvalidShapeError('chunk-size-indivisible', {
+      length: 6,
+      chunkSize: 4,
+      separator: '/',
+    });
+
+    expect(error.reason).toBe('chunk-size-indivisible');
+    expect(error.length).toBe(6);
+    expect(error.chunkSize).toBe(4);
+    expect(error.separator).toBe('/');
+  });
+
+  it('should describe each reason distinctly', () => {
+    const messages = (
+      [
+        'length',
+        'chunk-size',
+        'chunk-size-indivisible',
+        'separator-empty',
+        'separator-in-dictionary',
+      ] as const
+    ).map((reason) => new InvalidShapeError(reason, SHAPE).message);
+
+    expect(new Set(messages).size).toBe(messages.length);
+    for (const message of messages) expect(message.length).toBeGreaterThan(0);
+  });
+});

--- a/libs/token/src/lib/exceptions.ts
+++ b/libs/token/src/lib/exceptions.ts
@@ -1,0 +1,140 @@
+/**
+ * Every error this library throws is raised by `createToken`. `generate` and
+ * `validate` are total: an accepted configuration cannot fail at use.
+ */
+
+const codePointList = (offending: readonly string[]): string =>
+  offending.map((entry) => JSON.stringify(entry)).join(', ');
+
+/**
+ * Base class for every error this library throws.
+ *
+ * ```ts
+ * try {
+ *   createToken(options);
+ * } catch (error) {
+ *   if (error instanceof TokenError) {
+ *     // the configuration is unusable
+ *   }
+ * }
+ * ```
+ *
+ * A dictionary that fails one of Luhn's own constraints throws
+ * `InvalidDictionaryError` from `@evanion/luhn` instead, which does not extend
+ * this class. Catch `Error` to cover both.
+ */
+export class TokenError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TokenError';
+  }
+}
+
+/** Which of token's own dictionary constraints the alphabet failed. */
+export type InvalidDictionaryReason = 'confusable' | 'unfolded' | 'non-uniform';
+
+const dictionaryMessage = (
+  reason: InvalidDictionaryReason,
+  dictionary: string,
+  offending: readonly string[],
+): string => {
+  switch (reason) {
+    case 'confusable':
+      return `Token dictionary must not contain characters that are confused when read or heard; found: ${codePointList(offending)}.`;
+    case 'unfolded':
+      return `Token dictionary must be lowercase, or case folding makes the entry unreachable; found: ${codePointList(offending)}.`;
+    case 'non-uniform':
+      return `Token dictionary must contain a number of code points that divides 256, so that every character is equally likely; ${[...dictionary].length} does not.`;
+  }
+};
+
+/**
+ * Thrown by `createToken` for the dictionary constraints token owns:
+ * legibility, reachability under case folding, and uniform sampling from a
+ * random byte.
+ *
+ * The remaining constraints — even length, no duplicates, no case pairs — are
+ * Luhn's, and `@evanion/luhn` reports them as its own `InvalidDictionaryError`.
+ *
+ * One class carrying a `reason` rather than one class per constraint, so a
+ * caller that only wants to know whether an alphabet is acceptable writes one
+ * `catch` arm.
+ */
+export class InvalidAlphabetError extends TokenError {
+  readonly reason: InvalidDictionaryReason;
+  readonly dictionary: string;
+  /**
+   * The code points the constraint named, empty for `non-uniform`, which is a
+   * property of the dictionary's size rather than of any one character.
+   */
+  readonly offending: readonly string[];
+
+  constructor(
+    reason: InvalidDictionaryReason,
+    dictionary: string,
+    offending: readonly string[] = [],
+  ) {
+    super(dictionaryMessage(reason, dictionary, offending));
+    this.name = 'InvalidAlphabetError';
+    this.reason = reason;
+    this.dictionary = dictionary;
+    this.offending = offending;
+  }
+}
+
+/** Which of the three shape options `createToken` rejected, and why. */
+export type InvalidShapeReason =
+  | 'length'
+  | 'chunk-size'
+  | 'chunk-size-indivisible'
+  | 'separator-empty'
+  | 'separator-in-dictionary';
+
+const shapeMessage = (
+  reason: InvalidShapeReason,
+  shape: TokenShape,
+): string => {
+  switch (reason) {
+    case 'length':
+      return `Token length must be an integer of at least 2 — one payload character and one check character — received ${shape.length}.`;
+    case 'chunk-size':
+      return `Token chunkSize must be an integer of at least 1, received ${shape.chunkSize}.`;
+    case 'chunk-size-indivisible':
+      return `Token chunkSize must divide length, or the last chunk is shorter than the rest; ${shape.chunkSize} does not divide ${shape.length}.`;
+    case 'separator-empty':
+      return 'Token separator must be a non-empty string; set chunkSize to length for an unchunked token.';
+    case 'separator-in-dictionary':
+      return `Token separator must share no code point with the dictionary, or validate cannot strip it; ${JSON.stringify(shape.separator)} does.`;
+  }
+};
+
+/** The three options that decide how a token is laid out, as supplied. */
+export interface TokenShape {
+  length: number;
+  chunkSize: number;
+  separator: string;
+}
+
+/**
+ * Thrown by `createToken` when `length`, `chunkSize` or `separator` cannot
+ * describe a token.
+ *
+ * It carries all three rather than only the offending one: the constraints are
+ * relations between them, so the value that has to change is not always the
+ * value the `reason` names.
+ */
+export class InvalidShapeError extends TokenError {
+  readonly reason: InvalidShapeReason;
+  readonly length: number;
+  readonly chunkSize: number;
+  readonly separator: string;
+
+  constructor(reason: InvalidShapeReason, shape: TokenShape) {
+    super(shapeMessage(reason, shape));
+    this.name = 'InvalidShapeError';
+    this.reason = reason;
+    this.length = shape.length;
+    this.chunkSize = shape.chunkSize;
+    this.separator = shape.separator;
+  }
+}

--- a/libs/token/src/lib/token.spec.ts
+++ b/libs/token/src/lib/token.spec.ts
@@ -1,0 +1,469 @@
+import { InvalidDictionaryError } from '@evanion/luhn';
+import { describe, expect, it } from 'vitest';
+
+import { InvalidAlphabetError, InvalidShapeError } from './exceptions.js';
+import {
+  CONFUSABLE_CHARACTERS,
+  DEFAULT_CHUNK_SIZE,
+  DEFAULT_DICTIONARY,
+  DEFAULT_LENGTH,
+  DEFAULT_SEPARATOR,
+  createToken,
+} from './token.js';
+
+const token = createToken();
+const alphabet = [...DEFAULT_DICTIONARY];
+
+/**
+ * 30 code points, none of them confusable, and 256 % 30 === 16. It isolates
+ * the uniformity constraint from the other two.
+ */
+const NON_UNIFORM_DICTIONARY = '0123456789abcdefghjkmnpqrstuvx';
+
+/** Strips the separators from a generated `value`, leaving the raw code. */
+const raw = (value: string): string => value.split(DEFAULT_SEPARATOR).join('');
+
+/**
+ * The check character `body` must carry, found by asking the instance which
+ * candidate checks out.
+ *
+ * Recomputing Luhn's fold here would only test a second copy of it; probing
+ * `validate` tests the instance under test, and there are only `n` candidates.
+ */
+const checkCharacterFor = (body: string): string => {
+  const instance = createToken({ length: body.length + 1 });
+  const found = alphabet.find(
+    (candidate) => instance.validate(body + candidate).valid,
+  );
+
+  if (found === undefined) {
+    throw new Error(`no check character checks out for ${body}`);
+  }
+  return found;
+};
+
+/** `body` with its check character appended, unchunked. */
+const codeFor = (body: string): string => body + checkCharacterFor(body);
+
+describe('createToken', () => {
+  describe('the constructed instance', () => {
+    it('should expose the configuration it was given', () => {
+      expect(token.dictionary).toBe(DEFAULT_DICTIONARY);
+      expect(token.n).toBe(32);
+      expect(token.length).toBe(DEFAULT_LENGTH);
+      expect(token.chunkSize).toBe(DEFAULT_CHUNK_SIZE);
+      expect(token.separator).toBe(DEFAULT_SEPARATOR);
+    });
+
+    it('should report usable entropy excluding the check character', () => {
+      expect(token.entropyBits).toBe(35);
+      expect(createToken({ length: 12 }).entropyBits).toBe(55);
+    });
+
+    it('should be frozen', () => {
+      expect(Object.isFrozen(token)).toBe(true);
+      expect(() => {
+        (token as { length: number }).length = 99;
+      }).toThrow(TypeError);
+    });
+  });
+
+  describe('the default dictionary', () => {
+    it('should be 32 distinct lowercase code points', () => {
+      expect(alphabet).toHaveLength(32);
+      expect(new Set(alphabet).size).toBe(32);
+      expect(DEFAULT_DICTIONARY).toBe(DEFAULT_DICTIONARY.toLowerCase());
+    });
+
+    it('should exclude every confusable character', () => {
+      for (const char of CONFUSABLE_CHARACTERS) {
+        expect(DEFAULT_DICTIONARY).not.toContain(char);
+      }
+    });
+
+    it('should divide 256, so byte % n is unbiased', () => {
+      expect(256 % alphabet.length).toBe(0);
+    });
+  });
+});
+
+describe('generate', () => {
+  it('should return the code in both its chunked and unchunked forms', () => {
+    const { value, body, check, prefix } = token.generate();
+
+    expect(body).toHaveLength(DEFAULT_LENGTH - 1);
+    expect(check).toHaveLength(1);
+    expect(value).toBe(
+      `${body.slice(0, 4)}${DEFAULT_SEPARATOR}${body.slice(4)}${check}`,
+    );
+    expect(prefix).toBeUndefined();
+  });
+
+  it('should draw every character from the dictionary', () => {
+    const { body, check } = token.generate();
+
+    for (const char of body + check) {
+      expect(DEFAULT_DICTIONARY).toContain(char);
+    }
+  });
+
+  it('should write the prefix ahead of the code, separated', () => {
+    const { value, body, check, prefix } = token.generate({ prefix: 'ORD' });
+
+    expect(prefix).toBe('ORD');
+    expect(value.startsWith('ORD-')).toBe(true);
+    expect(raw(value.slice('ORD-'.length))).toBe(body + check);
+  });
+
+  it('should emit one chunk when chunkSize equals length', () => {
+    const { value } = createToken({ chunkSize: DEFAULT_LENGTH }).generate();
+
+    expect(value).not.toContain(DEFAULT_SEPARATOR);
+    expect(value).toHaveLength(DEFAULT_LENGTH);
+  });
+
+  it('should chunk a longer code evenly', () => {
+    const long = createToken({ length: 12, chunkSize: 3 });
+    const widths = long
+      .generate()
+      .value.split(DEFAULT_SEPARATOR)
+      .map((chunk) => chunk.length);
+
+    expect(widths).toEqual([3, 3, 3, 3]);
+  });
+
+  it('should produce a code its own validate accepts, over 10,000 draws', () => {
+    const rejected: string[] = [];
+
+    for (let draw = 0; draw < 10_000; draw++) {
+      const { value } = token.generate();
+      if (!token.validate(value).valid) rejected.push(value);
+    }
+
+    expect(rejected).toEqual([]);
+  });
+
+  it('should compute the check character from the body alone', () => {
+    // The prefix sits outside the checksum, so one body carries one check
+    // character no matter what is written in front of it.
+    for (const prefix of ['ORD', 'INVOICE-2026', '']) {
+      for (let draw = 0; draw < 200; draw++) {
+        const { body, check, value } = token.generate({ prefix });
+
+        expect(check).toBe(checkCharacterFor(body));
+        expect(value.endsWith(check)).toBe(true);
+        expect(token.validate(body + check)).toEqual({ valid: true, body });
+      }
+    }
+  });
+});
+
+describe('the check character', () => {
+  it('should catch a single-character substitution anywhere in the code', () => {
+    const accepted: string[] = [];
+
+    for (let draw = 0; draw < 500; draw++) {
+      const code = raw(token.generate().value);
+
+      for (let at = 0; at < code.length; at++) {
+        for (const replacement of alphabet) {
+          if (replacement === code[at]) continue;
+
+          const mutated = code.slice(0, at) + replacement + code.slice(at + 1);
+          if (token.validate(mutated).valid) accepted.push(mutated);
+        }
+      }
+    }
+
+    expect(accepted).toEqual([]);
+  });
+
+  it('should catch every adjacent transposition but the one pair it cannot', () => {
+    const missed = new Set<string>();
+
+    for (let draw = 0; draw < 2_000; draw++) {
+      const code = raw(token.generate().value);
+
+      for (let at = 0; at + 1 < code.length; at++) {
+        const left = code[at] as string;
+        const right = code[at + 1] as string;
+        if (left === right) continue;
+
+        const swapped = code.slice(0, at) + right + left + code.slice(at + 2);
+        if (token.validate(swapped).valid) {
+          missed.add([left, right].sort().join(''));
+        }
+      }
+    }
+
+    expect([...missed].filter((pair) => pair !== '0z')).toEqual([]);
+  });
+
+  it('should miss a swap of the first and last dictionary entries', () => {
+    // A fixed vector: at 1 pair in C(32, 2) = 496 per adjacent slot, a random
+    // body would essentially never place `0` beside `z`, and a negative case
+    // that never fires is worse than no case at all.
+    for (const body of ['0zabcde', 'a0zbcde', 'abc0zde', 'abcde0z']) {
+      const code = codeFor(body);
+      const at = body.indexOf('0z');
+      const swapped = code.slice(0, at) + 'z0' + code.slice(at + 2);
+
+      expect(swapped).not.toBe(code);
+      expect(token.validate(code)).toEqual({ valid: true, body });
+      expect(token.validate(swapped).valid).toBe(true);
+    }
+  });
+
+  it('should miss that pair in either order', () => {
+    // The blind spot is a property of the two dictionary indices, not of which
+    // one comes first.
+    const body = 'az0bcde';
+    const code = codeFor(body);
+    const at = body.indexOf('z0');
+
+    expect(
+      token.validate(code.slice(0, at) + '0z' + code.slice(at + 2)).valid,
+    ).toBe(true);
+  });
+});
+
+describe('uniformity', () => {
+  it('should draw every character within 10% of 1/n over 100,000 codes', () => {
+    // 10% is about 1.5x the worst deviation measured over 100 independent runs
+    // of this size, while the n = 36 alphabet below misses by ~13%. The bound
+    // separates the two without being flaky.
+    const counts = new Map(alphabet.map((char) => [char, 0]));
+    let total = 0;
+
+    for (let draw = 0; draw < 100_000; draw++) {
+      for (const char of token.generate().body) {
+        counts.set(char, (counts.get(char) as number) + 1);
+        total++;
+      }
+    }
+
+    const expected = total / alphabet.length;
+    const worst = Math.max(
+      ...[...counts.values()].map(
+        (count) => Math.abs(count - expected) / expected,
+      ),
+    );
+
+    expect(worst).toBeLessThanOrEqual(0.1);
+  });
+
+  it('should reject an alphabet that would bias byte % n', () => {
+    expect(() => createToken({ dictionary: NON_UNIFORM_DICTIONARY })).toThrow(
+      InvalidAlphabetError,
+    );
+    expect(() => createToken({ dictionary: NON_UNIFORM_DICTIONARY })).toThrow(
+      /divides 256/,
+    );
+  });
+});
+
+describe('validate', () => {
+  it('should accept a code however its separators are placed', () => {
+    const { value, body, check } = token.generate();
+    const code = body + check;
+    const expected = { valid: true, body };
+
+    expect(token.validate(value)).toEqual(expected);
+    expect(token.validate(code)).toEqual(expected);
+    expect(token.validate(value.replace('-', '--'))).toEqual(expected);
+    expect(token.validate([...code].join('-'))).toEqual(expected);
+    expect(token.validate(`-${code}-`)).toEqual(expected);
+  });
+
+  it('should fold case', () => {
+    const { value, body } = token.generate();
+
+    expect(token.validate(value.toUpperCase())).toEqual({ valid: true, body });
+  });
+
+  it('should report outside-alphabet for a character not in the dictionary', () => {
+    for (const intruder of ['o', 'i', 'l', 'w', '!', 'é']) {
+      const { body, check } = token.generate();
+
+      expect(token.validate(body.slice(1) + intruder + check)).toEqual({
+        valid: false,
+        reason: 'outside-alphabet',
+      });
+    }
+  });
+
+  it('should report outside-alphabet before wrong-length', () => {
+    expect(token.validate('oo')).toEqual({
+      valid: false,
+      reason: 'outside-alphabet',
+    });
+  });
+
+  it('should report wrong-length for a code of the wrong size', () => {
+    const { value } = token.generate();
+
+    expect(token.validate(value.slice(0, -1))).toEqual({
+      valid: false,
+      reason: 'wrong-length',
+    });
+    expect(token.validate(`${raw(value)}0`)).toEqual({
+      valid: false,
+      reason: 'wrong-length',
+    });
+    expect(token.validate('')).toEqual({
+      valid: false,
+      reason: 'wrong-length',
+    });
+  });
+
+  it('should report check-failed for a well-shaped code that does not check out', () => {
+    const { body, check } = token.generate();
+    const wrong = alphabet.find((char) => char !== check) as string;
+
+    expect(token.validate(body + wrong)).toEqual({
+      valid: false,
+      reason: 'check-failed',
+    });
+  });
+
+  it('should reject a prefixed value, which is the caller to strip', () => {
+    const { value } = token.generate({ prefix: 'ORD' });
+
+    expect(token.validate(value)).toEqual({
+      valid: false,
+      reason: 'outside-alphabet',
+    });
+  });
+});
+
+describe('dictionary constraints', () => {
+  it('should reject a dictionary that is valid for Luhn but confusable', () => {
+    // 36 lowercase alphanumerics: even, no repeats, no case pairs, so Luhn is
+    // satisfied -- and `i`, `l`, `o` and `w` are all still in it.
+    try {
+      createToken({ dictionary: '0123456789abcdefghijklmnopqrstuvwxyz' });
+      expect.unreachable('a confusable dictionary must not be accepted');
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidAlphabetError);
+      expect(error).toMatchObject({
+        reason: 'confusable',
+        offending: ['i', 'l', 'o', 'w'],
+      });
+    }
+  });
+
+  it('should reject a dictionary that is unconfusable but not uniform', () => {
+    try {
+      createToken({ dictionary: NON_UNIFORM_DICTIONARY });
+      expect.unreachable('a biased dictionary must not be accepted');
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidAlphabetError);
+      expect(error).toMatchObject({ reason: 'non-uniform', offending: [] });
+    }
+  });
+
+  it('should reject an uppercase dictionary, which case folding cannot reach', () => {
+    try {
+      createToken({ dictionary: DEFAULT_DICTIONARY.toUpperCase() });
+      expect.unreachable('an uppercase dictionary must not be accepted');
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidAlphabetError);
+      expect(error).toMatchObject({ reason: 'unfolded' });
+    }
+  });
+
+  it("should let Luhn's own constraints throw", () => {
+    // 31 code points: odd, so no check character is definable over it. The
+    // error comes from `@evanion/luhn`, not from this package.
+    expect(() =>
+      createToken({ dictionary: '0123456789abcdefghjkmnpqrstuvxy' }),
+    ).toThrow(InvalidDictionaryError);
+    expect(() => createToken({ dictionary: '0011' })).toThrow(
+      InvalidDictionaryError,
+    );
+    expect(() => createToken({ dictionary: '0' })).toThrow(
+      InvalidDictionaryError,
+    );
+  });
+
+  it('should accept a reordering of the default', () => {
+    // The order decides which index each character occupies, so a reordering
+    // is a different alphabet -- and an equally valid one.
+    const reordered = createToken({
+      dictionary: [...DEFAULT_DICTIONARY].reverse().join(''),
+    });
+
+    expect(reordered.n).toBe(32);
+    expect(reordered.validate(reordered.generate().value).valid).toBe(true);
+  });
+});
+
+describe('shape constraints', () => {
+  const shapeReason = (options: Parameters<typeof createToken>[0]): string => {
+    try {
+      createToken(options);
+      return 'accepted';
+    } catch (error) {
+      return (error as InvalidShapeError).reason;
+    }
+  };
+
+  it('should reject a length that cannot carry a payload and a check', () => {
+    expect(shapeReason({ length: 1, chunkSize: 1 })).toBe('length');
+    expect(shapeReason({ length: 0, chunkSize: 1 })).toBe('length');
+    expect(shapeReason({ length: 8.5, chunkSize: 1 })).toBe('length');
+    expect(shapeReason({ length: Number.NaN, chunkSize: 1 })).toBe('length');
+  });
+
+  it('should reject a chunk size that is not a positive integer', () => {
+    expect(shapeReason({ chunkSize: 0 })).toBe('chunk-size');
+    expect(shapeReason({ chunkSize: -4 })).toBe('chunk-size');
+    expect(shapeReason({ chunkSize: 2.5 })).toBe('chunk-size');
+  });
+
+  it('should reject a chunk size that leaves a short trailing chunk', () => {
+    expect(shapeReason({ length: 6 })).toBe('chunk-size-indivisible');
+    expect(shapeReason({ length: 10, chunkSize: 3 })).toBe(
+      'chunk-size-indivisible',
+    );
+    expect(shapeReason({ length: 10, chunkSize: 5 })).toBe('accepted');
+  });
+
+  it('should reject a separator validate could not strip', () => {
+    expect(shapeReason({ separator: '' })).toBe('separator-empty');
+    expect(shapeReason({ separator: 'a' })).toBe('separator-in-dictionary');
+    expect(shapeReason({ separator: ' - ' })).toBe('accepted');
+    expect(shapeReason({ separator: '.' })).toBe('accepted');
+  });
+
+  it('should carry all three shape values on the error', () => {
+    try {
+      createToken({ length: 6, chunkSize: 4, separator: '/' });
+      expect.unreachable('6 is not a multiple of 4');
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidShapeError);
+      expect(error).toMatchObject({
+        reason: 'chunk-size-indivisible',
+        length: 6,
+        chunkSize: 4,
+        separator: '/',
+      });
+    }
+  });
+
+  it('should round-trip a fully custom configuration', () => {
+    const custom = createToken({
+      length: 10,
+      chunkSize: 5,
+      separator: '.',
+      dictionary: [...DEFAULT_DICTIONARY].reverse().join(''),
+    });
+    const { value, body } = custom.generate({ prefix: 'REF' });
+
+    expect(value.startsWith('REF.')).toBe(true);
+    expect(custom.validate(value.slice('REF.'.length))).toEqual({
+      valid: true,
+      body,
+    });
+  });
+});

--- a/libs/token/src/lib/token.ts
+++ b/libs/token/src/lib/token.ts
@@ -1,0 +1,338 @@
+import { createLuhn } from '@evanion/luhn';
+import { randomBytes } from 'node:crypto';
+
+import { InvalidAlphabetError, InvalidShapeError } from './exceptions.js';
+
+/* -------------------------------------------------------------------------
+ * Defaults
+ * ---------------------------------------------------------------------- */
+
+/**
+ * 32 characters: the lowercase alphanumerics without `i`, `l`, `o` and `w`.
+ *
+ * Each removal drops a character a person confuses with another: `i` and `l`
+ * read as `1`, `o` reads as `0`, and `w` is the one English letter whose name
+ * is polysyllabic and contains another letter's name — "double-u" — which is
+ * what breaks it when a code is dictated.
+ *
+ * 32 is not an accident either. It is even and free of case pairs, so
+ * `@evanion/luhn` can compute a check character over it, and it divides 256,
+ * so `byte % 32` draws every character with equal probability.
+ */
+export const DEFAULT_DICTIONARY = '0123456789abcdefghjkmnpqrstuvxyz';
+
+/**
+ * Characters excluded from every token alphabet, matched without regard to
+ * case.
+ *
+ * `1` and `0` survive their groups because a code is as often typed as it is
+ * spoken, and a digit reads unambiguously on a keypad.
+ */
+export const CONFUSABLE_CHARACTERS = 'ilow';
+
+/** Total code points in a token, the check character included. */
+export const DEFAULT_LENGTH = 8;
+
+/** Code points between separators. Divides {@link DEFAULT_LENGTH} exactly. */
+export const DEFAULT_CHUNK_SIZE = 4;
+
+/** Placed between chunks, and between a prefix and the code. */
+export const DEFAULT_SEPARATOR = '-';
+
+/* -------------------------------------------------------------------------
+ * Types
+ * ---------------------------------------------------------------------- */
+
+export interface TokenOptions {
+  /**
+   * Total code points in the code, the check character included, so usable
+   * entropy is `(length - 1) * log2(dictionary size)`.
+   *
+   * Defaults to {@link DEFAULT_LENGTH}.
+   */
+  length?: number;
+  /**
+   * Code points between separators. Must divide `length`: a trailing chunk
+   * shorter than the rest is the thing that is hard to read aloud.
+   *
+   * Set it equal to `length` for an unchunked code. Defaults to
+   * {@link DEFAULT_CHUNK_SIZE}, which does not divide every `length` — a
+   * `length` that is not a multiple of 4 has to name its own `chunkSize`.
+   */
+  chunkSize?: number;
+  /**
+   * Placed between chunks, and between a prefix and the code. Must share no
+   * code point with the dictionary, so that `validate` can strip it.
+   *
+   * Defaults to {@link DEFAULT_SEPARATOR}.
+   */
+  separator?: string;
+  /**
+   * The alphabet. Must be free of confusable characters, lowercase, and of a
+   * size that both divides 256 and satisfies Luhn: even, no repeats.
+   *
+   * Defaults to {@link DEFAULT_DICTIONARY}.
+   */
+  dictionary?: string;
+}
+
+/** Options `generate` takes per call. */
+export interface GenerateOptions {
+  /**
+   * Written ahead of the code, separated by `separator`, and left out of the
+   * checksum. Compared by literal string match, which is what a caller reading
+   * `value.startsWith('ORD-')` expects.
+   */
+  prefix?: string;
+}
+
+/** A freshly minted code, in the two forms a caller needs. */
+export interface GenerateResult {
+  /** The code as a person sees it: prefix, chunks and separators. */
+  value: string;
+  /** The payload the check character was computed over, unchunked. */
+  body: string;
+  /** The check character, one code point of the dictionary. */
+  check: string;
+  /** Echoed from the call, `undefined` when none was given. */
+  prefix: string | undefined;
+}
+
+/** Why a code is not well formed. */
+export type ValidateFailureReason =
+  /** A code point outside the dictionary, after separators are stripped. */
+  | 'outside-alphabet'
+  /** The stripped code is not `length` code points long. */
+  | 'wrong-length'
+  /** The last code point does not check out against the ones before it. */
+  | 'check-failed';
+
+/** A code that is well formed. It does not follow that the code exists. */
+export interface ValidToken {
+  valid: true;
+  /** The code without its check character, case folded. */
+  body: string;
+}
+
+/** A code that is not well formed, and the first constraint it failed. */
+export interface InvalidToken {
+  valid: false;
+  reason: ValidateFailureReason;
+}
+
+export type ValidateResult = ValidToken | InvalidToken;
+
+/** A configuration with `generate` and `validate` bound to it. */
+export interface Token {
+  readonly dictionary: string;
+  /** Code points in the dictionary. */
+  readonly n: number;
+  readonly length: number;
+  readonly chunkSize: number;
+  readonly separator: string;
+  /** Usable entropy in bits: `(length - 1) * log2(n)`. */
+  readonly entropyBits: number;
+
+  /**
+   * Draws a new code from `crypto.randomBytes` and appends its check
+   * character.
+   *
+   * It never retries and never checks for collisions. Uniqueness is a database
+   * constraint, not a property a generator can offer.
+   */
+  generate(options?: GenerateOptions): GenerateResult;
+
+  /**
+   * Reports whether `input` is a well-formed code for this configuration.
+   *
+   * Total, free of side effects, and cheap enough to run before every lookup —
+   * which is the point of the check character. Separators are stripped first,
+   * so a code typed without them, or grouped differently, still validates.
+   *
+   * Luhn catches every single-character substitution, and every swap of
+   * adjacent characters except one pair: the first and last entries of the
+   * dictionary, `0` and `z` by default. That blind spot is structural rather
+   * than incidental — with `g(x) = floor(2x / n) + (2x mod n)`, a swap of
+   * indices `a` and `b` goes undetected exactly when `a + g(b) ≡ b + g(a)`
+   * (mod n), which for even `n` has the single non-trivial solution
+   * `{0, n - 1}`. It is the textbook mod-10 `{0, 9}` case generalised.
+   *
+   * A prefix is not part of the code. Strip it before calling: `validate` sees
+   * a leading `ORD-` as three characters outside the alphabet.
+   */
+  validate(input: string): ValidateResult;
+}
+
+/* -------------------------------------------------------------------------
+ * Construction
+ * ---------------------------------------------------------------------- */
+
+/**
+ * Applies the three dictionary constraints token owns: legibility,
+ * reachability under case folding, and uniform sampling from a random byte.
+ *
+ * Luhn's constraints — even size, no repeats, no case pairs — are checked by
+ * `createLuhn`, which is why `luhn` arrives already built: `uniformOverBytes`
+ * is read from it rather than recomputed here.
+ */
+const assertAlphabet = (
+  dictionary: string,
+  uniformOverBytes: boolean,
+): void => {
+  const chars = [...dictionary];
+
+  const confusable = chars.filter((char) =>
+    CONFUSABLE_CHARACTERS.includes(char.toLowerCase()),
+  );
+  if (confusable.length > 0) {
+    throw new InvalidAlphabetError('confusable', dictionary, confusable);
+  }
+
+  // Input is folded to lowercase before it is looked up, so an uppercase code
+  // point is an index nothing can ever reach.
+  const unfolded = chars.filter((char) => char.toLowerCase() !== char);
+  if (unfolded.length > 0) {
+    throw new InvalidAlphabetError('unfolded', dictionary, unfolded);
+  }
+
+  if (!uniformOverBytes) {
+    throw new InvalidAlphabetError('non-uniform', dictionary);
+  }
+};
+
+/** Applies the constraints that relate `length`, `chunkSize` and `separator`. */
+const assertShape = (
+  length: number,
+  chunkSize: number,
+  separator: string,
+  dictionary: string,
+): void => {
+  const shape = { length, chunkSize, separator };
+
+  if (!Number.isInteger(length) || length < 2) {
+    throw new InvalidShapeError('length', shape);
+  }
+  if (!Number.isInteger(chunkSize) || chunkSize < 1) {
+    throw new InvalidShapeError('chunk-size', shape);
+  }
+  if (length % chunkSize !== 0) {
+    throw new InvalidShapeError('chunk-size-indivisible', shape);
+  }
+  if (separator.length === 0) {
+    throw new InvalidShapeError('separator-empty', shape);
+  }
+  if ([...separator].some((char) => dictionary.includes(char))) {
+    throw new InvalidShapeError('separator-in-dictionary', shape);
+  }
+};
+
+/**
+ * Validates the options and returns a frozen object carrying them and the two
+ * operations bound to them.
+ *
+ * Everything is checked here, once. Nothing is checked at use, so an accepted
+ * instance cannot produce a code its own `validate` rejects.
+ *
+ * @throws {InvalidAlphabetError} when the dictionary is confusable, not
+ * lowercase, or of a size that biases `byte % n`.
+ * @throws {InvalidShapeError} when `length`, `chunkSize` and `separator`
+ * cannot describe a code.
+ * @throws {InvalidDictionaryError} from `@evanion/luhn`, when the dictionary
+ * cannot carry a check character.
+ *
+ * @example
+ * const token = createToken();
+ *
+ * token.validate('a4kp-9mxa'); // -> { valid: true, body: 'a4kp9mx' }
+ * token.validate('a4kp-9mx8'); // -> { valid: false, reason: 'check-failed' }
+ */
+export function createToken(options: TokenOptions = {}): Token {
+  const {
+    length = DEFAULT_LENGTH,
+    chunkSize = DEFAULT_CHUNK_SIZE,
+    separator = DEFAULT_SEPARATOR,
+    dictionary = DEFAULT_DICTIONARY,
+  } = options;
+
+  // Case folding is on because a code is read off a card and typed back in,
+  // and it is what puts luhn's `case-pairs` constraint in force.
+  const luhn = createLuhn({ dictionary, caseInsensitive: true });
+
+  assertAlphabet(dictionary, luhn.uniformOverBytes);
+  assertShape(length, chunkSize, separator, dictionary);
+
+  const chars = [...dictionary];
+  const n = luhn.n;
+  const inDictionary = new Set(chars);
+
+  /** Groups `code` into chunks of `chunkSize`, joined by the separator. */
+  const chunked = (code: string): string => {
+    const points = [...code];
+    const groups: string[] = [];
+
+    for (let at = 0; at < points.length; at += chunkSize) {
+      groups.push(points.slice(at, at + chunkSize).join(''));
+    }
+
+    return groups.join(separator);
+  };
+
+  /**
+   * Draws `length - 1` characters uniformly.
+   *
+   * `byte % n` is unbiased only because `n` divides 256, which the alphabet
+   * constraint guarantees. That is what lets this stay constant-time rather
+   * than rejection-sampling.
+   */
+  const randomBody = (): string => {
+    const bytes = randomBytes(length - 1);
+    let body = '';
+
+    for (const byte of bytes) {
+      body += chars[byte % n] as string;
+    }
+
+    return body;
+  };
+
+  const generate = ({ prefix }: GenerateOptions = {}): GenerateResult => {
+    const body = randomBody();
+    const { checksum } = luhn.generate(body);
+    const code = chunked(body + checksum);
+
+    return {
+      value: prefix === undefined ? code : `${prefix}${separator}${code}`,
+      body,
+      check: checksum,
+      prefix,
+    };
+  };
+
+  const validate = (input: string): ValidateResult => {
+    const stripped = input.split(separator).join('').toLowerCase();
+    const points = [...stripped];
+
+    if (points.some((char) => !inDictionary.has(char))) {
+      return { valid: false, reason: 'outside-alphabet' };
+    }
+    if (points.length !== length) {
+      return { valid: false, reason: 'wrong-length' };
+    }
+    if (!luhn.validate(stripped).isValid) {
+      return { valid: false, reason: 'check-failed' };
+    }
+
+    return { valid: true, body: points.slice(0, -1).join('') };
+  };
+
+  return Object.freeze({
+    dictionary,
+    n,
+    length,
+    chunkSize,
+    separator,
+    entropyBits: (length - 1) * Math.log2(n),
+    generate,
+    validate,
+  });
+}

--- a/libs/token/tsconfig.json
+++ b/libs/token/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "ignoreDeprecations": "6.0"
+  }
+}

--- a/libs/token/tsconfig.lib.json
+++ b/libs/token/tsconfig.lib.json
@@ -1,0 +1,35 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"],
+    "ignoreDeprecations": "6.0"
+  },
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../luhn/tsconfig.lib.json"
+    }
+  ],
+  "exclude": [
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.test-d.ts",
+    "src/**/*.test-d.tsx"
+  ]
+}

--- a/libs/token/tsconfig.spec.json
+++ b/libs/token/tsconfig.spec.json
@@ -1,0 +1,40 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/vitest",
+    "types": [
+      "vitest/globals",
+      "vitest/importMeta",
+      "vite/client",
+      "node",
+      "vitest"
+    ],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "forceConsistentCasingInFileNames": true,
+    "ignoreDeprecations": "6.0",
+    "rootDir": "."
+  },
+  "include": [
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.test-d.ts",
+    "src/**/*.test-d.tsx",
+    "src/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/token/vite.config.ts
+++ b/libs/token/vite.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig(() => ({
+  root: import.meta.dirname,
+  cacheDir: '../../node_modules/.vite/libs/token',
+  plugins: [],
+  test: {
+    name: '@evanion/token',
+    watch: false,
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: './test-output/vitest/coverage',
+      provider: 'v8' as const,
+    },
+  },
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -221,6 +221,18 @@
         "node": ">=20"
       }
     },
+    "libs/token": {
+      "name": "@evanion/token",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@evanion/luhn": "^2.0.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "libs/urn": {
       "name": "@evanion/urn",
       "version": "2.0.0",
@@ -3493,6 +3505,10 @@
     },
     "node_modules/@evanion/shop-api": {
       "resolved": "apps/shop-api",
+      "link": true
+    },
+    "node_modules/@evanion/token": {
+      "resolved": "libs/token",
       "link": true
     },
     "node_modules/@evanion/urn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -226,7 +226,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@evanion/luhn": "^2.0.1",
+        "@evanion/luhn": "^3.0.0",
         "tslib": "^2.8.1"
       },
       "engines": {

--- a/scripts/verify-packaging.mjs
+++ b/scripts/verify-packaging.mjs
@@ -34,6 +34,7 @@ const LIBS = [
   ['libs/astro-widget', '@evanion/astro-widget'],
   ['libs/luhn', '@evanion/luhn'],
   ['libs/feature', '@evanion/feature'],
+  ['libs/token', '@evanion/token'],
 ];
 
 const run = (cmd, args, cwd) =>
@@ -98,6 +99,8 @@ import { Luhn, createLuhn, InvalidDictionaryError, LuhnError } from '@evanion/lu
 import type { LuhnOptions } from '@evanion/luhn';
 import { createFeatures, FeatureCycleError } from '@evanion/feature';
 import type { Decision, FeatureDefinition } from '@evanion/feature';
+import { createToken, DEFAULT_DICTIONARY, InvalidAlphabetError, TokenError } from '@evanion/token';
+import type { TokenOptions, ValidateResult } from '@evanion/token';
 // Second entry point, and the only one that may touch React.
 import { FeatureProvider, useFeature, useFeatureEnabled, useFeatures } from '@evanion/feature/react';
 
@@ -125,10 +128,15 @@ const toggleConfig: FeatureDefinition<'payments-v3' | 'checkout-v2'>[] = [
 const toggles = createFeatures(toggleConfig);
 const toggleDecision: Decision<'payments-v3' | 'checkout-v2'> =
   toggles.resolve({ targetingKey: 'acct-1' })['checkout-v2'];
+const tokenOptions: TokenOptions = { dictionary: DEFAULT_DICTIONARY, length: 8 };
+const tokenCheck: string = createToken(tokenOptions).generate({ prefix: 'ORD' }).check;
+const tokenResult: ValidateResult = createToken().validate('a4kp-9mxa');
+const tokenErr: TokenError = new InvalidAlphabetError('non-uniform', 'abcdef');
 void [ComposeProvider, provider, parsed, arr, err, items, widgetProblems, DefaultItem, DefaultWrapper,
       CorrelationModule, CorrelationService, withCorrelation, correlation,
       registry, sections, problems, checksum, filtered, luhnErr,
-      toggleDecision, FeatureCycleError, FeatureProvider, useFeature, useFeatureEnabled, useFeatures];
+      toggleDecision, FeatureCycleError, FeatureProvider, useFeature, useFeatureEnabled, useFeatures,
+      tokenCheck, tokenResult, tokenErr];
 `,
   );
 
@@ -168,12 +176,24 @@ import { defineBlocks, validateBlocks } from '@evanion/astro-widget';
 import { Luhn, createLuhn, InvalidDictionaryError } from '@evanion/luhn';
 import { createFeatures } from '@evanion/feature';
 import { FeatureProvider, useFeature } from '@evanion/feature/react';
+import { createToken, InvalidAlphabetError, TokenError } from '@evanion/token';
 const missing = Object.entries({
   URN, InvalidError, ValidationError, ComposeProvider, provider,
   createWidgets, DefaultItem, DefaultWrapper, validateItems,
   defineBlocks, validateBlocks, createLuhn, InvalidDictionaryError,
   createFeatures, FeatureProvider, useFeature,
+  createToken, InvalidAlphabetError, TokenError,
 }).filter(([, v]) => typeof v !== 'function').map(([k]) => k);
+// token depends on luhn rather than bundling it, so a broken dependency range
+// only shows up once both are installed from their tarballs: this call is the
+// first thing that actually resolves the import.
+const token = createToken();
+const minted = token.generate({ prefix: 'ORD' });
+if (!minted.value.startsWith('ORD-') || !token.validate(minted.value.slice(4)).valid) {
+  console.error('@evanion/token cannot round-trip a code against the installed @evanion/luhn');
+  process.exit(1);
+}
+if (!Object.isFrozen(token)) missing.push('createToken (result not frozen)');
 // Luhn is the default instance rather than a class, and it is frozen so that
 // assigning a dictionary to it throws instead of being silently ignored.
 if (typeof Luhn?.generate !== 'function' || !Object.isFrozen(Luhn)) missing.push('Luhn');
@@ -316,7 +336,9 @@ if (missing.length) { console.error('not exported at runtime:', missing.join(', 
       (entry) =>
         entry.isFile() &&
         entry.name.endsWith('.js') &&
-        !join(entry.parentPath, entry.name).includes(join(featureDist, 'react')),
+        !join(entry.parentPath, entry.name).includes(
+          join(featureDist, 'react'),
+        ),
     )
     .map((entry) => join(entry.parentPath, entry.name));
 
@@ -335,7 +357,7 @@ if (missing.length) { console.error('not exported at runtime:', missing.join(', 
         reactImporters
           .map((file) => file.slice(featureDist.length + 1))
           .join(', ') +
-        ". The core must be usable from the API and at build time, so nothing under it may import react.",
+        '. The core must be usable from the API and at build time, so nothing under it may import react.',
     );
   }
   console.log('  ✓ feature core imports nothing from react');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,6 +38,9 @@
     },
     {
       "path": "./libs/feature"
+    },
+    {
+      "path": "./libs/token"
     }
   ],
   "compilerOptions": {


### PR DESCRIPTION
Implements `docs/specs/2026-09-12-token-codes.md`, and amends the spec where the implementation proved it wrong.

## API

```ts
createToken({ length?, chunkSize?, separator?, dictionary? }): Token  // frozen
Token: { dictionary, n, length, chunkSize, separator, entropyBits, generate, validate }
generate({ prefix? }) -> { value, body, check, prefix }
validate(input)       -> { valid: true, body } | { valid: false, reason }
```

`reason` is `outside-alphabet | wrong-length | check-failed`. Defaults: alphabet `0123456789abcdefghjkmnpqrstuvxyz`, length 8, chunk size 4, separator `-`. 35 bits of usable entropy.

Errors: `TokenError` base, `InvalidAlphabetError` (`confusable | unfolded | non-uniform`) and `InvalidShapeError`. Luhn's `InvalidDictionaryError` propagates unwrapped.

## Tests — 73

`token.spec.ts` 37, `docs.spec.ts` 27, `exceptions.spec.ts` 9. The Luhn properties are asserted against measured values rather than assumed ones:

- The adjacent-transposition blind spot over this alphabet is exactly one pair, `{'0', 'z'}` — indices `{0, n-1}`, the base-10 Luhn `{0,9}` case generalised. Asserted with fixed vectors in both orders plus an exhaustive sweep of all 496 pairs, because at 1/496 per slot a random-sample test would never fire.
- Single-character substitution is caught at every position including the check character: 1,240,000 mutations, zero escapes.
- Uniformity asserted at ≤10% deviation over 100,000 draws. Worst observed across 100 runs was 6.59%; the non-uniform n=36 alphabet measures ~13%, so the bound still catches a regression.

## Spec amendments in this PR

- **The worked examples had guessed check characters.** The real check character for body `a4kp9mx` is `a`, not `7`. This is the exact failure the spec's own Testing section exists to prevent, and `docs.spec.ts` now pins every example.
- **`length` and `body` named different things in different sections.** `length` is the whole token including the check character; `body` excludes it.
- **`unfolded` is a fourth dictionary reason.** The "no case pairs" constraint only fires under luhn's `caseInsensitive`, so token folds case. An all-uppercase dictionary passes every constraint in the table and then matches nothing after folding — a construction that succeeds followed by a `generate` that throws. Construction rejects it instead.
- **Collisions and the uniqueness path not taken.** The space is 34,359,738,368; the 50% birthday threshold is ~218,000; the per-insert probability at a million issued codes is 1 in 34,360. The last governs when there is a unique constraint, and the spec now documents the insert-retry loop and why `generate` takes no `exists` callback (time-of-check-to-time-of-use). Format-preserving encryption over a counter is recorded as the construction that removes collisions outright, and why it is not implemented: it needs a monotonic counter and a secret key, so the library would depend on the caller's storage.

## Blocked on the luhn 3.0.0 release

`libs/token/package.json` declares `"@evanion/luhn": "^2.0.1"`, which is wrong — token needs v3 for `uniformOverBytes`. It cannot declare `^3.0.0` yet because luhn 3.0.0 is merged but unpublished, so `libs/luhn/package.json` still reads `2.0.1` on disk and both `@nx/dependency-checks` and `verify-packaging` reject a range that does not contain the installed version.

`nx release version --dry-run` confirms the consequence: `preserveMatchingDependencyRanges` is enabled, so nx refuses to rewrite the range and errors out rather than publishing a wrong one.

Release luhn 3.0.0 first, then flip this range to `^3.0.0` before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019s6FWxb6zpDUvbN4j1XH2B