### PR TITLE
fix(astro-widget): keep tsc's typecheck emit out of the build output

### DIFF
--- a/apps/shop-api/tsconfig.app.json
+++ b/apps/shop-api/tsconfig.app.json
@@ -1,10 +1,14 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist",
+    // `dist` belongs to the webpack build, which cleans it before writing.
+    // tsc runs over this config only to type-check -- nothing consumes its
+    // emit -- so it goes to a throwaway directory: two producers writing one
+    // directory race whenever `build` and `typecheck` are scheduled together.
+    "outDir": "out-tsc/app",
     "types": ["node"],
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.app.tsbuildinfo",
+    "tsBuildInfoFile": "out-tsc/app/tsconfig.app.tsbuildinfo",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "target": "es2021"

--- a/apps/shop-api/tsconfig.spec.json
+++ b/apps/shop-api/tsconfig.spec.json
@@ -10,11 +10,13 @@
     "ignoreDeprecations": "6.0",
     "rootDir": "."
   },
+  // The sources are compiled here rather than reached through a reference to
+  // tsconfig.app.json. A reference resolves a relative import to that
+  // project's declaration output, so every type-check of the tests would need
+  // some other target to have emitted it first; compiling the sources checks
+  // the tests against the real types and needs nothing built.
   "include": [
     "vite.config.mts",
-    "src/**/*.test.ts",
-    "src/**/*.spec.ts",
-    "src/**/*.d.ts"
-  ],
-  "references": [{ "path": "./tsconfig.app.json" }]
+    "src/**/*.ts"
+  ]
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,6 +27,9 @@ export default [
   {
     ignores: [
       '**/dist',
+      // Where tsc puts the declarations it emits only because `tsc --build`
+      // has no check-only mode. Generated, never shipped, never read.
+      '**/out-tsc',
       '**/vite.config.*.timestamp*',
       '**/vitest.config.*.timestamp*',
     ],

--- a/libs/astro-widget/tsconfig.lib.json
+++ b/libs/astro-widget/tsconfig.lib.json
@@ -1,12 +1,17 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist",
+    // `dist` belongs to the vite build, which empties it and writes the
+    // published declarations through vite-plugin-dts. tsc runs over this
+    // config only to type-check, so its emit goes to a throwaway directory:
+    // two producers writing one directory race whenever `build` and
+    // `typecheck` are scheduled together.
+    "outDir": "out-tsc/lib",
     "types": ["node", "vite/client"],
     "rootDir": "src",
     "module": "esnext",
     "moduleResolution": "bundler",
-    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "tsBuildInfoFile": "out-tsc/lib/tsconfig.lib.tsbuildinfo",
     "ignoreDeprecations": "6.0"
   },
   "exclude": [

--- a/libs/astro-widget/tsconfig.spec.json
+++ b/libs/astro-widget/tsconfig.spec.json
@@ -6,16 +6,18 @@
     "module": "esnext",
     "moduleResolution": "bundler"
   },
+  // The sources are compiled here rather than reached through a reference to
+  // tsconfig.lib.json. A reference resolves a relative import to that
+  // project's declaration output, so every type-check of the tests would need
+  // some other target to have emitted it first; compiling the sources checks
+  // the tests against the real types and needs nothing built.
   "include": [
-    "src/**/*.test.ts",
-    "src/**/*.test-d.ts",
-    "src/**/*.d.ts",
+    "src/**/*.ts",
     "vite.config.ts"
   ],
   // The container tests import .astro modules. tsc has no loader for those and
   // `astro check` -- which does -- would then type-check Widgets.astro through
   // this project rather than the library one, where its deliberate `as never`
   // registry casts are errors. Vitest runs the file; tsc does not read it.
-  "exclude": ["src/**/*.astro.test.ts"],
-  "references": [{ "path": "./tsconfig.lib.json" }]
+  "exclude": ["src/**/*.astro.test.ts"]
 }

