### PR TITLE
fix(release): show breaking refactors in the changelog

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -132,7 +132,16 @@
       // resolve as a patch release. `scope-enum` in commitlint.config.js
       // enforces that every scope used here is a real project name, which is
       // what this setting requires.
-      "useCommitScope": true
+      "useCommitScope": true,
+      // nx's defaults mark `refactor` as hidden from the changelog, on the
+      // reading that a refactor changes no behaviour. A `refactor(x)!` does,
+      // and it is the commit that makes a release major, so hiding it leaves a
+      // major version whose changelog does not say what broke. Unhiding it also
+      // restores the Breaking Changes section, which is rendered from the
+      // commits the changelog shows.
+      "types": {
+        "refactor": { "changelog": { "hidden": false } }
+      }
     },
     "changelog": {
       "workspaceChangelog": false,


### PR DESCRIPTION
The luhn 3.0.0 dry run proposed this changelog:

```
# 3.0.0 (2026-09-12)

### 🚀 Features

- **repo:** make documented examples executable and sync them to the docs app (bfb72e9)

### ❤️ Thank You
```

A major release whose changelog does not mention what broke, credited to a commit that has nothing to do with the package.

## Cause

`node_modules/nx/dist/src/command-line/release/config/conventional-commits.js`:

```js
refactor: {
    semverBump: 'none',
    changelog: { title: '💅 Refactors', hidden: true },
},
```

`refactor(luhn)!: validate the dictionary at construction instead of at use` is the commit that makes this release major. The `!` still drives the version — the specifier resolved as `major` correctly — but a hidden type is omitted from the changelog, and the Breaking Changes section is rendered from the commits the changelog shows, so it disappeared too.

## After

```
### 💅 Refactors

- ⚠️  **luhn:** validate the dictionary at construction instead of at use (#85, #86, ...)

### ⚠️  Breaking Changes

- **luhn:** validate the dictionary at construction instead of at use (#85, #86, ...)
  `createLuhn` replaces the class; `Luhn` is now the frozen default instance, so
  `Luhn.dictionary = x` throws instead of being ignored. The default dictionary
  changes from 62 characters to 36, so every check character the library has ever
  emitted changes. ...
```

Verified with `nx release changelog --dry-run 3.0.0 -p @evanion/luhn`. Unhiding `refactor` alone is enough; `docs` stays hidden.

`repo-checks` still passes 63/63, including the guard that asserts `nx.json` keeps its comments.

## Known, not fixed here

The `feat(repo)` line remains. Scope `repo` matches no project, so nx falls back to attributing the commit by the files it changed, and #112 did touch `libs/luhn`. The fix is a commit convention — repo-wide tooling belongs under a type that is hidden, such as `chore` or `build`, rather than `feat` — and it cannot be applied retroactively to a merged commit. luhn 3.0.0's changelog will carry that one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019s6FWxb6zpDUvbN4j1XH2B