### PR TITLE
docs(repo): make compose, urn and luhn comments evergreen

### DIFF
--- a/libs/compose/src/Compose.test-d.tsx
+++ b/libs/compose/src/Compose.test-d.tsx
@@ -19,7 +19,11 @@ const SimpleProvider = ({ children }: React.PropsWithChildren) => (
   <div>{children}</div>
 );
 
-/** All props optional, so it is a "weak type" -- see the excess-prop case below. */
+/**
+ * Every prop optional, which makes it a TypeScript "weak type": an object
+ * sharing none of its keys is still structurally assignable to it. The
+ * excess-prop case below turns on that.
+ */
 type OptProvider = (
   props: React.PropsWithChildren<{ a?: string }>,
 ) => React.JSX.Element;
@@ -30,8 +34,8 @@ type OptProvider = (
  * Some negative cases go through this rather than JSX: on a plain call the
  * error is always reported on the call itself, while in JSX it lands on
  * whichever attribute line the checker reaches first, which moves when the
- * formatter reflows the element. The JSX cases below cover the real call shape
- * (#21); these cover the same checks in a position that cannot drift.
+ * formatter reflows the element. The JSX cases below cover the real call shape;
+ * these cover the same checks in a position that cannot drift.
  */
 declare function acceptsProviders<const T extends ProviderArray>(
   providers: ValidatedProviders<T>,
@@ -124,10 +128,10 @@ describe('compose error carriers', () => {
     }>();
   });
 
-  // Guards #20: a component whose props are all optional is a "weak type", so
-  // an object of only unknown keys is structurally assignable to it. The
-  // excess-key check must run before that structural comparison, or the
-  // excess prop goes unnamed.
+  // A component whose props are all optional is a "weak type", so an object of
+  // only unknown keys is structurally assignable to it. The excess-key check
+  // must run before that structural comparison, or the excess prop goes
+  // unnamed.
   it('names an excess prop on an all-optional-props component', () => {
     expectTypeOf<
       ValidateProvider<readonly [OptProvider, { b: number }]>
@@ -198,9 +202,9 @@ describe('ComposeProvider in JSX', () => {
     expectTypeOf(el).toMatchTypeOf<React.ReactElement>();
   });
 
-  // #19: a value already typed as `ProviderArray` has lost its element
-  // identity, so there is nothing left to validate element-wise. It must still
-  // be forwardable, which is the whole point of exporting the type.
+  // A value already typed as `ProviderArray` has lost its element identity, so
+  // there is nothing left to validate element-wise. It must still be
+  // forwardable, which is the whole point of exporting the type.
   it('compiles a widened ProviderArray forwarded through a wrapper', () => {
     function AppProviders({
       providers,
@@ -290,10 +294,10 @@ describe('ComposeProvider in JSX', () => {
     expectTypeOf(el).toMatchTypeOf<React.ReactElement>();
   });
 
-  it('rejects the removed components prop', () => {
+  it('rejects a components prop in place of providers', () => {
     const el = (
       <ComposeProvider
-        // @ts-expect-error `components` was removed in v2.0; `providers` is required
+        // @ts-expect-error `components` is not a prop; `providers` is required
         components={[SimpleProvider]}
       >
         <span />

--- a/libs/compose/src/Compose.test.tsx
+++ b/libs/compose/src/Compose.test.tsx
@@ -18,7 +18,6 @@ const LooseComposeProvider = ComposeProvider as unknown as React.FC<
   Record<string, unknown>
 >;
 
-// Example provider components with different prop types
 interface ThemeProviderProps {
   theme: 'light' | 'dark';
   primaryColor: string;
@@ -134,7 +133,7 @@ describe('ComposeProvider', () => {
     expect(authElement).toHaveAttribute('data-token', 'abc123');
   });
 
-  it('should throw a rename hint when only the removed components prop is passed', () => {
+  it('should name the providers prop when only components is passed', () => {
     const consoleErrorSpy = vi
       .spyOn(console, 'error')
       .mockImplementation(() => undefined);
@@ -207,7 +206,6 @@ describe('ComposeProvider', () => {
       </ComposeProvider>,
     );
 
-    // Verify provider order: first provider should be outermost
     const provider1 = container.querySelector('[data-provider="1"]');
     const provider5 = container.querySelector('[data-provider="5"]');
 
@@ -216,7 +214,6 @@ describe('ComposeProvider', () => {
     expect(provider1).toHaveAttribute('data-id', 'first');
     expect(provider5).toHaveAttribute('data-id', 'fifth');
 
-    // Provider1 should contain Provider5 (outermost contains innermost)
     expect(provider1).toContainElement(provider5 as HTMLElement);
   });
 
@@ -273,7 +270,6 @@ describe('ComposeProvider', () => {
   });
 
   it('should apply providers in correct order (pyramid-of-doom reading order)', () => {
-    // Create providers that show their nesting order
     const OuterProvider: React.FC<
       React.PropsWithChildren<{ name: string }>
     > = ({ children, name }) => (
@@ -312,7 +308,6 @@ describe('ComposeProvider', () => {
     const middle = container.querySelector('[data-level="middle"]');
     const inner = container.querySelector('[data-level="inner"]');
 
-    // Verify nesting: outer contains middle, middle contains inner
     expect(outer).toContainElement(middle as HTMLElement);
     expect(middle).toContainElement(inner as HTMLElement);
     expect(outer).toHaveAttribute('data-name', 'outer');
@@ -334,7 +329,8 @@ describe('ComposeProvider', () => {
 
     const afterFirstRender = consoleWarnSpy.mock.calls.length;
 
-    // Same array identity across re-renders -> the effect must not re-run.
+    // Same array identity across re-renders. The dedupe is by message, not by
+    // array identity, so this would still pass once per process either way.
     rerender(
       <ComposeProvider providers={providers}>
         <div>Content</div>
@@ -350,7 +346,7 @@ describe('ComposeProvider', () => {
     consoleWarnSpy.mockRestore();
   });
 
-  it('should let providers win over components when both are supplied', () => {
+  it('should ignore components when providers is also supplied', () => {
     const bothProps = {
       providers: [SimpleProvider],
       components: [

--- a/libs/compose/src/Compose.tsx
+++ b/libs/compose/src/Compose.tsx
@@ -41,9 +41,9 @@ function warnOnce(message: string): void {
 /**
  * Clears the warn-once cache.
  *
- * Deliberately not re-exported from `index.ts`, so it is not public API -- it
- * exists because a module-level cache is otherwise impossible to test more than
- * once per file.
+ * Not re-exported from `index.ts`, so it is not public API. It exists because a
+ * module-level cache otherwise lets only the first test in a file observe a
+ * warning.
  *
  * @internal
  */
@@ -64,8 +64,25 @@ export interface ComposeProviderProps<T extends ProviderArray = ProviderArray> {
 }
 
 /**
- * Composes multiple React providers into a single component to eliminate nesting.
- * Providers are applied in order (first provider is outermost, matching pyramid-of-doom reading order).
+ * Nests `providers` around `children`, first entry outermost, so the rendered
+ * tree reads in the order the array is written.
+ *
+ * A generic function rather than a `React.FC`: the `const T` parameter infers
+ * the array as a literal tuple, which is what lets each entry be checked
+ * against its own component. A `React.FC` annotation would widen it and the
+ * per-entry checking would be gone.
+ *
+ * Hook-free, so it can be imported from a React Server Component graph without
+ * a `'use client'` boundary. React's `react-server` export condition leaves
+ * every stateful hook, `createContext` and `useContext` `undefined`.
+ *
+ * Changing the length or order of the array remounts everything below it: React
+ * reconciles by position, so `[...(isAuthed ? [AuthProvider] : []), Theme]`
+ * unmounts and remounts the whole subtree on login. Keep the array a fixed
+ * length and let the providers handle the conditional case themselves.
+ *
+ * @throws {TypeError} when `providers` is not an array, which only a caller
+ * outside TypeScript can reach.
  *
  * @example
  * ```tsx
@@ -78,16 +95,13 @@ export interface ComposeProviderProps<T extends ProviderArray = ProviderArray> {
  *   <App />
  * </ComposeProvider>
  * ```
- *
- * @param props.providers - Array of providers to compose
- * @param props.children - Child elements to wrap with providers
  */
 export function ComposeProvider<const T extends ProviderArray>(
   props: ComposeProviderProps<T>,
 ): React.ReactElement {
-  // A JavaScript consumer can still reach this with the removed `components`
-  // prop. Refusing by name beats silently accepting a prop the types do not
-  // describe.
+  // `components` is not in `ComposeProviderProps`, so only a caller outside
+  // TypeScript reaches here. Naming the prop is what turns an empty render
+  // into a message the caller can act on.
   if (!('providers' in props) && 'components' in props) {
     throw new TypeError(
       'ComposeProvider: `components` was removed in v2.0 \u2014 rename it to `providers`.',
@@ -96,9 +110,9 @@ export function ComposeProvider<const T extends ProviderArray>(
 
   const providerList = props.providers as ProviderArray;
 
-  // Fail with a message that names the problem. Without this, a missing prop
-  // surfaces as "Cannot read properties of undefined (reading 'length')", which
-  // says nothing about what the caller did wrong.
+  // Without this guard a missing prop surfaces from the array reads below as
+  // "Cannot read properties of undefined", naming neither the prop nor the
+  // component.
   if (!Array.isArray(providerList)) {
     throw new TypeError(
       `ComposeProvider: expected \`providers\` to be an array, received ${

--- a/libs/compose/src/Compose.types.ts
+++ b/libs/compose/src/Compose.types.ts
@@ -16,7 +16,11 @@ import { ComponentType, ComponentProps } from 'react';
 export type AnyComponent = ComponentType<any>;
 
 /**
- * Extracts props from a React component, excluding the children prop.
+ * `T`'s props without `children`.
+ *
+ * `children` is excluded because `ComposeProvider` supplies it — it is the next
+ * provider in the array, or the caller's own children at the innermost level.
+ * Leaving it in would make every provider's props look incomplete.
  */
 export type PropsWithoutChildren<T extends AnyComponent> = Omit<
   ComponentProps<T>,
@@ -24,15 +28,22 @@ export type PropsWithoutChildren<T extends AnyComponent> = Omit<
 >;
 
 /**
- * Helper to create a strongly-typed provider tuple.
+ * Pairs a component with its props as a `[component, props]` tuple.
  *
- * @param component - The provider component
- * @param props - Props for the provider (autocompleted based on component type)
+ * The props are checked here, at the call, rather than where the array reaches
+ * `ComposeProvider`: `T` is inferred from `component` in the same call, so the
+ * editor has the component's prop names while the object is being typed. A bare
+ * tuple literal only knows what it should be once `ComposeProvider` sees it.
+ *
+ * The `Record<Exclude<…>, never>` intersection on `props` is what rejects an
+ * excess key. Plain assignability would not: TypeScript's excess-property check
+ * fires on a fresh object literal and is skipped for a props object passed
+ * through a variable.
  *
  * @example
  * ```tsx
  * const p = provider(ThemeProvider, {
- *   theme: 'dark',           // ← IntelliSense suggests 'theme' and 'primaryColor'
+ *   theme: 'dark',
  *   primaryColor: '#007acc'
  * });
  * ```
@@ -63,8 +74,12 @@ export function provider<
 export type Provider = AnyComponent | readonly [AnyComponent, unknown];
 
 /**
- * Array of providers to be composed.
- * Providers are applied in order (first provider is outermost).
+ * A list of providers, first entry outermost.
+ *
+ * `readonly`, so an array written with `as const` is assignable. Annotating a
+ * value with this type widens away the element identity, and
+ * {@link ValidatedProviders} then checks nothing — build the array where the
+ * components are known if you want per-entry errors.
  */
 export type ProviderArray = readonly Provider[];
 
@@ -102,12 +117,11 @@ export type ValidateProvider<T> = T extends readonly [infer C, infer P]
       ? ComposeError<'second tuple element must be props, not another component'>
       : // The excess-key check runs *before* the assignability check, and the
         // order is load-bearing. A component whose props are all optional is a
-        // weak type, so `{ b: 1 }` is not assignable to it -- checking
-        // assignability first sent that case down the repaired-shape branch,
-        // where comparing the caller's mutable tuple against a constructed
-        // `readonly` tuple made TypeScript report the variance of
-        // `Array.prototype.every` instead of the prop nobody declared. That is
-        // the error #20 opens with.
+        // weak type, so an object of only unknown keys is not assignable to it;
+        // checking assignability first sends that case down the repaired-shape
+        // branch, where comparing the caller's mutable tuple against a
+        // constructed `readonly` tuple makes TypeScript report the variance of
+        // `Array.prototype.every` rather than the prop nobody declared.
         Exclude<keyof P, keyof PropsWithoutChildren<C>> extends never
         ? [P] extends [PropsWithoutChildren<C>]
           ? T
@@ -136,14 +150,13 @@ export type ValidateProviders<T extends ProviderArray> = {
  * tuple, and the plain array type for anything already widened.
  *
  * `number extends T['length']` is the standard tuple-versus-array test (the one
- * type-fest's `is-tuple.d.ts` uses). It is the whole fix for two separate
- * problems:
+ * type-fest's `is-tuple.d.ts` uses). Two things depend on it:
  *
  * - A value already typed as {@link ProviderArray} has lost its element
- *   identity, so there is nothing left to check element by element. Sending it
- *   through {@link ValidateProviders} mapped every entry onto the *repaired*
- *   shape, which the original was not assignable to, so forwarding a
- *   `ProviderArray` through a wrapper component could not compile.
+ *   identity, so there is nothing left to check element by element. Sent
+ *   through {@link ValidateProviders} it maps every entry onto the *repaired*
+ *   shape, which the original is not assignable to, and forwarding a
+ *   `ProviderArray` through a wrapper component stops compiling.
  * - Comparing a non-tuple array against a constructed `ReadonlyArray` makes
  *   TypeScript walk every inherited member -- `every`, `map`, `reduce` -- and
  *   report the variance of `predicate` before it ever mentions the real

--- a/libs/compose/vite.config.ts
+++ b/libs/compose/vite.config.ts
@@ -9,17 +9,14 @@ export default defineConfig(() => ({
   cacheDir: '../../node_modules/.vite/libs/compose',
   plugins: [
     react(),
+    // The published `dist/*.d.ts` files come from here, not from tsc: this
+    // build owns `dist` and empties it, so tsc emits to a throwaway directory
+    // instead. See the `outDir` note in tsconfig.lib.json.
     dts({
       entryRoot: 'src',
       tsconfigPath: path.join(import.meta.dirname, 'tsconfig.lib.json'),
     }),
   ],
-  // Uncomment this if you are using workers.
-  // worker: {
-  //  plugins: [ nxViteTsPaths() ],
-  // },
-  // Configuration for building your library.
-  // See: https://vitejs.dev/guide/build.html#library-mode
   build: {
     outDir: './dist',
     emptyOutDir: true,
@@ -28,16 +25,18 @@ export default defineConfig(() => ({
       transformMixedEsModules: true,
     },
     lib: {
-      // Could also be a dictionary or array of multiple entry points.
       entry: 'src/index.ts',
       name: '@evanion/compose',
       fileName: 'index',
-      // Change this to the formats you want to support.
-      // Don't forget to update your package.json as well.
+      // ESM only, which is what package.json declares: there is no `require`
+      // condition in its exports map and no CJS artifact to point one at.
       formats: ['es' as const],
     },
     rolldownOptions: {
-      // External packages that should not be bundled into your library.
+      // React is a peer dependency. Bundling it would give a consumer a second
+      // React instance, and two instances share no context or hook state.
+      // `react/jsx-runtime` is listed separately because the automatic JSX
+      // transform imports it directly, not through `react`.
       external: ['react', 'react-dom', 'react/jsx-runtime'],
     },
   },

--- a/libs/luhn/eslint.config.mjs
+++ b/libs/luhn/eslint.config.mjs
@@ -8,6 +8,10 @@ export default [
       '@nx/dependency-checks': [
         'error',
         {
+          // The rule reads every import in the project and requires a matching
+          // entry in package.json. These two files are build tooling, not
+          // shipped code: their imports are devDependencies of the workspace
+          // and must not be declared as dependencies of the package.
           ignoredFiles: [
             '{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}',
             '{projectRoot}/vite.config.{js,ts,mjs,mts}',

--- a/libs/luhn/src/lib/docs.spec.ts
+++ b/libs/luhn/src/lib/docs.spec.ts
@@ -6,15 +6,14 @@ import { ALTERNATING_CASE_DICTIONARY, DEFAULT_DICTIONARY, Luhn, createLuhn } fro
 /**
  * The documented claims that the README cannot make as an executable example.
  *
- * Every `// -> value` in README.md is now checked where it is written: the
- * blocks are marked `@import.meta.vitest`, and the claims become assertions at
- * transform time. What is left here is the rest — the claims that are about
- * throwing, about a fictional dependency, or about a statement too large to
- * carry a value claim on one line.
+ * Every `// -> value` in README.md is checked where it is written: those blocks
+ * are marked `@import.meta.vitest`, and `tools/doc-examples` turns each claim
+ * into an assertion at transform time. What is left here is the rest — the
+ * claims that are about throwing, about a fictional dependency, or about a
+ * statement too large to carry a value claim on one line.
  *
- * 2.0.0 changed the arithmetic and left the documented numbers at their 1.x
- * values, so the docs were wrong for two releases with nothing failing. That
- * is what both halves exist to prevent.
+ * Between them the two halves mean no documented value in this package can be
+ * wrong without a test failing.
  */
 describe('the documented claims the README cannot assert itself', () => {
   describe('README: quick start', () => {
@@ -63,7 +62,7 @@ describe('the documented claims the README cannot assert itself', () => {
     });
   });
 
-  describe('README: migration', () => {
+  describe('README: the default instance is frozen', () => {
     it('assignment to the default instance throws', () => {
       expect(() => {
         (Luhn as { dictionary: string }).dictionary = DEFAULT_DICTIONARY;

--- a/libs/luhn/src/lib/exceptions.ts
+++ b/libs/luhn/src/lib/exceptions.ts
@@ -1,3 +1,10 @@
+/**
+ * The sentence for one rejected dictionary.
+ *
+ * The switch has no `default` arm and the function has a declared return type,
+ * so adding a member to {@link InvalidDictionaryReason} without a message here
+ * fails to compile on the implicit `undefined` return.
+ */
 const messageFor = (
   reason: InvalidDictionaryReason,
   dictionary: string,
@@ -20,8 +27,13 @@ const messageFor = (
 };
 
 /**
- * Base class for every error this library throws.
+ * Base class for every error this library throws. Catch it to handle any
+ * failure without naming the subclasses.
  *
+ * `@evanion/urn` exports an unrelated `ValidationError`; the name here is
+ * package-specific so the two never collide in a consumer's import list.
+ *
+ * @example
  * ```ts
  * try {
  *   createLuhn({ dictionary });
@@ -31,9 +43,6 @@ const messageFor = (
  *   }
  * }
  * ```
- *
- * `@evanion/urn` exports an unrelated `ValidationError`; the name here is
- * package-specific so the two never collide in a consumer's import list.
  */
 export class LuhnError extends Error {
   constructor(message: string) {
@@ -56,6 +65,18 @@ export type InvalidDictionaryReason =
  * One class carrying a `reason` rather than one class per constraint, so a
  * caller that only wants to know whether a dictionary is acceptable writes one
  * `catch` arm instead of five.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   createLuhn({ dictionary: 'aabbccdd' });
+ * } catch (error) {
+ *   if (error instanceof InvalidDictionaryError) {
+ *     error.reason; // 'duplicate'
+ *     error.offending; // ['a', 'b', 'c', 'd']
+ *   }
+ * }
+ * ```
  */
 export class InvalidDictionaryError extends LuhnError {
   readonly reason: InvalidDictionaryReason;

--- a/libs/luhn/src/lib/luhn.ts
+++ b/libs/luhn/src/lib/luhn.ts
@@ -258,9 +258,15 @@ export function createLuhn(options: LuhnOptions = {}): Luhn {
 /**
  * `createLuhn()`: the 36 lowercase alphanumerics, folding case.
  *
- * Frozen, so `Luhn.dictionary = x` — the 1.x and 2.x way to configure this
- * library — throws a `TypeError` in a module rather than being accepted and
- * ignored. Build a second instance with `createLuhn` instead.
+ * Frozen, so `Luhn.dictionary = x` throws a `TypeError` in a module rather than
+ * being accepted and ignored. A second dictionary is a second instance, built
+ * with `createLuhn`.
+ *
+ * @example
+ * ```ts @import.meta.vitest
+ * Luhn.generate('foo'); // -> { phrase: 'foo', checksum: '5', filtered: 0 }
+ * Luhn.validate('foo5'); // -> { phrase: 'foo5', isValid: true, filtered: 0 }
+ * ```
  */
 /*
  * `Luhn` names the interface in type space and the default instance in value

--- a/libs/urn/README.md
+++ b/libs/urn/README.md
@@ -42,15 +42,16 @@ pnpm add @evanion/urn
 ```ts @import.meta.vitest
 import { URN } from '@evanion/urn';
 
-// You can easily extend the base class to create your own base schema
+// A subclass is the extension point: override the statics and every inherited
+// method reads the new values.
 class TRN extends URN {
   static override readonly urn = 'trn';
 }
 
-// Then you can generate a URN using the stringify method
 TRN.stringify('foo', 'bar'); // -> 'trn:bar:foo'
 
-// Parse a URN to get its constituent parts
+// `bar` is not this class's own NID, which is still the inherited `nid`, so
+// parse keeps it in the nss rather than discarding the namespace.
 const parsed = TRN.parse('trn:bar:foo'); // -> { urn: 'trn', nid: 'bar', nss: 'bar:foo' }
 ```
 <!-- #endregion basic-usage -->
@@ -71,17 +72,6 @@ const parsed = TRN.parse('trn:bar:foo'); // -> { urn: 'trn', nid: 'bar', nss: 'b
 - **r-, q- and f-components**: the optional `?+`, `?=` and `#` tails of
   RFC 8141 §2.3, parsed into their own fields and excluded from equivalence
 
-## Why should you use a URN
-
-How many times have you seen a random DocumentID being thrown around in a conversation,
-and you wonder what type of DocumentID it is? Is it a `product` or `productCategory` ID?  
-A URN will help, by always include information about the namespace that the ID is referring to.
-
-## Philosophy
-
-The idea with this library to make it as easy to work with URNs as it is to work with `JSON`.
-And the libraries API is inspired by the `JSON` API.
-
 ## Basic Usage
 
 ### Declare Namespace
@@ -89,12 +79,11 @@ And the libraries API is inspired by the `JSON` API.
 You can easily create a namespace specific class:
 
 ```ts
-// You can create namespace specific URN classes
 class UserTRN extends TRN {
   static override readonly nid = 'user';
 }
 
-// That will automatically create a URN with the proper namespace
+// With the NID on the class, the positional form needs only the identifier.
 UserTRN.stringify('1337'); // -> 'trn:user:1337'
 ```
 
@@ -102,12 +91,13 @@ UserTRN.stringify('1337'); // -> 'trn:user:1337'
 
 Create your own URN schemes for different domains:
 
-```ts
-// E-commerce system
+```ts @import.meta.vitest
 class EcommerceURN extends URN {
   static override readonly urn = 'ecommerce';
 }
 
+// A subclass per namespace, so the namespace is never an argument at the call
+// site and cannot be mistyped there.
 class ProductURN extends EcommerceURN {
   static override readonly nid = 'product';
 }
@@ -116,12 +106,8 @@ class OrderURN extends EcommerceURN {
   static override readonly nid = 'order';
 }
 
-// Usage
-const productUrn = ProductURN.stringify('laptop-123');
-console.log(productUrn); // "ecommerce:product:laptop-123"
-
-const orderUrn = OrderURN.stringify('456');
-console.log(orderUrn); // "ecommerce:order:456"
+ProductURN.stringify('laptop-123'); // -> 'ecommerce:product:laptop-123'
+OrderURN.stringify('456'); // -> 'ecommerce:order:456'
 ```
 
 ### Parse URNs
@@ -129,23 +115,21 @@ console.log(orderUrn); // "ecommerce:order:456"
 Parsing a URN will decode it into its constituent parts:
 
 ```ts
-const parsed = UserTRN.parse('trn:user:1337');
-console.log(parsed); // -> {urn:'trn', nid: 'user', nss: '1337'}
+UserTRN.parse('trn:user:1337'); // -> { urn: 'trn', nid: 'user', nss: '1337' }
 ```
 
 **Important**: If you parse a URN from another namespace ID, it will retain the namespace ID in the NSS. This way, each namespace should only work with plain ids when it's inside its own namespace, and retain the namespace information if it's from another namespace ID:
 
 ```ts
-const parsed = UserTRN.parse('trn:order:42');
-console.log(parsed); // -> {urn: 'trn', nid: 'order', nss: 'order:42'}
+UserTRN.parse('trn:order:42'); // -> { urn: 'trn', nid: 'order', nss: 'order:42' }
 ```
 
 A foreign **scheme** is retained the same way, verbatim, so a record read from
 another scheme cannot be silently re-labelled as this one:
 
 ```ts
-UserTRN.parse('ftp:user:1'); // -> {urn: 'ftp', nid: 'user', nss: 'ftp:user:1'}
-UserTRN.parse('trn:user:1'); // -> {urn: 'trn', nid: 'user', nss: '1'}
+UserTRN.parse('ftp:user:1'); // -> { urn: 'ftp', nid: 'user', nss: 'ftp:user:1' }
+UserTRN.parse('trn:user:1'); // -> { urn: 'trn', nid: 'user', nss: '1' }
 ```
 
 The comparisons are case-folded, so `URN:USER:1` is not foreign to a `urn` /
@@ -173,8 +157,8 @@ subclass's `separator`:
 
 <!-- #region grammars -->
 ```ts @import.meta.vitest
-URN.schemeGrammar; // /^[A-Za-z][A-Za-z0-9+.-]*$/
-URN.nidGrammar; // /^[A-Za-z0-9][A-Za-z0-9-]{0,30}[A-Za-z0-9]$/
+URN.schemeGrammar; // -> /^[A-Za-z][A-Za-z0-9+.-]*$/
+URN.nidGrammar; // -> /^[A-Za-z0-9][A-Za-z0-9-]{0,30}[A-Za-z0-9]$/
 URN.nssGrammar; // the RFC 8141 `pchar *(pchar / "/")` set
 URN.rComponentGrammar; // `pchar *(pchar / "/" / "?")`
 URN.qComponentGrammar; // the same production
@@ -185,13 +169,9 @@ URN.fComponentGrammar; // RFC 3986 `fragment`, which may be empty
 ```ts
 import { URN, InvalidError } from '@evanion/urn';
 
-// This will throw an InvalidError for invalid NID
-UserTRN.stringify('1337', 'f?o'); // throws InvalidError, an invalid NID
+UserTRN.stringify('1337', 'f?o'); // throws InvalidError: '?' is not an NID character
+UserTRN.stringify('1337', 'foo', 'b!r'); // throws InvalidError: '!' is not a scheme character
 
-// This will throw an InvalidError for invalid URN
-UserTRN.stringify('1337', 'foo', 'b!r'); // throws InvalidError, an invalid URN
-
-// Handle errors gracefully
 try {
   const urn = URN.stringify('invalid character', 'namespace');
 } catch (error) {
@@ -209,8 +189,8 @@ RFC 8141 Appendix B keeps earlier-valid URNs valid. Nothing else is relaxed on
 read:
 
 ```ts
-URN.parse('urn:x:1'); // ok
-URN.stringify('1', 'x'); // throws: NID must be at least 2 characters long
+URN.parse('urn:x:1'); // -> { urn: 'urn', nid: 'x', nss: 'x:1' }
+URN.stringify('1', 'x'); // throws InvalidError: NID must be at least 2 characters long
 ```
 
 ### Percent-encoding
@@ -259,10 +239,12 @@ parameters for the named resource) and the f-component (`#`, a secondary
 resource within the named one). `parse` returns each in its own field and never
 folds it into the `nss`:
 
-```ts
-URN.parse('urn:example:weather?=lat=39#today');
-// { urn: 'urn', nid: 'example', nss: 'weather',
-//   qComponent: 'lat=39', fComponent: 'today' }
+```ts @import.meta.vitest
+class WeatherURN extends URN {
+  static override readonly nid = 'example';
+}
+
+WeatherURN.parse('urn:example:weather?=lat=39#today'); // -> { urn: 'urn', nid: 'example', nss: 'weather', qComponent: 'lat=39', fComponent: 'today' }
 ```
 
 The fields are optional and absent — not `undefined` — when the URN carries no
@@ -271,9 +253,8 @@ saw before.
 
 Write them with the object form of `stringify`:
 
-```ts
-URN.stringify({ nss: 'weather', nid: 'example', qComponent: 'lat=39' });
-// 'urn:example:weather?=lat=39'
+```ts @import.meta.vitest
+URN.stringify({ nss: 'weather', nid: 'example', qComponent: 'lat=39' }); // -> 'urn:example:weather?=lat=39'
 ```
 
 The splitting needs no change to the NSS grammar: `pchar` contains neither `?`
@@ -285,9 +266,9 @@ first `?` of what remains introduces the r-component (`?+`) or the q-component
 RFC 8141 §3.1 excludes all three from equivalence, so `equals` ignores them,
 and `extractId` drops them:
 
-```ts
-URN.equals('urn:example:foo?+r1#a', 'urn:example:foo?+r2#b'); // true
-URN.extractId('urn:example:foo?=q#f'); // 'foo'
+```ts @import.meta.vitest
+URN.equals('urn:example:foo?+r1#a', 'urn:example:foo?+r2#b'); // -> true
+URN.extractId('urn:example:foo?=q#f'); // -> 'foo'
 ```
 
 A subclass whose `separator` contains `?` or `#` cannot tell a separator from a
@@ -312,9 +293,9 @@ UserTRN.stringify('user:42'); // -> 'trn:user:user:42'
 UserTRN.parse('trn:user:user:42').nss; // -> 'user:42'
 ```
 
-Earlier versions dropped the repeated segment, which made `user:42` — a
-composite key imported from another system — irrecoverable. If you meant the
-other namespace, name it:
+That keeps a composite key imported from another system recoverable: drop the
+repeated segment and `user:42` can never be read back. If you meant the other
+namespace, name it:
 
 ```ts
 UserTRN.stringify('42', 'order'); // -> 'trn:order:42'
@@ -342,19 +323,20 @@ return shape, so `stringify(...Object.values(parse(x)))` is silently wrong —
 `'foo:nid:urn'`. Hand `stringify` the object instead; the keys carry the
 meaning, and only that form can express the r-, q- and f-components:
 
-```ts
-URN.stringify(URN.parse('urn:nid:foo')); // 'urn:nid:foo'
-URN.stringify({ nss: '123', nid: 'user' }); // 'urn:user:123'
+```ts @import.meta.vitest
+URN.stringify(URN.parse('urn:nid:foo')); // -> 'urn:nid:foo'
+URN.stringify({ nss: '123', nid: 'user' }); // -> 'urn:user:123'
 ```
 
 `stringify(parse(x))` returns `x` for a URN in the parsing class's own
 namespace. It does not for a foreign one, because `parse` retains the foreign
 scheme and NID inside the `nss` so they cannot be lost, and `stringify` then
-prefixes the class's own:
+prefixes the class's own. The base class's NID is `nid`, so `user` below is
+foreign to it:
 
-```ts
-URN.parse('urn:user:123').nss; // 'user:123'  (base class nid is 'nid')
-URN.stringify(URN.parse('urn:user:123')); // 'urn:user:user:123'
+```ts @import.meta.vitest
+URN.parse('urn:user:123').nss; // -> 'user:123'
+URN.stringify(URN.parse('urn:user:123')); // -> 'urn:user:user:123'
 ```
 
 ## Common Use Cases
@@ -366,7 +348,7 @@ class ResourceURN extends URN {
   static override readonly urn = 'resource';
 }
 
-// Identify different types of resources
+// One class, the NID passed per call, when the namespaces are open-ended.
 const userUrn = ResourceURN.stringify('123', 'user');
 const productUrn = ResourceURN.stringify('456', 'product');
 const orderUrn = ResourceURN.stringify('789', 'order');
@@ -379,7 +361,8 @@ class ServiceURN extends URN {
   static override readonly urn = 'service';
 }
 
-// Identify services and their resources
+// The NID says whether the identifier names a service or a resource one of
+// them owns, so a bare id in a message is never ambiguous.
 const userServiceUrn = ServiceURN.stringify('user-service', 'service');
 const userResourceUrn = ServiceURN.stringify('123', 'user-service');
 ```
@@ -424,11 +407,11 @@ const userResourceUrn = ServiceURN.stringify('123', 'user-service');
 
 They differ on a foreign namespace, on purpose. `parse` keeps a non-matching NID
 attached to the `nss` so the namespace is not silently lost; `extractId` always
-drops it:
+drops it. The base class's NID is `nid`, so `user` here is foreign to it:
 
-```ts
-URN.parse('urn:user:123').nss; // 'user:123'  (base class nid is 'nid')
-URN.extractId('urn:user:123'); // '123'
+```ts @import.meta.vitest
+URN.parse('urn:user:123').nss; // -> 'user:123'
+URN.extractId('urn:user:123'); // -> '123'
 ```
 
 Reach for `parse` when the namespace matters, `extractId` when you only want the
@@ -457,9 +440,9 @@ trailing identifier.
 - `static fComponentGrammar: RegExp` - The grammar the f-component must match,
   the only one that accepts the empty string
 
-`isValid` is gone. One flat regex cannot describe three roles across two
-separator regimes; the three getters can, and they stay reactive to a
-subclass's `separator`.
+There is no single flat validation regex. One character class cannot describe
+three roles across two separator regimes; the getters above can, and they stay
+reactive to a subclass's `separator`.
 
 When overriding these in a subclass, TypeScript's `noImplicitOverride` requires
 the `override` keyword:

--- a/libs/urn/eslint.config.mjs
+++ b/libs/urn/eslint.config.mjs
@@ -8,6 +8,10 @@ export default [
       '@nx/dependency-checks': [
         'error',
         {
+          // The rule reads every import in the project and requires a matching
+          // entry in package.json. These two files are build tooling, not
+          // shipped code: their imports are devDependencies of the workspace
+          // and must not be declared as dependencies of the package.
           ignoredFiles: [
             '{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}',
             '{projectRoot}/vite.config.{js,ts,mjs,mts}',

--- a/libs/urn/src/lib/exceptions.ts
+++ b/libs/urn/src/lib/exceptions.ts
@@ -1,8 +1,11 @@
 /**
- * Base class for every error this library throws.
+ * Base class for every error this library throws. Catch it to handle any
+ * validation failure without naming the subclasses.
  *
- * Catch this to handle any validation failure:
+ * `@evanion/luhn` exports an unrelated `LuhnError` hierarchy, so the two
+ * packages' errors never share a base in a consumer's `catch`.
  *
+ * @example
  * ```ts
  * try {
  *   URN.parse(input);

--- a/libs/urn/src/lib/types.ts
+++ b/libs/urn/src/lib/types.ts
@@ -1,13 +1,14 @@
 /**
  * A URN string with known parts, for annotating literals in consumer code.
  *
- * ```ts
- * type UserUrn = IFullURN<'urn', 'user', string>;  // `urn:user:${string}`
- * const id: UserUrn = 'urn:user:123';
- * ```
- *
  * Assumes the default `:` separator. A subclass with a custom separator cannot
  * be described by this type.
+ *
+ * @example
+ * ```ts
+ * type UserUrn = IFullURN<'urn', 'user', string>; // `urn:user:${string}`
+ * const id: UserUrn = 'urn:user:123';
+ * ```
  */
 export type IFullURN<
   URN extends string,
@@ -22,10 +23,15 @@ export type IFullURN<
  * without any percent-decoding. RFC 8141 3.1 excludes all three from
  * URN-equivalence, so `URN.equals` ignores them.
  *
- * ```ts
- * URN.parse('urn:example:foo?+r?=q#f');
- * // { urn: 'urn', nid: 'example', nss: 'foo',
- * //   rComponent: 'r', qComponent: 'q', fComponent: 'f' }
+ * @example
+ * ```ts @import.meta.vitest
+ * import { URN } from '@evanion/urn';
+ *
+ * class ExampleURN extends URN {
+ *   static override readonly nid = 'example';
+ * }
+ *
+ * ExampleURN.parse('urn:example:foo?+r?=q#f'); // -> { urn: 'urn', nid: 'example', nss: 'foo', rComponent: 'r', qComponent: 'q', fComponent: 'f' }
  * ```
  */
 export interface URNComponents {
@@ -50,10 +56,10 @@ export interface URNComponents {
 /**
  * The object returned by `URN.parse`.
  *
- * The parts are plain strings on purpose. `parse` takes a runtime `string`, so
- * it cannot know their literal types; earlier versions declared free type
- * parameters here that the caller could set to anything, which let
- * `URN.parse<'a', 'b', 'c'>(someString)` claim a shape nothing verified.
+ * The parts are plain strings, and deliberately not type parameters. `parse`
+ * takes a runtime `string`, so it cannot know their literal types; free type
+ * parameters here would let `URN.parse<'a', 'b', 'c'>(someString)` assert a
+ * shape nothing verifies.
  *
  * The three component keys are absent rather than `undefined` when the URN
  * carries no components, so such a URN parses to exactly `{ urn, nid, nss }`.

--- a/libs/urn/src/lib/urn.spec.ts
+++ b/libs/urn/src/lib/urn.spec.ts
@@ -45,7 +45,7 @@ describe('URN', () => {
       expect(URN.parse('urn:nid:a:b').nss).toBe('a:b');
     });
 
-    it('should no longer deduplicate an NSS that starts with the NID', () => {
+    it('should emit an NSS that starts with the NID verbatim', () => {
       const UserURN = namespaceOf('urn', 'user');
       expect(UserURN.stringify('user:42')).toBe('urn:user:user:42');
       expect(UserURN.parse('urn:user:user:42').nss).toBe('user:42');
@@ -160,7 +160,7 @@ describe('URN', () => {
       }
     });
 
-    it('should accept sub-delims, colon and at-sign that used to be rejected', () => {
+    it('should accept the RFC 3986 sub-delims, colon and at-sign', () => {
       for (const nss of ['user@123', 'user$123', 'user!123', 'foo/bar']) {
         expect(() => URN.stringify(nss, 'example')).not.toThrow();
       }
@@ -337,7 +337,8 @@ describe('URN', () => {
       }
 
       // The foreign scheme is kept as-is. Substituting this.urn here would
-      // silently re-label the record, which is the bug in #11.
+      // re-label the record as belonging to a namespace it was never minted
+      // in, and nothing downstream could tell.
       expect(UserTRN.parse('ftp:user:1')).toEqual({
         urn: 'ftp',
         nid: 'user',
@@ -912,10 +913,10 @@ describe('URN', () => {
       );
     });
 
-    it('should undo what Object.values would have broken', () => {
+    it('should round-trip through the object form, not the spread', () => {
       // stringify's positional arguments are the reverse of parse's return
-      // shape, so spreading the parsed object mislabels every part. The object
-      // form is the fix: the keys carry the meaning.
+      // shape, so spreading the parsed object mislabels every part. Only the
+      // object form carries the meaning in the keys.
       const parsed = URN.parse('urn:nid:foo');
       expect(
         URN.stringify(...(Object.values(parsed) as [string, string, string])),

--- a/libs/urn/src/lib/urn.test-d.ts
+++ b/libs/urn/src/lib/urn.test-d.ts
@@ -65,8 +65,10 @@ describe('urn types', () => {
     expectTypeOf(URN.fComponentGrammar).toEqualTypeOf<RegExp>();
   });
 
-  it('no longer exposes a single flat isValid regex', () => {
-    // @ts-expect-error isValid was replaced by the three grammar getters
+  it('exposes no single flat validation regex', () => {
+    // One character class cannot describe three roles across two separator
+    // regimes; the role-scoped grammar getters above are the whole surface.
+    // @ts-expect-error URN has no isValid member
     void URN.isValid;
   });
 
@@ -107,8 +109,9 @@ describe('urn types', () => {
       static override readonly nid = 'bar';
     }
 
-    // Guards inherited statics from requiring a cast to `typeof URN`: free
-    // type parameters on parse would otherwise break variance for subclasses.
+    // A subclass calls every inherited static without a cast to `typeof URN`.
+    // Free type parameters on `parse` would break that: the subclass's own
+    // `parse` would not be assignable to the base signature.
     expectTypeOf(TRN.stringify('foo')).toEqualTypeOf<string>();
     expectTypeOf(TRN.parse('trn:bar:foo')).toEqualTypeOf<ParsedURN>();
     expectTypeOf(

--- a/libs/urn/src/lib/urn.ts
+++ b/libs/urn/src/lib/urn.ts
@@ -68,18 +68,31 @@ const UNRESERVED = /^[A-Za-z0-9\-._~]$/;
  */
 export class URN {
   /**
-   * separator between the different parts of the URN
+   * What the scheme, the NID and the NSS are joined by and split on.
+   *
+   * RFC 8141 2 fixes this at `:`. Overriding it trades the RFC grammars for
+   * separator-derived ones on the scheme and the NID, and a separator
+   * containing `?` or `#` also switches component parsing off.
    */
   static readonly separator: string = ':';
 
   /**
-   * URN schema; The first part of the URN
+   * The scheme: the first part of the identifier.
+   *
+   * RFC 8141 2 fixes this at the literal `urn`. A subclass overrides it to
+   * mint identifiers in a scheme of its own, which every read and write path
+   * on that subclass then compares against.
    */
   static readonly urn: string = 'urn';
 
   /**
-   * namespace ID
-   * identifies the resource type
+   * The namespace identifier: the part that says what kind of resource the NSS
+   * names.
+   *
+   * `'nid'` is a placeholder, not a registered namespace — IANA's URN
+   * namespace registry holds the real ones. A subclass overrides it so
+   * `stringify(nss)` needs no namespace argument, and so `parse` can tell its
+   * own namespace from a foreign one.
    */
   static readonly nid: string = 'nid';
 
@@ -209,15 +222,16 @@ export class URN {
    * The read path is lenient in exactly one respect: it accepts a
    * one-character NID, which RFC 2141 permitted. See {@link nidReadGrammar}.
    *
-   * ```ts
-   * URN.parse('urn:example:weather?=lat=39#today');
-   * // { urn: 'urn', nid: 'example', nss: 'weather',
-   * //   qComponent: 'lat=39', fComponent: 'today' }
-   * ```
+   * @throws {ValidationError} when the string is not a well-formed URN.
    *
-   * @param urnString The URN string to parse
-   * @returns object that contains the parts of the URN
-   * @throws {ValidationError} if the string is not a well-formed URN
+   * @example
+   * ```ts @import.meta.vitest
+   * class WeatherURN extends URN {
+   *   static override readonly nid = 'example';
+   * }
+   *
+   * WeatherURN.parse('urn:example:weather?=lat=39#today'); // -> { urn: 'urn', nid: 'example', nss: 'weather', qComponent: 'lat=39', fComponent: 'today' }
+   * ```
    */
   static parse(urnString: string): ParsedURN {
     const { urn, nid, nss, components } = this.splitParts(urnString);
@@ -239,13 +253,6 @@ export class URN {
   /**
    * Takes the parts of a URN and returns the URN string.
    *
-   * ```ts
-   * URN.stringify('123', 'user');                       // 'urn:user:123'
-   * URN.stringify({ nss: '123', nid: 'user' });         // 'urn:user:123'
-   * URN.stringify({ nss: 'weather', nid: 'example', qComponent: 'lat=39' });
-   * // 'urn:example:weather?=lat=39'
-   * ```
-   *
    * `stringify` operates on the wire form. It does not percent-encode: an NSS
    * that is not already encoded, such as one containing a literal space, is
    * rejected. Encode with {@link encodeNss} first if you need to.
@@ -254,9 +261,14 @@ export class URN {
    * is a static that subclasses may override, so any `${urn}:${nid}:${nss}`
    * type would be wrong for them.
    *
-   * @param parts The parts of the URN, keyed as {@link parse} returns them
-   * @returns generated URN
-   * @throws {InvalidError} if any part is empty or breaks its grammar
+   * @throws {InvalidError} when a part is empty or breaks its grammar.
+   *
+   * @example
+   * ```ts @import.meta.vitest
+   * URN.stringify('123', 'user'); // -> 'urn:user:123'
+   * URN.stringify({ nss: '123', nid: 'user' }); // -> 'urn:user:123'
+   * URN.stringify({ nss: 'weather', nid: 'example', qComponent: 'lat=39' }); // -> 'urn:example:weather?=lat=39'
+   * ```
    */
   static stringify(parts: URNParts): string;
   /**
@@ -267,9 +279,7 @@ export class URN {
    * which this form cannot express, so `stringify(parse(x))` returns `x` for a
    * URN in this class's own namespace.
    *
-   * @param nss Namespace specific string
-   * @param nid Namespace ID
-   * @param urn Schema
+   * `nid` and `urn` default to this class's own statics.
    */
   static stringify(nss: string, nid?: string, urn?: string): string;
   // The defaults sit in the parameter list so the positional overload can fall
@@ -302,10 +312,14 @@ export class URN {
    * Checks if a string is a valid URN.
    *
    * Delegates to {@link parse}, so the read path and this predicate cannot
-   * drift apart.
+   * drift apart. Never throws, which makes it the cheap way to screen input
+   * before committing to `parse`.
    *
-   * @param urnString The string to validate
-   * @returns true if the string parses
+   * @example
+   * ```ts @import.meta.vitest
+   * URN.isValidFormat('urn:example:123'); // -> true
+   * URN.isValidFormat('not-a-urn'); // -> false
+   * ```
    */
   static isValidFormat(urnString: string): boolean {
     try {
@@ -323,12 +337,7 @@ export class URN {
    * This is deliberately *structural* and differs from `parse(urnString).nss`
    * on a foreign namespace. `parse` keeps a non-matching NID attached to the
    * `nss` so the namespace is not silently lost, whereas `extractId` always
-   * drops it:
-   *
-   * ```ts
-   * URN.parse('urn:user:123').nss   // 'user:123' -- base class nid is 'nid'
-   * URN.extractId('urn:user:123')   // '123'
-   * ```
+   * drops it.
    *
    * Reach for `parse` when the namespace matters, and `extractId` when you
    * only want the trailing identifier.
@@ -337,22 +346,29 @@ export class URN {
    * resource's parameters and a secondary resource, none of which are part of
    * the identifier.
    *
-   * @param urnString The URN string to extract from
-   * @returns The identifier portion
-   * @throws {ValidationError} if the string is not a well-formed URN
+   * @throws {ValidationError} when the string is not a well-formed URN.
+   *
+   * @example
+   * ```ts @import.meta.vitest
+   * URN.parse('urn:user:123').nss; // -> 'user:123'
+   * URN.extractId('urn:user:123'); // -> '123'
+   * ```
    */
   static extractId(urnString: string): string {
     return this.splitParts(urnString).nss;
   }
 
   /**
-   * Checks if two URNs are in the same namespace (same URN scheme and NID).
+   * Checks if two URNs are in the same namespace: same scheme and same NID.
    *
    * The scheme and the NID are compared case-insensitively, per RFC 8141 3.1.
+   * Malformed input returns `false` rather than throwing.
    *
-   * @param urn1 First URN string
-   * @param urn2 Second URN string
-   * @returns true if both URNs have the same scheme and namespace ID
+   * @example
+   * ```ts @import.meta.vitest
+   * URN.sameNamespace('urn:user:1', 'URN:User:2'); // -> true
+   * URN.sameNamespace('urn:user:1', 'urn:order:2'); // -> false
+   * ```
    */
   static sameNamespace(urn1: string, urn2: string): boolean {
     try {
@@ -368,11 +384,15 @@ export class URN {
    * Checks if a URN belongs to a specific namespace.
    *
    * The scheme and the NID are compared case-insensitively, per RFC 8141 3.1.
+   * Malformed input returns `false` rather than throwing. `expectedUrn`
+   * defaults to this class's own scheme, so a subclass does not have to repeat
+   * it.
    *
-   * @param urnString The URN string to check
-   * @param expectedNid The expected namespace ID
-   * @param expectedUrn The expected URN scheme; defaults to this class's own scheme
-   * @returns true if the URN belongs to the specified namespace
+   * @example
+   * ```ts @import.meta.vitest
+   * URN.belongsToNamespace('urn:user:1', 'user'); // -> true
+   * URN.belongsToNamespace('ftp:user:1', 'user'); // -> false
+   * ```
    */
   static belongsToNamespace(
     urnString: string,
@@ -399,6 +419,12 @@ export class URN {
    * is never decoded, so `%2C` and `,` are *not* equivalent.
    *
    * Returns `false` for malformed input rather than throwing.
+   *
+   * @example
+   * ```ts @import.meta.vitest
+   * URN.equals('URN:Example:a123%2cz456', 'urn:example:a123%2Cz456'); // -> true
+   * URN.equals('urn:example:a123%2Cz456', 'urn:example:a123,z456'); // -> false
+   * ```
    */
   static equals(a: string, b: string): boolean {
     try {
@@ -646,6 +672,11 @@ function canonicaliseTriplets(value: string): string {
  * percent-triplets with uppercase hex, so the result is safe in any position
  * of an NSS. Neither `stringify` nor `parse` calls this: encoding is an
  * explicit, separate step, so a value can never be double-encoded by accident.
+ *
+ * @example
+ * ```ts @import.meta.vitest
+ * encodeNss('café'); // -> 'caf%C3%A9'
+ * ```
  */
 export function encodeNss(raw: string): string {
   let encoded = '';
@@ -664,8 +695,13 @@ export function encodeNss(raw: string): string {
 /**
  * Decodes the percent-triplets in an NSS back to the raw string.
  *
- * @throws {ValidationError} if the input contains a malformed or truncated
- *   percent sequence.
+ * @throws {ValidationError} when the input contains a malformed or truncated
+ * percent sequence.
+ *
+ * @example
+ * ```ts @import.meta.vitest
+ * decodeNss('caf%C3%A9'); // -> 'café'
+ * ```
  */
 export function decodeNss(encoded: string): string {
   if (/%(?![0-9A-Fa-f]{2})/.test(encoded)) {

--- a/libs/urn/vite.config.ts
+++ b/libs/urn/vite.config.ts
@@ -16,6 +16,9 @@ export default defineConfig(() => ({
   cacheDir: '../../node_modules/.vite/libs/urn',
   ...docExamples({ preamble }),
   test: {
+    // Without an explicit tsconfig, vitest falls back to the solution-style
+    // tsconfig.json (files: [], include: []), so it typechecks nothing and
+    // every expectTypeOf assertion silently passes.
     typecheck: {
       enabled: true,
       tsconfig: './tsconfig.spec.json',


### PR DESCRIPTION
Raises every comment and docblock in `libs/compose`, `libs/urn` and `libs/luhn` to the repo's standard: a comment states what the code does, then the constraint outside the file that forces it, in present tense, for a reader who has never seen the file.

## What changed

**Narration of change is gone.** No "earlier versions", no shipped version number as the subject of a comment, no issue number, no prior implementation. `libs/urn/src/lib/types.ts` explained `ParsedURN` by what earlier versions declared; it now states why free type parameters would be unsound. `libs/compose/src/Compose.types.ts` narrated a past TypeScript diagnostic in `ValidateProvider`; it now states the ordering constraint in present tense. Four `#19`/`#20`/`#21` issue references in the compose tests became the constraints they stood for.

**Deleted rather than reworded** where a comment only restated the signature: 22 `@param`/`@returns` tags in `urn.ts` whose text repeated the name and the type, the Nx generator's leftover instructions in `libs/compose/vite.config.ts` ("Uncomment this if you are using workers", "Change this to the formats you want to support"), and the tutorial narration above self-evident lines in the urn README.

## Three documented values were wrong

`URN.parse('urn:example:weather?=lat=39#today')` was documented as returning `nss: 'weather'` in three places — the urn README, `URN.parse`'s docblock, and `URNComponents` in `types.ts`. The base class's NID is `nid`, so the foreign `example` is retained in the NSS and the real value is `example:weather`. Each example now subclasses `URN` to own the namespace it reads, and each runs as a test.

## Executable coverage rises

urn now asserts 12 README claims and 10 docblock claims through `vite-plugin-doctest` and the `tools/doc-examples` rewriter, up from 5 and 1. Blocks converted where they were self-contained; blocks whose claim is "throws" or that depend on a class declared in an earlier block stay illustrative, since the rewriter has no form for either.

The urn README also carried its "Why should you use a URN" and "Philosophy" sections twice; the second copy is removed. No region marker was renamed or removed.

## Verification

- `npx nx run-many -t lint test build typecheck check --all` — green, 14 projects. The 13 lint warnings are pre-existing non-null assertions in `tools/nx-astro`, outside this change.
- `node scripts/verify-packaging.mjs` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019s6FWxb6zpDUvbN4j1XH2B