--- a/libs/compose/tsconfig.lib.json
+++ b/libs/compose/tsconfig.lib.json
@@ -1,7 +1,12 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist",
+    // `dist` belongs to the vite build, which empties it and writes the
+    // published declarations through vite-plugin-dts. tsc runs over this
+    // config only to type-check, so its emit goes to a throwaway directory:
+    // two producers writing one directory race whenever `build` and
+    // `typecheck` are scheduled together.
+    "outDir": "out-tsc/lib",
     "types": [
       "node",
       "@nx/react/typings/cssmodule.d.ts",
@@ -12,7 +17,7 @@
     "jsx": "react-jsx",
     "module": "esnext",
     "moduleResolution": "bundler",
-    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "tsBuildInfoFile": "out-tsc/lib/tsconfig.lib.tsbuildinfo",
     "ignoreDeprecations": "6.0"
   },
   "exclude": [

--- a/libs/compose/tsconfig.spec.json
+++ b/libs/compose/tsconfig.spec.json
@@ -21,26 +21,19 @@
     "ignoreDeprecations": "6.0",
     "rootDir": "."
   },
+  // The sources are compiled here rather than reached through a reference to
+  // tsconfig.lib.json. A reference resolves a relative import to that
+  // project's declaration output, so every type-check of the tests would need
+  // some other target to have emitted it first; compiling the sources checks
+  // the tests against the real types and needs nothing built.
   "include": [
+    "src/**/*.js",
+    "src/**/*.jsx",
+    "src/**/*.ts",
+    "src/**/*.tsx",
     "vite.config.ts",
     "vite.config.mts",
     "vitest.config.ts",
-    "vitest.config.mts",
-    "src/**/*.test.ts",
-    "src/**/*.spec.ts",
-    "src/**/*.test.tsx",
-    "src/**/*.spec.tsx",
-    "src/**/*.test.js",
-    "src/**/*.spec.js",
-    "src/**/*.test.jsx",
-    "src/**/*.spec.jsx",
-    "src/**/*.test-d.ts",
-    "src/**/*.test-d.tsx",
-    "src/**/*.d.ts"
-  ],
-  "references": [
-    {
-      "path": "./tsconfig.lib.json"
-    }
+    "vitest.config.mts"
   ]
 }

--- a/libs/widget/tsconfig.lib.json
+++ b/libs/widget/tsconfig.lib.json
@@ -1,7 +1,12 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist",
+    // `dist` belongs to the vite build, which empties it and writes the
+    // published declarations through vite-plugin-dts. tsc runs over this
+    // config only to type-check, so its emit goes to a throwaway directory:
+    // two producers writing one directory race whenever `build` and
+    // `typecheck` are scheduled together.
+    "outDir": "out-tsc/lib",
     "types": [
       "node",
       "@nx/react/typings/cssmodule.d.ts",
@@ -12,7 +17,7 @@
     "jsx": "react-jsx",
     "module": "esnext",
     "moduleResolution": "bundler",
-    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "tsBuildInfoFile": "out-tsc/lib/tsconfig.lib.tsbuildinfo",
     "ignoreDeprecations": "6.0"
   },
   "exclude": [

--- a/libs/widget/tsconfig.spec.json
+++ b/libs/widget/tsconfig.spec.json
@@ -21,26 +21,19 @@
     "ignoreDeprecations": "6.0",
     "rootDir": "."
   },
