### PR TITLE
fix(release): drop --yes, which --skip-publish already conflicts with

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,13 +107,20 @@ jobs:
         # `nx release` publishes on its own unless told not to, so this step
         # passes --skip-publish -- without it, the Publish step below would
         # publish the same version a second time.
+        #
+        # --skip-publish is also what makes the step non-interactive, so --yes
+        # is neither needed nor allowed. Both answer the same publish prompt,
+        # in opposite directions, and nx rejects the pair:
+        #
+        #   shouldPromptPublishing =
+        #     !args.yes && !args.skipPublish && !args.dryRun && hasNewVersion
         run: |
           args=(--skip-publish)
           # An empty PROJECTS omits the flag. `--projects ""` is a filter that
           # matches nothing, which nx reports as an internal bug rather than as
           # an empty release.
           if [ -n "$PROJECTS" ]; then args+=(--projects "$PROJECTS"); fi
-          if [ "$DRY_RUN" = "true" ]; then args+=(--dry-run); else args+=(--yes); fi
+          if [ "$DRY_RUN" = "true" ]; then args+=(--dry-run); fi
           echo "Running: nx release ${args[*]}"
           npx nx release "${args[@]}"
 


### PR DESCRIPTION
The live release run failed at the version step:

```
Running: nx release --skip-publish --projects @evanion/luhn --yes
...
The --yes and --skip-publish options are mutually exclusive, please use one or the other.
##[error]Process completed with exit code 1.
```

Nothing was versioned, tagged or published. It failed in nx's argument validation before any work ran — confirmed: no new tag on origin, `main` unmoved, npm still on 2.0.1.

## Cause

Both flags answer the same prompt in opposite directions, and `--skip-publish` is already what makes the step non-interactive. From `nx/dist/src/command-line/release/release.js:261-262`:

```js
let shouldPublish = !!args.yes && !args.skipPublish && hasNewVersion;
const shouldPromptPublishing = !args.yes && !args.skipPublish && !args.dryRun && hasNewVersion;
```

With `--skip-publish`, both are false. `--yes` adds nothing and `nx/dist/src/command-line/release/command-object.js:100` rejects the pair.

## Why the dry run passed

```
if [ "$DRY_RUN" = "true" ]; then args+=(--dry-run); else args+=(--yes); fi
```

`--yes` only appears on the live branch. A dry run structurally cannot exercise it. The two modes differed by more than the one flag whose name says so.

This has been latent since `02d96f4` added `--skip-publish`. It went unnoticed because `release.yml` was simultaneously invalid as a workflow file for the same two days (fixed in #113, guarded in #115), so no run ever got far enough to hit it.

## Verified

`--printConfig` runs the same validation and exits:

```
$ npx nx release --skip-publish --projects @evanion/luhn --yes --printConfig
The --yes and --skip-publish options are mutually exclusive, please use one or the other.

$ npx nx release --skip-publish --projects @evanion/luhn --printConfig
exit=0
```

actionlint passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019s6FWxb6zpDUvbN4j1XH2B