### PR TITLE
ci(release): point the projects input at the names it accepts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
         type: boolean
         default: true
       projects:
-        description: 'Projects to release, comma separated (e.g. "urn,luhn"). Empty releases everything affected.'
+        description: 'Projects, comma separated. Same names as commit scopes. Empty releases everything affected.'
         type: string
         default: ''
 


### PR DESCRIPTION
The dispatch form's `projects` field gave one example (`"urn,luhn"`) and no way to know what else is valid without opening the repo.

It now says the names are the same as commit scopes. That vocabulary is already documented in `CONTRIBUTING.md` and enforced by `commitlint.config.js`'s `scope-enum`, so it is a pointer to a maintained list rather than a second copy of one.

Listing the package names in the description was the other option and is rejected: it would need editing whenever a package is added, and adding a package here must not require touching unrelated files.

A wrong name still fails before anything is versioned, printing the valid names:

```
The 'projects' input names a project this repository does not release: urnn
Releasable: astro-widget, compose, feature, luhn, nestjs-correlation-id, react-widget, urn
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019s6FWxb6zpDUvbN4j1XH2B