### PR TITLE
ci: lint the workflow files with actionlint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,37 @@ permissions:
   contents: read
 
 jobs:
+  # An invalid workflow file does not fail a job, because no job runs. GitHub
+  # records a run with no jobs and the message "This run likely failed because
+  # of a workflow file issue", and a workflow that only triggers manually shows
+  # that against every push. actionlint reads the files as GitHub's schema
+  # does, so the error surfaces in a job that can actually go red.
+  #
+  # Separate from `main` so it reports on its own, and first because it takes
+  # seconds.
+  workflows:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          filter: tree:0
+
+      # Pinned by version and checksum rather than installed through a
+      # third-party action: the binary is the whole dependency, and verifying it
+      # is two lines.
+      - name: Lint workflow files
+        env:
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          set -euo pipefail
+          archive="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl -fsSL -o "$archive" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${archive}"
+          echo "${ACTIONLINT_SHA256}  ${archive}" | sha256sum --check --strict
+          tar xzf "$archive" actionlint
+          ./actionlint -color
+
   main:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
`release.yml` was invalid for two days and nothing went red in a way that pointed at it.

An invalid workflow file fails no job, because no job runs. GitHub records a run with no jobs and the message `This run likely failed because of a workflow file issue`. A workflow that only triggers manually shows that against every push, so the repo accumulated ~45 failed "Release" runs attributed to unrelated commits rather than to the one that broke it.

## What was wrong

The publish step's `env:` block held only comments after its last key was removed in `02d96f4`:

```yaml
      - name: Publish to npm
        if: ${{ !inputs.dry-run }}
        env:
          # No NODE_AUTH_TOKEN and no NPM_TOKEN, deliberately.
          # ...
        run: npx nx release publish
```

That is `env: null`. Valid YAML, invalid against GitHub's schema, which is why a YAML parser passes it. The comment block made the key look occupied.

`#113` fixed it incidentally by adding `PROJECTS:` under that same `env:`. Nothing stopped it recurring.

## The guard

actionlint reads the files the way GitHub's schema does. Verified against the broken file:

```
.github/workflows/release.yml:122:13: expecting a single ${{...}} expression or
  mapping value for "env" section, but found plain text node [syntax-check]
    |
122 |         env:
    |             ^
```

Demonstrated by reintroducing the defect on this branch: exit 1 sabotaged, exit 0 restored.

Its own job rather than a step in `main`, so it reports separately and runs in seconds. The binary is pinned by version and sha256 instead of installed through a third-party action — the binary is the whole dependency and verifying it is two lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019s6FWxb6zpDUvbN4j1XH2B