+  // The sources are compiled here rather than reached through a reference to
+  // tsconfig.lib.json. A reference resolves a relative import to that
+  // project's declaration output, so every type-check of the tests would need
+  // some other target to have emitted it first; compiling the sources checks
+  // the tests against the real types and needs nothing built.
   "include": [
+    "src/**/*.js",
+    "src/**/*.jsx",
+    "src/**/*.ts",
+    "src/**/*.tsx",
     "vite.config.ts",
     "vite.config.mts",
     "vitest.config.ts",
-    "vitest.config.mts",
-    "src/**/*.test.ts",
-    "src/**/*.spec.ts",
-    "src/**/*.test.tsx",
-    "src/**/*.spec.tsx",
-    "src/**/*.test.js",
-    "src/**/*.spec.js",
-    "src/**/*.test.jsx",
-    "src/**/*.spec.jsx",
-    "src/**/*.test-d.ts",
-    "src/**/*.test-d.tsx",
-    "src/**/*.d.ts"
-  ],
-  "references": [
-    {
-      "path": "./tsconfig.lib.json"
-    }
+    "vitest.config.mts"
   ]
 }

--- a/tools/repo-checks/src/tsc-emit-outside-build-output.test.ts
+++ b/tools/repo-checks/src/tsc-emit-outside-build-output.test.ts
@@ -1,0 +1,185 @@
+import { createProjectGraphAsync, parseJson, workspaceRoot } from '@nx/devkit';
+import type { ProjectGraphProjectNode, TargetConfiguration } from '@nx/devkit';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * `typecheck` is `tsc --build` over the solution tsconfig.json, so it emits
+ * declarations for every project that file references. Nothing consumes that
+ * emit -- it exists because `tsc --build` has no check-only mode -- but it
+ * still lands on disk, and Nx schedules `typecheck` and `build` concurrently
+ * because neither depends on the other.
+ *
+ * If the two write the same directory they corrupt each other. A vite library
+ * build empties its outDir before writing, which deletes the declarations tsc
+ * has just emitted and is about to read for the next project in the solution,
+ * and tsc reports TS6305. The same overlap also makes the `build` target's Nx
+ * cache artifact depend on whether `typecheck` happened to run first.
+ *
+ * The rule: tsc may emit into a directory another target declares as its
+ * output only when that target is the same `tsc --build` over the same
+ * config, which is one compiler producing one artifact rather than two
+ * producers sharing a directory.
+ */
+
+interface TsConfig {
+  compilerOptions?: { outDir?: string; tsBuildInfoFile?: string };
+  references?: { path: string }[];
+}
+
+function readTsConfig(file: string): TsConfig {
+  return parseJson<TsConfig>(readFileSync(file, 'utf-8'), {
+    expectComments: true,
+  });
+}
+
+/** `./tsconfig.lib.json` and `./some-dir` both resolve to a config file path. */
+function resolveConfigPath(fromDir: string, ref: string): string {
+  const target = resolve(fromDir, ref);
+  return existsSync(target) && !target.endsWith('.json')
+    ? join(target, 'tsconfig.json')
+    : target;
+}
+
+/** Absolute paths `tsc --build` writes when driven from `entry`, including it. */
+function emitPaths(entry: string): { config: string; paths: string[] }[] {
+  const seen = new Set<string>();
+  const out: { config: string; paths: string[] }[] = [];
+  const queue = [entry];
+
+  while (queue.length > 0) {
+    const config = queue.shift() as string;
+    if (seen.has(config) || !existsSync(config)) continue;
+    seen.add(config);
+
+    const { compilerOptions = {}, references = [] } = readTsConfig(config);
+    const dir = dirname(config);
+    const paths = [compilerOptions.outDir, compilerOptions.tsBuildInfoFile]
+      .filter((p): p is string => typeof p === 'string')
+      .map((p) => resolve(dir, p));
+
+    if (paths.length > 0) out.push({ config, paths });
+    for (const reference of references) {
+      queue.push(resolveConfigPath(dir, reference.path));
+    }
+  }
+
+  return out;
+}
+
+/** The directory part of an Nx output entry, with its tokens expanded. */
+function outputDir(output: string, projectRoot: string): string | undefined {
+  const expanded = output
+    .replace('{workspaceRoot}', workspaceRoot)
+    .replace('{projectRoot}', join(workspaceRoot, projectRoot));
+  if (!isAbsolute(expanded)) return undefined;
+
+  // `dist/**/*.d.ts` covers `dist`, not its parent, so cut at the last
+  // separator before the first glob character rather than taking a dirname of
+  // the truncated string, which would drop a trailing-slash segment.
+  const glob = expanded.search(/[*?{]/);
+  return glob === -1 ? expanded : expanded.slice(0, glob).replace(/\/[^/]*$/, '');
+}
+
+function isInside(child: string, parent: string): boolean {
+  const rel = relative(parent, child);
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+}
+
+/**
+ * A target is the same compiler producing the same artifact when it is
+ * `tsc --build` naming that very config, so its emit is not a second producer.
+ */
+function buildsConfigItself(
+  target: TargetConfiguration,
+  config: string,
+  projectRoot: string,
+): boolean {
+  const command = String(
+    (target.options as { command?: unknown } | undefined)?.command ?? '',
+  );
+  if (!command.startsWith('tsc --build')) return false;
+
+  return command
+    .split(/\s+/)
+    .slice(2)
+    .some(
+      (arg) =>
+        !arg.startsWith('-') &&
+        resolve(workspaceRoot, projectRoot, arg) === config,
+    );
+}
+
+/**
+ * A solution tsconfig reaches across project boundaries, so a config's emit is
+ * judged against the targets of the project that owns it -- the deepest
+ * project root containing it.
+ */
+function ownerOf(
+  config: string,
+  projects: ProjectGraphProjectNode[],
+): ProjectGraphProjectNode | undefined {
+  return projects
+    .filter((p) => isInside(config, join(workspaceRoot, p.data.root)))
+    .sort((a, b) => b.data.root.length - a.data.root.length)[0];
+}
+
+function collisions(
+  project: ProjectGraphProjectNode,
+  projects: ProjectGraphProjectNode[],
+): string[] {
+  if (!project.data.targets?.['typecheck']) return [];
+
+  const entry = join(workspaceRoot, project.data.root, 'tsconfig.json');
+  const found: string[] = [];
+
+  for (const { config, paths } of emitPaths(entry)) {
+    const owner = ownerOf(config, projects);
+    if (!owner) continue;
+    const { root, targets = {} } = owner.data;
+
+    for (const [name, target] of Object.entries(targets)) {
+      if (name === 'typecheck' || !target.outputs) continue;
+      if (buildsConfigItself(target, config, root)) continue;
+
+      for (const output of target.outputs) {
+        const dir = outputDir(output, root);
+        if (!dir) continue;
+
+        for (const path of paths) {
+          if (isInside(path, dir)) {
+            found.push(
+              `${project.name}: ${relative(workspaceRoot, config)} emits to ` +
+                `${relative(workspaceRoot, path)}, inside ${owner.name}'s ` +
+                `'${name}' target output ${output}`,
+            );
+          }
+        }
+      }
+    }
+  }
+
+  return found;
+}
+
+describe('tsc emit locations', () => {
+  it('stay out of directories another target owns', async () => {
+    const graph = await createProjectGraphAsync({ exitOnError: false });
+    const projects = Object.values(graph.nodes);
+
+    expect(
+      projects.length,
+      'the project graph resolved no projects',
+    ).toBeGreaterThan(0);
+
+    const found = projects.flatMap((p) => collisions(p, projects)).sort();
+
+    expect(
+      found,
+      `Point the tsconfig's outDir and tsBuildInfoFile at out-tsc/. ` +
+        `Two targets writing one directory run concurrently and corrupt ` +
+        `each other's output.`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Reproduced

The issue's hypothesis was close but named the wrong pair. It is not `typecheck` against `test` over a shared `tsbuildinfo` — it is **`typecheck` against `build` over a shared output directory**.

`typecheck` runs `tsc --build --emitDeclarationOnly` on the solution `tsconfig.json`, which builds `tsconfig.lib.json` (emitting into `libs/astro-widget/dist`) and then `tsconfig.spec.json`. `build` runs `vite build`, whose `emptyOutDir: true` deletes that same `dist` before writing. Neither target depends on the other, so Nx runs them concurrently; a warm cache hides it because only one of the two actually executes.

When vite's wipe lands between tsc's lib emit and its spec compile, the spec project resolves `./define-blocks` through the project reference to `dist/define-blocks.d.ts`, which no longer exists:

```
src/define-blocks.test-d.ts(2,30): error TS6305: Output file
  '.../libs/astro-widget/dist/define-blocks.d.ts' has not been built from
  source file '.../libs/astro-widget/src/define-blocks.ts'.
```

Both commands take about 1s, so the unstaggered window is narrow. Starting `vite build` 0.1–0.3s before `tsc --build` puts the wipe inside it reliably.

| | runs | TS6305 |
| --- | --- | --- |
| before | 30 | **5 (17%)** |
| after | 140 (7 stagger values × 20) | **0** |

Both figures are the same probe against a cleaned `dist`/`out-tsc` each iteration.

## Fix

`dist` gets one producer. `tsc` runs over `tsconfig.lib.json` / `tsconfig.app.json` only to type-check — nothing consumes its emit, since the published declarations come from vite-plugin-dts and the app bundle from webpack — so that emit moves to `out-tsc/`.

Moving it alone would have broken the `test` target, which type-checked the tests through the spec project's reference to the lib config and so silently depended on `build` having emitted first. The spec projects now compile the sources directly instead of reaching them through a reference, so a type-check of the tests needs nothing built.

Same defect, same fix, in every project where `build` owns and clears a directory `tsc` also wrote to:

- `libs/astro-widget`, `libs/compose`, `libs/widget` — vite's `emptyOutDir: true`
- `apps/shop-api` — webpack's `output.clean: true`

`libs/urn`, `libs/luhn`, `libs/feature` and `nest/correlation-id` are untouched: their `build` **is** `tsc --build tsconfig.lib.json`, so `dist` genuinely is tsc's output and there is one producer already.

## Guard

`tools/repo-checks/src/tsc-emit-outside-build-output.test.ts` walks each project's solution tsconfig, collects every `outDir`/`tsBuildInfoFile` reachable from it, and fails if one falls inside another target's declared Nx outputs — unless that target is the same `tsc --build` over that same config, which is one compiler producing one artifact rather than two producers sharing a directory. It resolves each config to the project that owns it, so it catches the cross-project case too.

Reverting just `libs/astro-widget/tsconfig.lib.json`'s `outDir` makes it fail:

```
@evanion/astro-widget: libs/astro-widget/tsconfig.lib.json emits to
  libs/astro-widget/dist, inside @evanion/astro-widget's 'build' target output
  {projectRoot}/dist
storefront: libs/astro-widget/tsconfig.lib.json emits to libs/astro-widget/dist,
  inside @evanion/astro-widget's 'build' target output {projectRoot}/dist
```

## Checking is still real

The caution about `noEmit: true` turning `typecheck` into a no-op echo applies to `docs` and `storefront`, which this PR does not touch; `astro check` still runs as their `check` target. For the libraries, both checks were confirmed to still fail on a real error:

- a deliberate type error in `src/validate-blocks.ts` fails `@evanion/astro-widget:typecheck`
- weakening the `expectTypeOf` assertion in `define-blocks.test-d.ts` fails `@evanion/astro-widget:test` with `Type Errors 1 failed`

`**/out-tsc` joins `**/dist` in the eslint ignores — the spec projects now emit declarations for the sources, and linting generated `.d.ts` reported `no-explicit-any` against them.

## Verification

- `npx nx run-many -t lint test build typecheck check --all --skip-nx-cache` — green, 12 projects
- `node scripts/verify-packaging.mjs` — green

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019s6FWxb6zpDUvbN4j1XH2B
