### PR TITLE
docs(repo): make comments state constraints in the widget, token and feature packages

### DIFF
--- a/libs/astro-widget/src/components/Widgets.astro
+++ b/libs/astro-widget/src/components/Widgets.astro
@@ -1,22 +1,32 @@
 ---
 /**
- * Renders a list of CMS blocks.
+ * Renders a list of CMS blocks, one component per block.
  *
- * Deliberately defensive: an unknown type is skipped rather than thrown on, so
- * a gap in build-time validation can never take a page down mid-render.
- * `validateBlocks` is the loud gate; this is the safety net.
+ * Defensive by design: an unknown type is skipped rather than thrown on, so a
+ * gap in build-time validation cannot take a page down mid-render.
+ * `validateBlocks` is the loud gate and this is the net underneath it.
  */
 import type { BlockItem, BlockRegistry } from '../types';
 
 interface Props {
   items: BlockItem[];
   registry: BlockRegistry;
-  /** Page-level data passed to every block. Astro renders at build time, so
-      there is no context provider to do this for us — and none is needed. */
+  /**
+   * Page-level data passed to every block as a `ctx` prop. The counterpart to
+   * `@evanion/react-widget`'s `ctx`.
+   *
+   * A prop rather than a provider: an Astro component runs once, top down, and
+   * has no render-time context to read from.
+   */
   ctx?: Record<string, unknown>;
-  /** Optional wrapper rendered around every block, e.g. for CMS edit affordances.
-      `chrome.item` MUST render <slot /> — if it doesn't, Astro silently drops
-      the wrapped block and it will not appear on the page. No error is thrown. */
+  /**
+   * Chrome rendered around every block, for CMS edit affordances and
+   * positioning. It is handed the block's `meta`.
+   *
+   * It has to render `<slot />`. An Astro component that does not render its
+   * slot discards the content passed to it, so the block inside disappears from
+   * the page with nothing thrown and nothing logged.
+   */
   chrome?: { item?: unknown };
 }
 
@@ -29,10 +39,11 @@ const Item = chrome?.item as never;
     const Component = registry[item?.type] as never;
     if (!Component) return null;
 
-    // `meta` is placement data for the item chrome -- grid column, span,
-    // ordering, CMS edit affordances. It is destructured out here so it never
-    // reaches the block: where a block sits is not something the block should
-    // know, and spreading it in would collide with the block's own props.
+    // `type`, `id`, `children` and `meta` are the renderer's own fields, and
+    // `props` is everything else the CMS wrote. Destructuring them out is what
+    // keeps them from being spread into the block: `meta` is placement data for
+    // the chrome, and where a block sits is not something the block should
+    // know.
     const { type, id, children, meta, ...props } = item;
 
     return Item ? (

--- a/libs/astro-widget/src/components/Widgets.astro.test.ts
+++ b/libs/astro-widget/src/components/Widgets.astro.test.ts
@@ -4,6 +4,13 @@ import Widgets from './Widgets.astro';
 import Probe from './__fixtures__/Probe.astro';
 import Wrapper from './__fixtures__/Wrapper.astro';
 
+/**
+ * Renders `Widgets.astro` to a string through Astro's container API, which is
+ * what makes a component testable outside a build.
+ *
+ * These cases run in the `@evanion/astro-widget:astro` project, for the reason
+ * vitest.astro.config.ts gives.
+ */
 async function renderWidgets(props: Record<string, unknown>) {
   const container = await AstroContainer.create();
   return container.renderToString(Widgets, { props });

--- a/libs/astro-widget/src/define-blocks.ts
+++ b/libs/astro-widget/src/define-blocks.ts
@@ -1,8 +1,20 @@
 import type { BlockRegistry } from './types';
 
 /**
- * Identity function that pins the registry's key union for editors and for
- * `validateBlocks`. It does no work at runtime by design.
+ * Returns the registry unchanged, typed as the literal object that was passed.
+ *
+ * The generic parameter is the whole point: annotating the same object as
+ * `BlockRegistry` widens its keys to `string`, and the key union is what an
+ * editor completes on and what a caller narrows a `required` map against.
+ *
+ * @example
+ * ```ts
+ * import Hero from './Hero.astro';
+ * import Text from './Text.astro';
+ *
+ * const registry = defineBlocks({ hero: Hero, text: Text });
+ * //    ^? { hero: AstroComponentFactory; text: AstroComponentFactory }
+ * ```
  */
 export function defineBlocks<M extends BlockRegistry>(map: M): M {
   return map;

--- a/libs/astro-widget/src/index.ts
+++ b/libs/astro-widget/src/index.ts
@@ -1,3 +1,12 @@
+/**
+ * `@evanion/astro-widget` -- CMS block rendering for Astro.
+ *
+ * This entry carries the registry helper, the validator and the types.
+ * `Widgets.astro` is not among them: an `.astro` module has to be compiled by
+ * Astro's own vite plugin, which runs in the consumer's project and not in this
+ * package's build, so package.json publishes it as source under
+ * `@evanion/astro-widget/components/Widgets.astro`.
+ */
 export { defineBlocks } from './define-blocks';
 export { validateBlocks } from './validate-blocks';
 export type { BlockItem, BlockRegistry, BlockProblem } from './types';

--- a/libs/astro-widget/src/types.ts
+++ b/libs/astro-widget/src/types.ts
@@ -4,14 +4,23 @@ export interface BlockItem {
   type: string;
   /** Optional stable id, useful as a DOM anchor. */
   id?: string;
-  /** Nested blocks, forwarded to the component as ordinary prop data.
-      The renderer does NOT recurse — Astro projects child content through
-      <slot />, not through a `children` prop. A block that wants nesting
-      renders <Widgets items={children} registry={registry} /> itself. */
+  /**
+   * Nested blocks, handed to the component as ordinary prop data.
+   *
+   * `Widgets.astro` does not recurse into them. An Astro component receives
+   * child content through `<slot />` rather than through a `children` prop, so
+   * there is nothing for a renderer to pass nested blocks into; a block that
+   * wants nesting renders `<Widgets items={children} registry={registry} />`
+   * itself.
+   */
   children?: BlockItem[];
-  /** Placement and presentation data for `chrome.item`. Handed to the item
-      wrapper and never spread into the block's own props, because where a
-      block sits is not something the block should know. */
+  /**
+   * Placement and presentation data for `chrome.item`: grid column, span,
+   * ordering, CMS edit affordances.
+   *
+   * Handed to the item wrapper and never spread into the block's own props,
+   * because where a block sits is not something the block should know.
+   */
   meta?: Record<string, unknown>;
   /** Everything else is passed to the component as props. */
   [key: string]: unknown;
@@ -20,15 +29,20 @@ export interface BlockItem {
 /**
  * Maps a block type to an Astro component.
  *
- * Values are deliberately `unknown`: Astro components are opaque at the type
- * level, so unlike @evanion/react-widget we cannot infer each block's props
- * from the component. `validateBlocks` covers that ground at build time.
+ * The values are `unknown` because an `.astro` module's default export is an
+ * `AstroComponentFactory`, which carries no prop types at all -- the props of a
+ * `.astro` file live in its frontmatter `Props` interface and are not reachable
+ * from the factory's type. So there is nothing to infer a block's props from,
+ * the way `@evanion/react-widget` infers them from a `ComponentType`, and
+ * `validateBlocks` covers that ground at build time instead.
  */
 export type BlockRegistry = Record<string, unknown>;
 
-/** A problem found by `validateBlocks`. */
+/** A problem found by `validateBlocks`. Mirrors react-widget's `WidgetItemProblem`. */
 export interface BlockProblem {
+  /** Index within the block's own sibling list; -1 when the root is not a list. */
   index: number;
+  /** The block's `type`, or `-` when it has none usable. */
   type: string;
   message: string;
 }

--- a/libs/astro-widget/src/validate-blocks.ts
+++ b/libs/astro-widget/src/validate-blocks.ts
@@ -1,11 +1,24 @@
 import type { BlockItem, BlockProblem, BlockRegistry } from './types';
 
 /**
- * Checks a block list against a registry. Returns problems rather than
- * throwing, so a caller can print all of them at once.
+ * Checks a block list against a registry, recursing into `children`.
+ *
+ * Returns problems rather than throwing, and accumulates rather than
+ * short-circuiting, so a caller can print all of them at once. `Widgets.astro`
+ * never calls this: the renderer skips a block it cannot render, and this is
+ * the loud gate to run at ingestion or build time. It is also the only check a
+ * block's props get, because an Astro component exposes no prop types to infer
+ * from.
  *
  * `required` maps a block type to the field names that must be present and
- * non-blank.
+ * non-blank, where blank means `undefined`, `null` or whitespace only -- a CMS
+ * text field that was opened and left empty arrives as the last of those.
+ *
+ * @example
+ * ```ts
+ * validateBlocks([{ type: 'hero' }], { hero: Hero }, { hero: ['heading'] });
+ * // [{ index: 0, type: 'hero', message: 'missing field heading' }]
+ * ```
  */
 export function validateBlocks(
   items: BlockItem[],

--- a/libs/astro-widget/vite.config.ts
+++ b/libs/astro-widget/vite.config.ts
@@ -42,10 +42,8 @@ export default defineConfig(() => ({
     environment: 'node',
     include: ['src/**/*.test.ts'],
     reporters: ['default'],
-    // Widgets.astro is the only source file the type checker cannot see into,
-    // so it is the one that needs rendering to test. Astro's container API does
-    // that, but importing a .astro module requires astro's own vite plugin,
-    // which the library build must not carry.
+    // The container tests live in their own project, for the reason
+    // vitest.astro.config.ts gives.
     projects: [
       {
         extends: true,

--- a/libs/astro-widget/vitest.astro.config.ts
+++ b/libs/astro-widget/vitest.astro.config.ts
@@ -5,9 +5,11 @@ import { getViteConfig } from 'astro/config';
  * Vitest project for the tests that render `Widgets.astro` through Astro's
  * container API.
  *
- * It needs Astro's own vite plugin to compile a `.astro` module, and the
- * library build in `vite.config.ts` must not carry that plugin -- hence a
- * separate config, referenced from that file's `test.projects`.
+ * `Widgets.astro` is the one source file in this package the type checker
+ * cannot see into, so it is the one that has to be rendered to be tested.
+ * Compiling a `.astro` module needs Astro's own vite plugin, and the library
+ * build in vite.config.ts must not carry that plugin -- hence a second config,
+ * referenced from that file's `test.projects`.
  */
 export default getViteConfig({
   test: {

--- a/libs/feature/src/lib/bucketing.spec.ts
+++ b/libs/feature/src/lib/bucketing.spec.ts
@@ -2,9 +2,13 @@ import { describe, expect, it } from 'vitest';
 import { bucketOf, inRollout, murmur3 } from './bucketing.js';
 
 /**
- * The three properties the spec requires of bucketing, each written so it fails
- * on the naive implementation it warns about
- * (`hashFnv32a(value + seed) % 1000`, GrowthBook pre-v2).
+ * The three properties `docs/specs/2026-09-11-feature-toggles.md`, "Rollout
+ * bucketing", requires: stable, decorrelated across features, and monotonic in
+ * the percentage.
+ *
+ * Each case is written so that it fails on the implementation that section
+ * names as the one to avoid -- GrowthBook's pre-v2
+ * `hashFnv32a(value + seed) % 1000` -- rather than merely passing on this one.
  */
 
 const members = (keys: readonly string[], percent: number, seed: string) =>
@@ -29,19 +33,20 @@ describe('bucketOf', () => {
   });
 
   it('is stable across processes', () => {
-    // Pinned literals, not a recomputation: a hash that changed between
-    // releases would still agree with itself inside one process. This is the
-    // only assertion that catches a changed hash, which would silently
-    // rebucket every user of every deployed flag.
+    // Pinned literals rather than a recomputation. A bucket is only useful if
+    // it agrees across processes and versions, and a changed hash still agrees
+    // with itself inside one process, so nothing but a pinned value catches it
+    // -- and a changed hash rebuckets every user of every deployed flag.
     expect(bucketOf('user-1', 'checkout-v2').toFixed(9)).toBe('0.550397675');
     expect(bucketOf('user-1', 'payments-v3').toFixed(9)).toBe('0.649353779');
     expect(bucketOf('', '').toFixed(9)).toBe('0.016881907');
   });
 
   it('hashes with a real MurmurHash3, x86 32-bit', () => {
-    // The canonical test vectors. Pinning only the bucket values above would
-    // also be satisfied by a private hash of my own invention, which is not
-    // something anyone else can reproduce or audit.
+    // MurmurHash3's canonical test vectors, from the reference
+    // implementation's own smhasher suite. The pinned buckets above are also
+    // satisfied by any private hash; these say which hash it is, so another
+    // implementation can reproduce a bucket without running this code.
     expect(murmur3('')).toBe(0);
     expect(murmur3('a').toString(16)).toBe('3c2569b2');
     expect(murmur3('abc').toString(16)).toBe('b3dd93fa');

--- a/libs/feature/src/lib/bucketing.ts
+++ b/libs/feature/src/lib/bucketing.ts
@@ -13,9 +13,10 @@
  *    at all; the percentage is only a threshold on it. Raising a percentage can
  *    therefore only add members, never move one out.
  *
- * The naive version the spec warns about -- GrowthBook's pre-v2
- * `hashFnv32a(value + seed) % 1000` -- fails (2) for two separate reasons, and
- * this implementation departs on both:
+ * GrowthBook's pre-v2 `hashFnv32a(value + seed) % 1000` fails (2) for two
+ * separate reasons -- it is the implementation
+ * `docs/specs/2026-09-11-feature-toggles.md`, "Rollout bucketing", names as the
+ * one to avoid -- and this departs from it on both:
  *
  * - Concatenating value and seed with no unambiguous boundary makes the pairs
  *   ('ab', 'c') and ('a', 'bc') the same input, so flags whose keys share a

--- a/libs/feature/src/lib/errors.ts
+++ b/libs/feature/src/lib/errors.ts
@@ -1,11 +1,13 @@
 import type { FeatureKey } from './types.js';
 
 /**
- * Configuration errors, all thrown at construction.
+ * Base class for every error this library throws. All of them are raised by
+ * `createFeatures`; `resolve`, `plan` and `toggle` are total.
  *
- * This follows the lesson from the luhn audit: reference implementations enforce
- * their constraints when the configuration is supplied, not when it is used.
- * Checking at use is how `@evanion/luhn` ended up with issue #87.
+ * Constraints are enforced where the configuration is supplied rather than
+ * where it is read, so a store a caller holds cannot fail mid-evaluation. It is
+ * the same split `@evanion/luhn` and `@evanion/token` draw between
+ * `createLuhn`/`createToken` and their operations.
  */
 export class FeatureConfigError extends Error {
   constructor(message: string) {

--- a/libs/feature/src/lib/features.spec.ts
+++ b/libs/feature/src/lib/features.spec.ts
@@ -249,8 +249,9 @@ describe('cascade', () => {
 
     features.toggle('a', false);
 
-    // The 2022 sketch's bug stops here: with the parent's *stored* value read
-    // instead of its resolved one, b goes off and c, d, e stay on.
+    // All five, not just b. A cascade that reads each parent's stored
+    // `enabled` rather than its resolved decision turns b off and leaves c, d
+    // and e on, because only a's stored value changed.
     expect(enabledOf(features.resolve())).toEqual({
       a: false,
       b: false,
@@ -403,8 +404,9 @@ describe('the store holds intent', () => {
 
     expect(JSON.stringify(definitions)).toBe(snapshot);
     expect(JSON.stringify(features.config)).toBe(snapshot);
-    // `enabled` meant "the maintainer wants this on" throughout, and that did
-    // not change when the window closed.
+    // `enabled` is the maintainer's intent, and a window closing is not the
+    // maintainer. Nothing but `toggle` and an edit to the configuration writes
+    // it.
     expect(features.definition('child')?.enabled).toBe(true);
   });
 

--- a/libs/feature/src/lib/features.ts
+++ b/libs/feature/src/lib/features.ts
@@ -59,10 +59,25 @@ function deepFreeze<T>(value: T): T {
 /**
  * Creates a feature store from its configuration.
  *
- * Validates the dependency graph here rather than at evaluation: a cycle, a
+ * The dependency graph is validated here rather than at evaluation: a cycle, a
  * dependency on a feature that does not exist and a duplicate key are all
- * configuration errors, and a cycle has no defined resolution order at all.
- * Checking at use is the mistake `@evanion/luhn` made with its alphabet.
+ * configuration errors, and a cycle has no defined resolution order at all, so
+ * there is nothing sensible for `resolve` to return for one.
+ *
+ * @throws {FeatureCycleError} when `dependsOn` closes a loop.
+ * @throws {UnknownDependencyError} when `dependsOn` names an unconfigured key.
+ * @throws {DuplicateFeatureError} when two definitions share a key.
+ *
+ * @example
+ * ```ts
+ * const features = createFeatures([
+ *   { key: 'checkout', enabled: true },
+ *   { key: 'express-checkout', enabled: true, dependsOn: ['checkout'] },
+ * ]);
+ *
+ * features.isEnabled('express-checkout'); // true
+ * features.toggle('checkout', false).willDisable; // ['express-checkout']
+ * ```
  */
 export function createFeatures<F extends FeatureKey>(
   definitions: readonly FeatureDefinition<F>[],
@@ -91,9 +106,8 @@ export function createFeatures<F extends FeatureKey>(
     const evaluationContext = withNow(context);
     const resolved = new Map<F, Decision<F>>();
 
-    // Dependency order, so a parent's *resolved* value exists before any
-    // dependant reads it. This is what makes the cascade transitive through a
-    // chain of any depth.
+    // `graph.order`, not `keys`: see FeatureGraph.order for why the cascade
+    // needs it.
     for (const key of graph.order) {
       const definition = definitionOf(key);
       if (!definition) continue;

--- a/libs/feature/src/lib/graph.spec.ts
+++ b/libs/feature/src/lib/graph.spec.ts
@@ -39,8 +39,6 @@ describe('buildGraph', () => {
 
     expect(error).toBeInstanceOf(FeatureCycleError);
     const cycle = error as FeatureCycleError;
-    // The path is a closed walk: it ends where it starts, so a reader can see
-    // the edge that closes it.
     expect(cycle.path[0]).toBe(cycle.path[cycle.path.length - 1]);
     expect(new Set(cycle.path)).toEqual(new Set(['a', 'b', 'c']));
     for (const key of ['a', 'b', 'c']) {

--- a/libs/feature/src/lib/graph.ts
+++ b/libs/feature/src/lib/graph.ts
@@ -9,12 +9,12 @@ export interface FeatureGraph<F extends FeatureKey> {
   /**
    * Every key, ordered so a feature always follows the features it depends on.
    *
-   * This ordering is what makes the cascade transitive. The 2022 sketch folded
-   * over the features in declaration order and read each parent's stored
-   * `active` rather than its computed result, so a chain A -> B -> C never
-   * cascaded past one level. Resolving in this order means a parent's result
-   * always exists by the time its dependants are evaluated, for a chain of any
-   * depth.
+   * This ordering is what makes the cascade transitive: a parent's *resolved*
+   * decision exists by the time any dependant is evaluated, for a chain of any
+   * depth. Evaluating in declaration order instead leaves a dependant with no
+   * resolved parent to read, and falling back to the parent's stored `enabled`
+   * cascades exactly one level -- `docs/specs/2026-09-11-feature-toggles.md`,
+   * "Cascade".
    */
   readonly order: readonly F[];
   /** Transitive dependants of `key`, in dependency order. */

--- a/libs/feature/src/lib/reason-is-output-only.spec.ts
+++ b/libs/feature/src/lib/reason-is-output-only.spec.ts
@@ -5,9 +5,10 @@ import { buildGraph } from './graph.js';
 import type { Decision, EvaluationContext, FeatureDefinition } from './types.js';
 
 /**
- * The spec's invariant: `reason` is output only. The cascade reads `enabled`
- * from a parent's result and nothing else, so deleting the reason field must
- * change no decision anywhere.
+ * The invariant from `docs/specs/2026-09-11-feature-toggles.md`, "Result":
+ * `reason` is output only. The cascade reads `enabled` from a parent's result
+ * and nothing else, so deleting every explanation field must change no decision
+ * anywhere.
  *
  * Asserting that the engine "does not branch on reason" by reading the source is
  * not a test. This runs the real per-feature decision function over the real

--- a/libs/feature/src/lib/types.ts
+++ b/libs/feature/src/lib/types.ts
@@ -1,7 +1,8 @@
 /**
- * A feature identifier. Carried over from the 2022 sketch, which parameterised
- * on `Feature extends string | number` so a consumer can use a string union or
- * a numeric enum and keep exhaustiveness.
+ * A feature identifier.
+ *
+ * `string | number` rather than `string`, so a consumer can key features on a
+ * numeric enum and still get exhaustiveness from `Decisions<F>`.
  */
 export type FeatureKey = string | number;
 

--- a/libs/token/README.md
+++ b/libs/token/README.md
@@ -12,7 +12,10 @@ import { createToken } from '@evanion/token';
 
 const token = createToken();
 
-token.generate(); // -> { value: 'a4kp-9mxa', body: 'a4kp9mx', check: 'a', prefix: undefined }
+token.generate(); // { value: 'a4kp-9mxa', body: 'a4kp9mx', check: 'a', prefix: undefined }
+```
+
+```ts @import.meta.vitest
 token.validate('a4kp-9mxa'); // -> { valid: true, body: 'a4kp9mx' }
 ```
 
@@ -52,10 +55,10 @@ pnpm add @evanion/token
 const token = createToken();
 
 token.generate();
-// -> { value: 'a4kp-9mxa', body: 'a4kp9mx', check: 'a', prefix: undefined }
+// { value: 'a4kp-9mxa', body: 'a4kp9mx', check: 'a', prefix: undefined }
 
 token.generate({ prefix: 'ORD' });
-// -> { value: 'ORD-a4kp-9mxa', body: 'a4kp9mx', check: 'a', prefix: 'ORD' }
+// { value: 'ORD-a4kp-9mxa', body: 'a4kp9mx', check: 'a', prefix: 'ORD' }
 ```
 
 `value` is the code as a person sees it. `body` is what the check character was
@@ -66,8 +69,8 @@ never checks for collisions — see [Entropy](#entropy).
 
 ## Validate a code
 
-```ts
-token.validate('a4kp-9mxa'); // -> { valid: true,  body: 'a4kp9mx' }
+```ts @import.meta.vitest
+token.validate('a4kp-9mxa'); // -> { valid: true, body: 'a4kp9mx' }
 token.validate('a4kp-9mx8'); // -> { valid: false, reason: 'check-failed' }
 token.validate('a4kp-9mxo'); // -> { valid: false, reason: 'outside-alphabet' }
 token.validate('a4kp-9mx'); // -> { valid: false, reason: 'wrong-length' }
@@ -107,14 +110,14 @@ textbook mod-10 `{0, 9}` case, generalised.
 separator first, so a code typed without it, or grouped differently, still
 validates:
 
-```ts
+```ts @import.meta.vitest
 token.validate('a4kp9mxa').valid; // -> true
 token.validate('a4-kp-9m-xa').valid; // -> true
 ```
 
 Case is folded too, so a code read off a card in capitals validates:
 
-```ts
+```ts @import.meta.vitest
 token.validate('A4KP-9MXA'); // -> { valid: true, body: 'a4kp9mx' }
 ```
 
@@ -125,7 +128,7 @@ one character is exactly the thing this package exists to avoid. Set
 ```ts
 const short = createToken({ length: 6, chunkSize: 3, separator: ' ' });
 
-short.generate(); // -> { value: 'q7t 3n7', body: 'q7t3n', check: '7', prefix: undefined }
+short.generate(); // { value: 'q7t 3n7', body: 'q7t3n', check: '7', prefix: undefined }
 ```
 
 ## The prefix sits outside the checksum
@@ -136,8 +139,8 @@ the prefix:
 ```ts
 const { value } = token.generate({ prefix: 'ORD' });
 
-token.validate(value); // -> { valid: false, reason: 'outside-alphabet' }
-token.validate(value.slice('ORD-'.length)); // -> { valid: true, ... }
+token.validate(value); // { valid: false, reason: 'outside-alphabet' }
+token.validate(value.slice('ORD-'.length)); // { valid: true, body: ... }
 ```
 
 Folding the prefix in would require every prefix character to be in the
@@ -166,9 +169,10 @@ characters buys 25 more bits.
 
 The default is 32 characters:
 
-```ts
+```ts @import.meta.vitest
 token.dictionary; // -> '0123456789abcdefghjkmnpqrstuvxyz'
 token.n; // -> 32
+token.entropyBits; // -> 35
 ```
 
 It is the lowercase alphanumerics without `i`, `l`, `o` and `w`. The first

--- a/libs/token/src/lib/docs.spec.ts
+++ b/libs/token/src/lib/docs.spec.ts
@@ -12,65 +12,66 @@ import {
 } from './token.js';
 
 /**
- * Every worked example in README.md and in the doc comments, as an assertion.
+ * The documented claims that an executed example cannot carry.
  *
- * A check character cannot be read off a page and cannot be guessed — it is
- * the output of a fold over a specific alphabet in a specific order. A
- * documented code with a made-up check character is a lie that ships, and this
- * file is what stops it.
+ * Every `EXPR; // -> VALUE` line in README.md and in a doc comment is already
+ * an assertion: `docExamples()` in vite.config.ts rewrites it and
+ * vite-plugin-doctest runs it, so a documented value that is wrong fails the
+ * suite where it is written. What is left over lands here, and it is of three
+ * kinds.
  *
- * `generate` is random, so the documented outputs are pinned through
- * `validate`, which is the half that is deterministic.
+ * - Claims about `generate`, which draws from `crypto.randomBytes`. The
+ *   documented output cannot be reproduced, so what is checked instead is that
+ *   it is internally consistent: the printed `value` really is the printed
+ *   `body` plus a check character that validates, chunked by the documented
+ *   `chunkSize`. A made-up check character fails here, which is the whole
+ *   reason this file exists -- a check character is the output of a fold over a
+ *   specific alphabet in a specific order, so it cannot be read off a page.
+ * - Claims a reader has to take arithmetic on trust: the entropy figures, the
+ *   collision volumes, and the exact set of swaps Luhn misses.
+ * - Claims about prose rather than about a value: which characters the alphabet
+ *   leaves out, and which constraint rejects a dictionary.
  */
-describe('the documented examples', () => {
+describe('the documented claims', () => {
   const token = createToken();
 
-  describe('README: quick start', () => {
-    it("token.validate('a4kp-9mxa')", () => {
-      expect(token.validate('a4kp-9mxa')).toEqual({
-        valid: true,
-        body: 'a4kp9mx',
-      });
-    });
+  /** What `createToken` threw for `dictionary`, so its fields can be read. */
+  const thrownBy = (dictionary: string): unknown => {
+    try {
+      createToken({ dictionary });
+    } catch (error) {
+      return error;
+    }
+    return expect.unreachable('the documented call must throw');
+  };
 
-    it('the generate() result shown alongside it', () => {
-      // value 'a4kp-9mxa', body 'a4kp9mx', check 'a'.
+  describe('README: the generate() outputs', () => {
+    it("the quick start's 'a4kp-9mxa' is body 'a4kp9mx' plus check 'a'", () => {
       expect(token.validate('a4kp9mx' + 'a').valid).toBe(true);
       expect(`${'a4kp9mx'.slice(0, 4)}-${'a4kp9mx'.slice(4)}a`).toBe(
         'a4kp-9mxa',
       );
     });
-  });
 
-  describe('README: generate a code', () => {
-    it("the prefixed form is 'ORD-a4kp-9mxa'", () => {
+    it("the prefixed form is the same code behind 'ORD-'", () => {
       expect(['ORD', 'a4kp-9mxa'].join(DEFAULT_SEPARATOR)).toBe(
         'ORD-a4kp-9mxa',
       );
-      expect(token.validate('a4kp-9mxa').valid).toBe(true);
+    });
+
+    it("the short configuration's 'q7t 3n7' is body 'q7t3n' plus check '7'", () => {
+      const short = createToken({ length: 6, chunkSize: 3, separator: ' ' });
+
+      expect(short.validate('q7t 3n7')).toEqual({ valid: true, body: 'q7t3n' });
+      expect(`${'q7t3n'.slice(0, 3)} ${'q7t3n'.slice(3)}7`).toBe('q7t 3n7');
+    });
+
+    it('an unchunked configuration produces no separator', () => {
+      expect(createToken({ chunkSize: 8 }).generate().value).not.toContain('-');
     });
   });
 
-  describe('README: validate a code', () => {
-    it('the four documented outcomes', () => {
-      expect(token.validate('a4kp-9mxa')).toEqual({
-        valid: true,
-        body: 'a4kp9mx',
-      });
-      expect(token.validate('a4kp-9mx8')).toEqual({
-        valid: false,
-        reason: 'check-failed',
-      });
-      expect(token.validate('a4kp-9mxo')).toEqual({
-        valid: false,
-        reason: 'outside-alphabet',
-      });
-      expect(token.validate('a4kp-9mx')).toEqual({
-        valid: false,
-        reason: 'wrong-length',
-      });
-    });
-
+  describe('README: valid is a filter, not a credential', () => {
     it('one code in n passes by construction', () => {
       const passing = [...DEFAULT_DICTIONARY].filter(
         (candidate) => token.validate(`a4kp9mx${candidate}`).valid,
@@ -82,7 +83,7 @@ describe('the documented examples', () => {
   });
 
   describe('README: what the check character catches', () => {
-    it('catches every single-character substitution', () => {
+    it('every single-character substitution, at every position', () => {
       const code = 'a4kp9mxa';
 
       for (let at = 0; at < code.length; at++) {
@@ -97,7 +98,7 @@ describe('the documented examples', () => {
       }
     });
 
-    it('misses a swap of `0` and `z`, and nothing else adjacent', () => {
+    it('every adjacent swap except `0` and `z`', () => {
       const missed = new Set<string>();
       const digits = [...DEFAULT_DICTIONARY];
 
@@ -119,27 +120,109 @@ describe('the documented examples', () => {
       expect([...missed]).toEqual(['0z']);
     });
 
-    it('the first and last dictionary entries are `0` and `z`', () => {
+    it('`0` and `z` are the first and last dictionary entries', () => {
       expect(DEFAULT_DICTIONARY.at(0)).toBe('0');
       expect(DEFAULT_DICTIONARY.at(-1)).toBe('z');
     });
   });
 
-  describe('README: separators are presentation', () => {
-    it('a code validates however it is grouped, and in capitals', () => {
-      expect(token.validate('a4kp9mxa').valid).toBe(true);
-      expect(token.validate('a4-kp-9m-xa').valid).toBe(true);
-      expect(token.validate('A4KP-9MXA')).toEqual({
-        valid: true,
-        body: 'a4kp9mx',
+  describe('README: entropy', () => {
+    it('35 bits is 34,359,738,368 values', () => {
+      expect((DEFAULT_LENGTH - 1) * Math.log2(32)).toBe(35);
+      expect(2 ** 35).toBe(34_359_738_368);
+    });
+
+    it('a 50% collision chance arrives at about 218,000 codes', () => {
+      const half = Math.sqrt(2 * Math.LN2 * 2 ** 35);
+
+      expect(Math.round(half / 1_000) * 1_000).toBe(218_000);
+    });
+
+    it('a collision is effectively certain at 1,000,000 codes', () => {
+      const certainty = 1 - Math.exp(-(1_000_000 ** 2) / (2 * 2 ** 35));
+
+      expect(certainty).toBeGreaterThan(0.999_999);
+    });
+
+    it('five more characters buys 25 more bits', () => {
+      expect(createToken({ length: 13, chunkSize: 13 }).entropyBits).toBe(60);
+    });
+
+    it('entropyBits is (length - 1) * log2(n) at every length', () => {
+      for (const length of [2, 8, 12, 16]) {
+        expect(createToken({ length, chunkSize: length }).entropyBits).toBe(
+          (length - 1) * 5,
+        );
+      }
+    });
+  });
+
+  describe('README: the alphabet', () => {
+    it('leaves out exactly `i`, `l`, `o` and `w`', () => {
+      const removed = [...'0123456789abcdefghijklmnopqrstuvwxyz'].filter(
+        (char) => !DEFAULT_DICTIONARY.includes(char),
+      );
+
+      expect(removed).toEqual(['i', 'l', 'o', 'w']);
+      expect(CONFUSABLE_CHARACTERS).toBe('ilow');
+      expect([...DEFAULT_DICTIONARY]).toHaveLength(32);
+    });
+
+    it('the documented defaults are 8, 4 and `-`', () => {
+      expect([DEFAULT_LENGTH, DEFAULT_CHUNK_SIZE, DEFAULT_SEPARATOR]).toEqual([
+        8,
+        4,
+        '-',
+      ]);
+      expect([token.length, token.chunkSize, token.separator]).toEqual([
+        8,
+        4,
+        '-',
+      ]);
+    });
+
+    it('rejects the 36-character alphabet as confusable', () => {
+      expect(
+        thrownBy('0123456789abcdefghijklmnopqrstuvwxyz'),
+      ).toBeInstanceOf(InvalidAlphabetError);
+      expect(thrownBy('0123456789abcdefghijklmnopqrstuvwxyz')).toMatchObject({
+        reason: 'confusable',
+        offending: ['i', 'l', 'o', 'w'],
       });
     });
 
-    it("the short configuration produces 'q7t 3n7'", () => {
-      const short = createToken({ length: 6, chunkSize: 3, separator: ' ' });
+    it('rejects a 30-character alphabet as non-uniform', () => {
+      expect(thrownBy('0123456789abcdefghjkmnpqrstuvx')).toBeInstanceOf(
+        InvalidAlphabetError,
+      );
+      expect(thrownBy('0123456789abcdefghjkmnpqrstuvx')).toMatchObject({
+        reason: 'non-uniform',
+      });
+      expect([...'0123456789abcdefghjkmnpqrstuvx']).toHaveLength(30);
+      expect(256 % 30).not.toBe(0);
+    });
 
-      expect(short.validate('q7t 3n7')).toEqual({ valid: true, body: 'q7t3n' });
-      expect(`${'q7t3n'.slice(0, 3)} ${'q7t3n'.slice(3)}7`).toBe('q7t 3n7');
+    it("over-represents four of Luhn's 36 characters by 14.3%", () => {
+      const luhn = createLuhn();
+
+      expect(luhn.uniformOverBytes).toBe(false);
+      expect(256 % luhn.n).toBe(4);
+      // Four indices are hit by 8 of the 256 bytes, the other 32 by 7.
+      expect(Math.round((8 / 7 - 1) * 1000) / 10).toBe(14.3);
+    });
+
+    it('samples the default alphabet uniformly', () => {
+      expect(256 % token.n).toBe(0);
+      expect(
+        createLuhn({ dictionary: DEFAULT_DICTIONARY }).uniformOverBytes,
+      ).toBe(true);
+    });
+  });
+
+  describe('README: chunking', () => {
+    it('rejects a chunkSize that does not divide length', () => {
+      expect(() => createToken({ length: 6 })).toThrow(InvalidShapeError);
+      expect(() => createToken({ length: 6, chunkSize: 3 })).not.toThrow();
     });
   });
 
@@ -160,136 +243,6 @@ describe('the documented examples', () => {
     it('`ORD` contains a character the alphabet excludes', () => {
       expect(DEFAULT_DICTIONARY).not.toContain('o');
       expect(CONFUSABLE_CHARACTERS).toContain('o');
-    });
-  });
-
-  describe('README: entropy', () => {
-    it('35 bits at the defaults', () => {
-      expect(token.entropyBits).toBe(35);
-      expect((DEFAULT_LENGTH - 1) * Math.log2(32)).toBe(35);
-      expect(2 ** 35).toBe(34_359_738_368);
-    });
-
-    it('a 50% collision chance at about 218,000 codes', () => {
-      const half = Math.sqrt(2 * Math.LN2 * 2 ** 35);
-
-      expect(Math.round(half / 1_000) * 1_000).toBe(218_000);
-    });
-
-    it('a collision is effectively certain at 1,000,000 codes', () => {
-      const certainty = 1 - Math.exp(-(1_000_000 ** 2) / (2 * 2 ** 35));
-
-      expect(certainty).toBeGreaterThan(0.999_999);
-    });
-
-    it('five more characters buys 25 more bits', () => {
-      expect(createToken({ length: 13, chunkSize: 13 }).entropyBits).toBe(60);
-    });
-  });
-
-  describe('README: the alphabet', () => {
-    it('the default', () => {
-      expect(token.dictionary).toBe('0123456789abcdefghjkmnpqrstuvxyz');
-      expect(token.n).toBe(32);
-      expect(DEFAULT_DICTIONARY).toBe('0123456789abcdefghjkmnpqrstuvxyz');
-      expect(CONFUSABLE_CHARACTERS).toBe('ilow');
-    });
-
-    it('the documented defaults', () => {
-      expect([DEFAULT_LENGTH, DEFAULT_CHUNK_SIZE, DEFAULT_SEPARATOR]).toEqual([
-        8,
-        4,
-        '-',
-      ]);
-      expect(token.length).toBe(8);
-      expect(token.chunkSize).toBe(4);
-      expect(token.separator).toBe('-');
-    });
-
-    it('a confusable dictionary is rejected at construction', () => {
-      try {
-        createToken({ dictionary: '0123456789abcdefghijklmnopqrstuvwxyz' });
-        expect.unreachable('the documented call must throw');
-      } catch (error) {
-        expect(error).toBeInstanceOf(InvalidAlphabetError);
-        expect(error).toMatchObject({
-          reason: 'confusable',
-          offending: ['i', 'l', 'o', 'w'],
-        });
-      }
-    });
-
-    it('a 30-character dictionary is rejected as non-uniform', () => {
-      try {
-        createToken({ dictionary: '0123456789abcdefghjkmnpqrstuvx' });
-        expect.unreachable('the documented call must throw');
-      } catch (error) {
-        expect(error).toBeInstanceOf(InvalidAlphabetError);
-        expect(error).toMatchObject({ reason: 'non-uniform' });
-      }
-      expect([...'0123456789abcdefghjkmnpqrstuvx']).toHaveLength(30);
-      expect(256 % 30).not.toBe(0);
-    });
-
-    it("Luhn's 36-character default over-represents four characters by 14.3%", () => {
-      const luhn = createLuhn();
-
-      expect(luhn.uniformOverBytes).toBe(false);
-      expect(256 % luhn.n).toBe(4);
-      // Four indices are hit by 8 of the 256 bytes, the other 32 by 7.
-      expect(Math.round((8 / 7 - 1) * 1000) / 10).toBe(14.3);
-    });
-
-    it('the default alphabet is uniform', () => {
-      expect(256 % token.n).toBe(0);
-      expect(
-        createLuhn({ dictionary: DEFAULT_DICTIONARY }).uniformOverBytes,
-      ).toBe(true);
-    });
-  });
-
-  describe('README: chunking', () => {
-    it('chunkSize must divide length', () => {
-      expect(() => createToken({ length: 6 })).toThrow(InvalidShapeError);
-      expect(() => createToken({ length: 6, chunkSize: 3 })).not.toThrow();
-    });
-
-    it('chunkSize equal to length produces an unchunked code', () => {
-      const unchunked = createToken({ chunkSize: 8 });
-
-      expect(unchunked.generate().value).not.toContain('-');
-    });
-  });
-
-  describe('doc comments', () => {
-    it('createToken', () => {
-      const instance = createToken();
-
-      expect(instance.validate('a4kp-9mxa')).toEqual({
-        valid: true,
-        body: 'a4kp9mx',
-      });
-      expect(instance.validate('a4kp-9mx8')).toEqual({
-        valid: false,
-        reason: 'check-failed',
-      });
-    });
-
-    it('DEFAULT_DICTIONARY is the lowercase alphanumerics less `i`, `l`, `o`, `w`', () => {
-      const removed = [...'0123456789abcdefghijklmnopqrstuvwxyz'].filter(
-        (char) => !DEFAULT_DICTIONARY.includes(char),
-      );
-
-      expect(removed).toEqual(['i', 'l', 'o', 'w']);
-      expect([...DEFAULT_DICTIONARY]).toHaveLength(32);
-    });
-
-    it('Token.entropyBits is (length - 1) * log2(n)', () => {
-      for (const length of [2, 8, 12, 16]) {
-        expect(createToken({ length, chunkSize: length }).entropyBits).toBe(
-          (length - 1) * 5,
-        );
-      }
     });
   });
 });

--- a/libs/token/src/lib/exceptions.ts
+++ b/libs/token/src/lib/exceptions.ts
@@ -1,13 +1,10 @@
-/**
- * Every error this library throws is raised by `createToken`. `generate` and
- * `validate` are total: an accepted configuration cannot fail at use.
- */
-
 const codePointList = (offending: readonly string[]): string =>
   offending.map((entry) => JSON.stringify(entry)).join(', ');
 
 /**
- * Base class for every error this library throws.
+ * Base class for every error this library throws. All of them are raised by
+ * `createToken`: `generate` and `validate` are total, so an accepted
+ * configuration cannot fail at use.
  *
  * ```ts
  * try {

--- a/libs/token/src/lib/token.ts
+++ b/libs/token/src/lib/token.ts
@@ -241,10 +241,12 @@ const assertShape = (
  * cannot carry a check character.
  *
  * @example
+ * ```ts @import.meta.vitest
  * const token = createToken();
  *
  * token.validate('a4kp-9mxa'); // -> { valid: true, body: 'a4kp9mx' }
  * token.validate('a4kp-9mx8'); // -> { valid: false, reason: 'check-failed' }
+ * ```
  */
 export function createToken(options: TokenOptions = {}): Token {
   const {

--- a/libs/token/tsconfig.lib.json
+++ b/libs/token/tsconfig.lib.json
@@ -14,6 +14,9 @@
   "references": [
     {
       "path": "../luhn/tsconfig.lib.json"
+    },
+    {
+      "path": "../../tools/doc-examples"
     }
   ],
   "exclude": [

--- a/libs/token/vite.config.ts
+++ b/libs/token/vite.config.ts
@@ -1,15 +1,26 @@
 import { defineConfig } from 'vite';
 
+import { docExampleSources, docExamples } from '@evanion/doc-examples';
+
+// The names the README's later blocks use without reintroducing the import line
+// every time. A block that does show its imports shadows these, so the two
+// never disagree. `token` is here as well as `createToken`, because the code a
+// reader needs in front of them is the call they are reading about, not the
+// construction they already saw at the top of the page.
+const preamble =
+  "import { createToken } from '@evanion/token';\nconst token = createToken();\n";
+
 export default defineConfig(() => ({
   root: import.meta.dirname,
   cacheDir: '../../node_modules/.vite/libs/token',
-  plugins: [],
+  ...docExamples({ preamble }),
   test: {
     name: '@evanion/token',
     watch: false,
     globals: true,
     environment: 'node',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    includeSource: docExampleSources(),
     reporters: ['default'],
     coverage: {
       reportsDirectory: './test-output/vitest/coverage',

--- a/libs/widget/src/constants.ts
+++ b/libs/widget/src/constants.ts
@@ -1,3 +1,10 @@
+/**
+ * Messages `Widgets` and `renderWidget` pass to `warnOnce`.
+ *
+ * Each one names the offending item's `id` and `type`, which is what lets
+ * `warnOnce` key on the message text and still report a second bad item
+ * separately.
+ */
 export const ERROR_MESSAGES = {
   UNKNOWN_WIDGET: (type: string, id: string) =>
     `Unknown widget type "${type}" for widget ID "${id}". Skipping render.`,

--- a/libs/widget/src/index.ts
+++ b/libs/widget/src/index.ts
@@ -1,12 +1,14 @@
-// No 'use client'. This package is deliberately importable from a React Server
-// Component: it uses only exports React provides under its `react-server`
+// This package carries no 'use client' and is importable from a React Server
+// Component. It uses only what React exports under its `react-server`
 // condition -- createElement, Suspense, memo -- and no createContext,
-// useContext, Component or stateful hook.
+// useContext, Component or stateful hook. `react/package.json` maps that
+// condition to `react.react-server.js`, which does not export them at all, so
+// reaching for one turns an import into `undefined` at module evaluation.
 //
-// That is easy to lose silently, so two guards exist. `*.server.test.tsx` runs
-// in a vitest project that resolves react under the `react-server` condition,
-// and scripts/verify-packaging.mjs asserts the packed dist/index.js carries
-// neither the directive nor a createContext/useContext call.
+// Neither a bundler nor a jsdom test run resolves that condition, so two
+// guards do. `*.server.test.tsx` runs in a vitest project that pins the
+// condition, and scripts/verify-packaging.mjs asserts the packed dist/index.js
+// carries neither the directive nor a createContext/useContext call.
 //
 // `./utils.js` is not re-exported: renderWidget and the nesting mechanism are
 // internal, so changing them is not a breaking release.

--- a/libs/widget/src/integration.test.tsx
+++ b/libs/widget/src/integration.test.tsx
@@ -2,7 +2,6 @@ import { render, screen, cleanup } from '@testing-library/react';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { createWidgets } from './widget.js';
 
-// Real-world CMS components
 const HeroBanner = ({
   title,
   subtitle,
@@ -135,7 +134,6 @@ describe('Widget System - CMS Integration Example', () => {
   });
 
   it('should render a complete e-commerce homepage', () => {
-    // Example: Complete e-commerce homepage with multiple widget types
     const { Widgets } = createWidgets({
       components: {
         heroBanner: HeroBanner,
@@ -221,14 +219,11 @@ describe('Widget System - CMS Integration Example', () => {
 
     render(<Widgets items={homepageItems} />);
 
-    // Verify homepage structure
     expect(screen.getByTestId('homepage')).toBeInTheDocument();
 
-    // Verify all widget sections are rendered
     const widgetSections = screen.getAllByTestId('widget-section');
     expect(widgetSections).toHaveLength(4);
 
-    // Verify hero banner
     expect(screen.getByTestId('hero-banner')).toBeInTheDocument();
     expect(screen.getByText('Welcome to Our Store')).toBeInTheDocument();
     expect(
@@ -236,14 +231,12 @@ describe('Widget System - CMS Integration Example', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('Shop Now')).toBeInTheDocument();
 
-    // Verify product grid
     expect(screen.getByTestId('product-grid')).toBeInTheDocument();
     expect(screen.getByText('Wireless Headphones')).toBeInTheDocument();
     expect(screen.getByText('$99.99')).toBeInTheDocument();
     expect(screen.getByText('Smart Watch')).toBeInTheDocument();
     expect(screen.getByText('$199.99')).toBeInTheDocument();
 
-    // Verify testimonial
     expect(screen.getByTestId('testimonial')).toBeInTheDocument();
     expect(
       screen.getByText('"This product changed my life!"'),
@@ -251,7 +244,6 @@ describe('Widget System - CMS Integration Example', () => {
     expect(screen.getByText('Jane Smith')).toBeInTheDocument();
     expect(screen.getByText('Tech Corp')).toBeInTheDocument();
 
-    // Verify newsletter signup
     expect(screen.getByTestId('newsletter-signup')).toBeInTheDocument();
     expect(screen.getByText('Stay Updated')).toBeInTheDocument();
     expect(
@@ -260,7 +252,6 @@ describe('Widget System - CMS Integration Example', () => {
   });
 
   it('should handle dynamic content updates', () => {
-    // Example: CMS content that changes based on user preferences or A/B testing
     const { Widgets } = createWidgets({
       components: {
         heroBanner: HeroBanner,
@@ -285,11 +276,9 @@ describe('Widget System - CMS Integration Example', () => {
 
     const { rerender } = render(<Widgets items={initialItems} />);
 
-    // Verify initial content
     expect(screen.getByText('Version A')).toBeInTheDocument();
     expect(screen.getByText('Original design')).toBeInTheDocument();
 
-    // Simulate A/B test variant
     const variantItems = [
       {
         id: 'hero1',
@@ -306,7 +295,6 @@ describe('Widget System - CMS Integration Example', () => {
 
     rerender(<Widgets items={variantItems} />);
 
-    // Verify updated content
     expect(screen.getByText('Version B')).toBeInTheDocument();
     expect(screen.getByText('Improved design')).toBeInTheDocument();
     expect(screen.getByText('Get Started')).toBeInTheDocument();
@@ -314,7 +302,6 @@ describe('Widget System - CMS Integration Example', () => {
   });
 
   it('should handle mixed widget types in different layouts', () => {
-    // Example: Different page layouts using the same widget system
     const { Widgets } = createWidgets({
       components: {
         heroBanner: HeroBanner,
@@ -324,7 +311,6 @@ describe('Widget System - CMS Integration Example', () => {
       },
     });
 
-    // Blog layout
     const blogItems = [
       {
         id: 'hero1',
@@ -346,7 +332,6 @@ describe('Widget System - CMS Integration Example', () => {
       screen.getByText('A deep dive into our latest insights'),
     ).toBeInTheDocument();
 
-    // Contact page layout
     const contactItems = [
       {
         id: 'contact1',
@@ -387,7 +372,6 @@ describe('Widget System - CMS Integration Example', () => {
   });
 
   it('should handle complex nested data structures', () => {
-    // Example: Complex CMS data with nested objects and arrays
     const { Widgets } = createWidgets({
       components: {
         productGrid: ProductGrid,
@@ -444,14 +428,12 @@ describe('Widget System - CMS Integration Example', () => {
 
     render(<Widgets items={complexItems} />);
 
-    // Verify product grid with complex data
     expect(screen.getByTestId('product-grid')).toBeInTheDocument();
     expect(screen.getByText('Premium Headphones')).toBeInTheDocument();
     expect(screen.getByText('$299.99')).toBeInTheDocument();
     expect(screen.getByText('Gaming Mouse')).toBeInTheDocument();
     expect(screen.getByText('$79.99')).toBeInTheDocument();
 
-    // Verify testimonial with complex data
     expect(screen.getByTestId('testimonial')).toBeInTheDocument();
     expect(
       screen.getByText(

--- a/libs/widget/src/malformed-items.test.tsx
+++ b/libs/widget/src/malformed-items.test.tsx
@@ -118,10 +118,11 @@ describe('malformed items are skipped instead of crashing', () => {
   });
 
   it('renders duplicate sibling ids rather than validating, per the safety-net split', () => {
-    // validateItems is the loud gate; the renderer stays defensive but never
-    // calls it. Two siblings sharing an id is a validateItems problem and must
-    // still render. React's own duplicate-key warning is dev-only and stripped
-    // in production, which is exactly why validateItems checks for it.
+    // Two siblings sharing an id is a `validateItems` problem and still
+    // renders: validation is the explicit gate, and the renderer only skips
+    // what it cannot render at all. React's own duplicate-key warning is
+    // dev-only and dropped in a production build, so `validateItems` is the
+    // only place the duplicate is reported where it matters.
     const errorSpy = vi
       .spyOn(console, 'error')
       .mockImplementation(() => undefined);

--- a/libs/widget/src/meta.test.tsx
+++ b/libs/widget/src/meta.test.tsx
@@ -12,7 +12,7 @@ const Leaf = (props: { label: string }) => {
   return <span data-testid={`leaf-${props.label}`}>{props.label}</span>;
 };
 
-describe('item meta (#71)', () => {
+describe('item meta', () => {
   beforeEach(() => {
     cleanup();
     spyProps.mockClear();

--- a/libs/widget/src/performance.test.tsx
+++ b/libs/widget/src/performance.test.tsx
@@ -32,14 +32,11 @@ describe('Widget System - Performance', () => {
 
     const { rerender } = render(<Widgets items={items} />);
 
-    // Initial render
     expect(renderSpy).toHaveBeenCalledTimes(1);
 
-    // Re-render with same props - should not cause widget to re-render
     rerender(<Widgets items={items} />);
     expect(renderSpy).toHaveBeenCalledTimes(1);
 
-    // Re-render with different items - should cause re-render
     const newItems = [
       {
         id: 'widget1',
@@ -95,14 +92,11 @@ describe('Widget System - Performance', () => {
 
     const { rerender } = render(<Widgets items={items} />);
 
-    // Initial render
     expect(outputRenderSpy).toHaveBeenCalledTimes(1);
 
-    // Re-render with same items - should not cause re-render
     rerender(<Widgets items={items} />);
     expect(outputRenderSpy).toHaveBeenCalledTimes(1);
 
-    // Re-render with different children - should cause re-render
     const newItems = [
       {
         id: 'card1',
@@ -135,14 +129,12 @@ describe('Widget System - Performance', () => {
       },
     });
 
-    // Create 1000 widgets
-    // 50 rather than 1000. The library renders every item eagerly with no
-    // windowing, so a 1000-item region is not a workload it should imply support
-    // for -- realistic CMS regions, sidebars and dashboards are in the tens. At
-    // 1000 this also took long enough under the CPU contention of a full
-    // `nx run-many` to blow vitest's 5s timeout, failing intermittently for
-    // reasons that had nothing to do with correctness.
-    // For genuinely large regions, render a virtualized component *as* a widget.
+    // 50 items, which is the order of a real CMS region, sidebar or dashboard.
+    // The renderer has no windowing and renders every item eagerly, so a count
+    // in the thousands measures the machine rather than the library and, under
+    // the CPU contention of a full `nx run-many`, exceeds vitest's 5s default
+    // timeout. A genuinely large region is served by rendering a virtualized
+    // component as a widget.
     const items = Array.from({ length: 50 }, (_, i) => ({
       id: `widget-${i}`,
       type: 'test' as const,
@@ -151,12 +143,11 @@ describe('Widget System - Performance', () => {
 
     render(<Widgets items={items} />);
 
-    // Exactly one render per widget is the real performance property here, and
-    // unlike wall-clock time it is a property of the library rather than of the
-    // machine. This deliberately does not assert an elapsed-time budget: the
-    // suite runs concurrently with build, lint and typecheck, and a 1000ms
-    // threshold that passed in isolation took 2369ms under that load -- failing
-    // every cold run while looking like flakiness.
+    // One render per widget, rather than an elapsed-time budget. Render count
+    // is a property of the library; wall-clock time is a property of the
+    // machine, and `nx run-many` schedules this suite alongside build, lint and
+    // typecheck, where a threshold calibrated on an idle machine fails and
+    // reads as flakiness.
     expect(renderSpy).toHaveBeenCalledTimes(50);
     expect(screen.getByTestId('widget-0')).toBeInTheDocument();
     expect(screen.getByTestId('widget-49')).toBeInTheDocument();
@@ -192,10 +183,8 @@ describe('Widget System - Performance', () => {
       <Widgets items={items} components={instanceComponents} />,
     );
 
-    // Initial render
     expect(renderSpy).toHaveBeenCalledTimes(1);
 
-    // Re-render with same instance components reference - should not cause re-render
     rerender(<Widgets items={items} components={instanceComponents} />);
     expect(renderSpy).toHaveBeenCalledTimes(1);
   });
@@ -235,16 +224,13 @@ describe('Widget System - Performance', () => {
 
     render(<TestComponent />);
 
-    // Initial render
     expect(renderSpy).toHaveBeenCalledTimes(1);
 
-    // Click button multiple times rapidly
     const button = screen.getByText('Increment');
     fireEvent.click(button);
     fireEvent.click(button);
     fireEvent.click(button);
 
-    // Should only re-render when count actually changes
     expect(renderSpy).toHaveBeenCalledTimes(4); // Initial + 3 clicks
     expect(screen.getByText('Count: 3')).toBeInTheDocument();
   });
@@ -273,14 +259,11 @@ describe('Widget System - Performance', () => {
 
     const { rerender } = render(<Widgets items={items} />);
 
-    // Initial render
     expect(renderSpy).toHaveBeenCalledTimes(1);
 
-    // Re-render with same items - should not cause re-render due to memoization
     rerender(<Widgets items={items} />);
     expect(renderSpy).toHaveBeenCalledTimes(1);
 
-    // Re-render with different items - should cause re-render
     const newItems = [
       {
         id: 'widget1',
@@ -355,11 +338,9 @@ describe('Widget System - Performance', () => {
 
     const { rerender } = render(<Widgets items={items} />);
 
-    // Initial render
     expect(cardRenderSpy).toHaveBeenCalledTimes(2); // 2 cards
     expect(textRenderSpy).toHaveBeenCalledTimes(3); // 3 text widgets
 
-    // Re-render with same items - should not cause re-renders
     rerender(<Widgets items={items} />);
     expect(cardRenderSpy).toHaveBeenCalledTimes(2);
     expect(textRenderSpy).toHaveBeenCalledTimes(3);

--- a/libs/widget/src/regressions.test.tsx
+++ b/libs/widget/src/regressions.test.tsx
@@ -2,10 +2,10 @@ import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { PropsWithChildren, useState } from 'react';
 
-// Deliberately imported from the public barrel rather than the internal
-// modules. Every other test file imports from './widget.js' or './widgets'
-// directly, which is exactly why the missing `export * from './widgets.js'` went
-// unnoticed.
+// Imported from the public barrel, unlike every other test file here, which
+// reaches './widget.js' and './widgets.js' directly. Only this import path can
+// tell that a re-export is missing from `src/index.ts`, which is what a
+// consumer resolves.
 import { createWidgets, DefaultItem, DefaultWrapper } from './index.js';
 
 const Box = ({ label, children }: PropsWithChildren<{ label: string }>) => (
@@ -72,9 +72,9 @@ describe('widget regressions', () => {
 
       expect(screen.getByTestId('box-a')).toBeInTheDocument();
       expect(screen.getByTestId('box-b')).toBeInTheDocument();
-      // Guards against grandchildren silently not rendering: Output must pass
-      // itself down at every nesting level, not just the first, or deeper
-      // content renders without any Output wrapping it.
+      // The grandchild is the assertion: `renderWidget` recurses through
+      // `item.children` at every level, so a renderer that handles only the
+      // first level renders a and b and drops c without warning.
       expect(screen.getByTestId('leaf-c')).toBeInTheDocument();
     });
 
@@ -168,14 +168,14 @@ describe('widget regressions', () => {
           .mockImplementation(() => undefined);
         const { Widgets } = createWidgets({ components: { leaf: Leaf } });
 
-        // `type in components` walked the prototype chain and handed React
-        // Object.prototype.toString, crashing instead of warning and skipping.
+        // `in` walks the prototype chain, so a lookup written that way finds
+        // these keys on Object.prototype and hands React a built-in function
+        // as a component. Items are untrusted CMS data, so the renderer owes
+        // the same warn-and-skip here as for any unknown type.
         expect(() =>
           render(
             <Widgets
               items={[
-                // Untrusted input: an inherited Object.prototype key. Cast
-                // because the point of the test is the runtime guard.
                 { id: 'x', type, props: {} } as unknown as {
                   id: string;
                   type: 'leaf';
@@ -232,9 +232,9 @@ describe('widget regressions', () => {
         />,
       );
 
-      // Guards against nested items falling back to the factory-level chrome:
-      // renderWidget threads the resolved chrome through the recursion, so a
-      // nested item gets the instance-level override too.
+      // Two, not one: `renderWidget` threads the resolved chrome through the
+      // recursion, so the nested item is wrapped in the instance-level
+      // override rather than falling back to the factory's.
       expect(
         container.querySelectorAll('[data-custom-item="yes"]'),
       ).toHaveLength(2);
@@ -262,11 +262,11 @@ describe('widget regressions', () => {
       fireEvent.click(screen.getByTestId('inc'));
       expect(screen.getByTestId('inc')).toHaveTextContent('count:2');
 
-      // A fresh array identity forces Widgets to re-render. This guards
-      // against React remounting the nested subtree when that happens: the
-      // injected Output component keeps a stable identity across renders
-      // rather than a new type each time, so nested state -- the counter here
-      // -- survives.
+      // A fresh array identity defeats the `memo` and forces a re-render.
+      // React remounts a subtree whenever the element type at that position
+      // changes identity, so the renderer has to reuse the same component
+      // references across renders rather than defining any of them per render;
+      // the counter's state is what shows it does.
       rerender(<Widgets items={[...items]} />);
 
       expect(screen.getByTestId('inc')).toHaveTextContent('count:2');

--- a/libs/widget/src/rsc.server.test.tsx
+++ b/libs/widget/src/rsc.server.test.tsx
@@ -4,17 +4,23 @@ import * as pkg from './index.js';
 import { createWidgets } from './index.js';
 
 /**
- * This file runs in the `@evanion/react-widget:react-server` vitest project,
- * which resolves react under its `react-server` export condition. That build
- * omits createContext, useContext, Component, PureComponent and every stateful
- * hook, so any of them creeping back into the package fails here at module
- * evaluation -- which is exactly the failure mode that shipped as #22 and that
- * the `'use client'` directive was papering over.
+ * Holds `@evanion/react-widget` to its promise of being importable from a React
+ * Server Component.
  *
- * There is no DOM renderer under this condition (`react-dom/server` throws
- * outright), so rendering is driven by invoking the component functions and
- * walking the element tree they return. That still executes every line of
- * `renderWidget`, because the recursion happens during render, not lazily.
+ * This file runs in the `@evanion/react-widget:react-server` vitest project,
+ * which resolves react under its `react-server` export condition.
+ * `react/package.json` maps that condition to `react.react-server.js`, which
+ * exports no createContext, useContext, Component, PureComponent or stateful
+ * hook, so an import of one is `undefined` and fails at module evaluation. No
+ * other suite resolves that condition: the library build and the jsdom project
+ * both get the default entry, where all of them exist.
+ *
+ * Rendering is driven by invoking the component functions and walking the
+ * element tree they return, because there is no renderer to call --
+ * `react-dom/server` resolves under this condition to a module whose only
+ * statement throws "react-dom/server is not supported in React Server
+ * Components". Walking the tree still executes every line of `renderWidget`,
+ * since the recursion happens during render rather than lazily.
  */
 
 type Element = React.ReactElement<Record<string, unknown>>;
@@ -59,7 +65,11 @@ describe('@evanion/react-widget under react-server', () => {
     expect(pkg.DefaultWrapper).toBeTypeOf('function');
   });
 
-  it('no longer exports the context-based surface', () => {
+  it('keeps internals and client-only shapes out of the published surface', () => {
+    // A provider, a hook, a context and a class error boundary each need a
+    // react export this condition omits, so none of them can be exported. The
+    // render internals are absent for a different reason: nothing outside the
+    // package may depend on them.
     const surface = pkg as unknown as Record<string, unknown>;
     expect(surface['WidgetsProvider']).toBeUndefined();
     expect(surface['useWidgets']).toBeUndefined();

--- a/libs/widget/src/ssr.test.tsx
+++ b/libs/widget/src/ssr.test.tsx
@@ -44,8 +44,9 @@ describe('server rendering', () => {
     container.innerHTML = html;
     document.body.appendChild(container);
 
-    // A hydration mismatch is reported through console.error, and React
-    // silently repairs the DOM afterwards -- so the spy is the assertion.
+    // React reports a hydration mismatch through console.error and then
+    // repairs the DOM, so the rendered result looks correct either way and the
+    // spy is the only thing that can tell the difference.
     const errorSpy = vi
       .spyOn(console, 'error')
       .mockImplementation(() => undefined);

--- a/libs/widget/src/suspense.test.tsx
+++ b/libs/widget/src/suspense.test.tsx
@@ -83,10 +83,10 @@ describe('suspense boundary', () => {
   });
 
   it('suspends and resolves a data-fetching widget', async () => {
-    // A widget that fetches its own data is the point of the redesign. On the
-    // client that is `use(promise)`; in an RSC graph it is the `await` in an
-    // async Server Component. Both suspend through the same mechanism, and only
-    // the first is renderable without a flight renderer.
+    // A widget that fetches its own data suspends through the same mechanism
+    // whether it is `use(promise)` on the client or the `await` in an async
+    // Server Component. `use` is the form this suite can exercise: rendering an
+    // async component needs a flight renderer, which jsdom has none of.
     const fetched = new Map<string, Promise<string>>();
     const fetchValue = (id: string) => {
       const existing = fetched.get(id);

--- a/libs/widget/src/types.test-d.tsx
+++ b/libs/widget/src/types.test-d.tsx
@@ -84,7 +84,7 @@ describe('widget type inference', () => {
     ]);
   });
 
-  it('rejects `children` on a component that does not accept children (#25.2)', () => {
+  it('rejects `children` on a component that does not accept children', () => {
     const { defineItems } = createWidgets({ components });
 
     defineItems([

--- a/libs/widget/src/types.ts
+++ b/libs/widget/src/types.ts
@@ -42,11 +42,13 @@ export type WidgetDataProps<C extends AnyWidgetComponent> = [
   : Omit<ComponentProps<C>, 'children'>;
 
 /**
- * Whether a component actually accepts `children`.
+ * The item's nested items when `C[K]` accepts `children`, and `never` when it
+ * does not.
  *
- * This is what makes nesting checkable. Attaching `children` to every variant
- * of the union let a CMS editor nest items under a widget that never renders
- * them, and they vanished with no compile error and no console output (#25.2).
+ * `never` is what makes `children` unwritable on such an item. The alternative
+ * -- `WidgetItem<C>[]` on every variant of the union -- admits nesting under a
+ * widget that never renders `children`, and the renderer then drops the whole
+ * nested subtree with no compile error and nothing logged.
  */
 export type WidgetChildren<
   C extends WidgetComponentMap,
@@ -72,7 +74,8 @@ export type WidgetItem<C extends WidgetComponentMap> = {
      * Placement and presentation data for the item chrome: grid column, span,
      * ordering, CMS edit affordances. Handed to `chrome.item` and never
      * spread into the widget's own props, because where a widget sits is not
-     * something the widget should know (#71).
+     * something the widget should know, and an unknown key spread onto a DOM
+     * element draws a React unknown-attribute warning.
      */
     meta?: Record<string, unknown>;
     /**

--- a/libs/widget/src/validate-items.ts
+++ b/libs/widget/src/validate-items.ts
@@ -30,6 +30,12 @@ function knows(known: KnownWidgetTypes, type: string): boolean {
  * is an explicit step run at ingestion or build time. Required props are
  * already checked at compile time by `WidgetItem<C>`; this exists for data that
  * bypasses the type checker.
+ *
+ * @example
+ * ```ts
+ * validateItems([{ id: 'a', type: 'nope', props: {} }], ['news']);
+ * // [{ index: 0, id: 'a', type: 'nope', message: 'unknown widget type' }]
+ * ```
  */
 export function validateItems(
   items: unknown,

--- a/libs/widget/src/warn.ts
+++ b/libs/widget/src/warn.ts
@@ -1,20 +1,22 @@
+/** Messages already reported, for the lifetime of the process. */
+const seen = new Set<string>();
+
 /**
  * Dev-only console warning, emitted once per distinct message.
  *
- * The renderer warns from render, so a single stale `type` in a CMS payload
- * logs again on every re-render, and twice over for a page that renders on the
- * server and then hydrates. Every message carries the offending item's `type`
- * and `id`, so keying on the message text reports each bad item exactly once
- * per process while still reporting a second bad item separately.
+ * The renderer warns from render, so one stale `type` in a CMS payload logs
+ * again on every re-render, and twice over for a page that renders on the
+ * server and then hydrates. Every message in `ERROR_MESSAGES` carries the
+ * offending item's `type` and `id`, which is what makes the message text a
+ * usable key: each bad item is reported once per process, and a second bad
+ * item is still reported separately.
  *
- * Nothing is logged when `NODE_ENV` is `production`: bundlers fold that check
- * to `false` and drop the call, so a stale item never reaches an end user's
- * console.
+ * Nothing is logged when `NODE_ENV` is `production`. A bundler folds that
+ * comparison to `false` and drops the call, so a stale item never reaches an
+ * end user's console.
  *
  * Internal: not re-exported from the package entry point.
  */
-const seen = new Set<string>();
-
 export function warnOnce(message: string): void {
   if (process.env.NODE_ENV === 'production') return;
   if (seen.has(message)) return;
@@ -25,9 +27,11 @@ export function warnOnce(message: string): void {
 /**
  * Clears the set of already-reported messages.
  *
- * The set lives as long as the process, which is what a dev server wants and
- * what a test file does not: one case's warning would silence the next case
- * that produces the same message. `test-setup.ts` calls this before each test.
+ * A set that lives as long as the process is what a dev server wants and what a
+ * test file cannot have: one case's warning would silence the next case that
+ * produces the same message. `test-setup.ts` calls this before each test.
+ *
+ * Internal: not re-exported from the package entry point.
  */
 export function resetWarnings(): void {
   seen.clear();

--- a/libs/widget/src/widget.test.tsx
+++ b/libs/widget/src/widget.test.tsx
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createWidgets } from './widget.js';
 import { PropsWithChildren } from 'react';
 
-// Test components for our examples
 const NewsTeaser = ({
   title,
   publishedAt,
@@ -74,7 +73,6 @@ describe('Widget System - Basic Usage', () => {
   });
 
   it('should render widgets with basic configuration', () => {
-    // Example: Basic sidebar with news and user info
     const { Widgets } = createWidgets({
       components: {
         news: NewsTeaser,
@@ -105,12 +103,10 @@ describe('Widget System - Basic Usage', () => {
 
     render(<Widgets items={items} />);
 
-    // Verify user sidebar is rendered
     expect(screen.getByTestId('user-sidebar')).toBeInTheDocument();
     expect(screen.getByText('Evanion')).toBeInTheDocument();
     expect(screen.getByText('5 messages')).toBeInTheDocument();
 
-    // Verify news teaser is rendered
     expect(screen.getByTestId('news-teaser')).toBeInTheDocument();
     expect(screen.getByText('Breaking News')).toBeInTheDocument();
     expect(screen.getByText('1/15/2024')).toBeInTheDocument();
@@ -125,7 +121,6 @@ describe('Widget System - Basic Usage', () => {
 
     render(<Widgets items={[]} />);
 
-    // Should render without errors
     expect(screen.queryByTestId('news-teaser')).not.toBeInTheDocument();
   });
 
@@ -137,9 +132,9 @@ describe('Widget System - Basic Usage', () => {
     });
 
     const items = [
-      // Deliberately not in the component map: this models untrusted CMS data
-      // and is cast wholesale, because rejecting it is exactly what the types
-      // now do. The test asserts the runtime guard still warns and skips.
+      // A type the component map does not contain, cast wholesale. The types
+      // reject this item, which is the point: it models a CMS payload that
+      // never met the type checker, and the renderer is the net underneath.
       {
         id: 'unknown',
         type: 'unknownType',
@@ -162,7 +157,6 @@ describe('Widget System - Basic Usage', () => {
 
     render(<Widgets items={items} />);
 
-    // Only the valid news should render
     expect(screen.getByTestId('news-teaser')).toBeInTheDocument();
     expect(screen.getByText('Valid News')).toBeInTheDocument();
     expect(
@@ -177,7 +171,6 @@ describe('Widget System - Custom Chrome', () => {
   });
 
   it('should render with custom wrapper chrome', () => {
-    // Example: E-commerce product showcase with custom styling
     const { Widgets } = createWidgets({
       components: {
         productCard: ProductCard,
@@ -216,17 +209,14 @@ describe('Widget System - Custom Chrome', () => {
 
     render(<Widgets items={items} />);
 
-    // Verify custom wrapper is applied
     expect(screen.getByTestId('product-showcase')).toBeInTheDocument();
     expect(screen.getByText('Featured Products')).toBeInTheDocument();
 
-    // Verify widgets are rendered inside the wrapper
     expect(screen.getByTestId('banner')).toBeInTheDocument();
     expect(screen.getByTestId('product-card')).toBeInTheDocument();
   });
 
   it('should render with custom item wrapper chrome', () => {
-    // Example: Blog sidebar with custom item styling
     const { Widgets } = createWidgets({
       components: {
         news: NewsTeaser,
@@ -259,7 +249,6 @@ describe('Widget System - Custom Chrome', () => {
 
     render(<Widgets items={items} />);
 
-    // Verify both wrappers are applied
     expect(screen.getByTestId('blog-sidebar')).toBeInTheDocument();
     expect(screen.getByTestId('widget-item')).toBeInTheDocument();
     expect(screen.getByTestId('news-teaser')).toBeInTheDocument();
@@ -272,7 +261,6 @@ describe('Widget System - Instance Overrides', () => {
   });
 
   it('should allow instance-specific component overrides', () => {
-    // Example: Different news components for different pages
     const { Widgets } = createWidgets({
       components: {
         news: NewsTeaser,
@@ -308,7 +296,6 @@ describe('Widget System - Instance Overrides', () => {
       <Widgets items={items} components={{ news: specialNewsComponent }} />,
     );
 
-    // Should use the overridden component
     expect(screen.getByTestId('featured-news')).toBeInTheDocument();
     expect(screen.getByText('Featured: Regular News')).toBeInTheDocument();
     expect(
@@ -351,7 +338,6 @@ describe('Widget System - Instance Overrides', () => {
       />,
     );
 
-    // Should use the overridden chrome
     expect(screen.getByTestId('override-wrapper')).toBeInTheDocument();
     expect(screen.getByText('Override:')).toBeInTheDocument();
     expect(screen.queryByTestId('default-wrapper')).not.toBeInTheDocument();
@@ -364,7 +350,6 @@ describe('Widget System - Nested Widgets', () => {
   });
 
   it('should render nested widgets through children', () => {
-    // Example: Card with nested content
     const CardWidget = ({ title, children }: PropsWithChildren<{ title: string }>) => (
       <div data-testid="card" className="card">
         <h3>{title}</h3>
@@ -407,11 +392,9 @@ describe('Widget System - Nested Widgets', () => {
 
     render(<Widgets items={items} />);
 
-    // Verify card is rendered
     expect(screen.getByTestId('card')).toBeInTheDocument();
     expect(screen.getByText('My Card')).toBeInTheDocument();
 
-    // Verify nested widgets are rendered
     const textWidgets = screen.getAllByTestId('text');
     expect(textWidgets).toHaveLength(2);
     expect(screen.getByText('Nested text content')).toBeInTheDocument();
@@ -445,7 +428,6 @@ describe('Widget System - Nested Widgets', () => {
 
     render(<Widgets items={items} />);
 
-    // Should render without errors
     expect(screen.getByTestId('card')).toBeInTheDocument();
     expect(screen.getByText('Empty Card')).toBeInTheDocument();
   });
@@ -464,7 +446,7 @@ describe('Widget System - Nested Widgets', () => {
     const items = [
       {
         id: 'unknown1',
-        // Deliberately not in the component map -- see note above.
+        // A type the component map does not contain, cast past the check.
         type: 'unknown-widget' as unknown as 'text',
         props: { content: 'This should not render' },
       },
@@ -486,7 +468,6 @@ describe('Widget System - Real World Examples', () => {
   });
 
   it('should handle CMS-driven blog layout', () => {
-    // Example: Blog with author bio, related posts, and social sharing
     const AuthorBio = ({
       name,
       bio,
@@ -575,7 +556,6 @@ describe('Widget System - Real World Examples', () => {
 
     render(<Widgets items={blogItems} />);
 
-    // Verify all components are rendered
     expect(screen.getByTestId('blog-sidebar')).toBeInTheDocument();
     expect(screen.getByTestId('author-bio')).toBeInTheDocument();
     expect(screen.getByText('John Doe')).toBeInTheDocument();
@@ -586,7 +566,6 @@ describe('Widget System - Real World Examples', () => {
   });
 
   it('should handle dashboard with mixed widget types', () => {
-    // Example: Admin dashboard with charts, stats, and actions
     const StatCard = ({
       title,
       value,
@@ -667,10 +646,8 @@ describe('Widget System - Real World Examples', () => {
 
     render(<Widgets items={dashboardItems} />);
 
-    // Verify dashboard layout
     expect(screen.getByTestId('dashboard-grid')).toBeInTheDocument();
 
-    // Verify stat cards
     const statCards = screen.getAllByTestId('stat-card');
     expect(statCards).toHaveLength(2);
     expect(screen.getByText('Total Users')).toBeInTheDocument();
@@ -678,7 +655,6 @@ describe('Widget System - Real World Examples', () => {
     expect(screen.getByText('Revenue')).toBeInTheDocument();
     expect(screen.getByText('$45,678')).toBeInTheDocument();
 
-    // Verify action button
     expect(screen.getByTestId('action-button')).toBeInTheDocument();
     expect(screen.getByText('Export Data')).toBeInTheDocument();
   });

--- a/libs/widget/src/widgets.tsx
+++ b/libs/widget/src/widgets.tsx
@@ -1,17 +1,27 @@
 import type { HTMLProps } from 'react';
 
+/**
+ * Default chrome around the whole set: a `<section>` carrying whatever props it
+ * is handed.
+ *
+ * `<section>` rather than `<div>` because a named section maps to the `region`
+ * landmark role (HTML-AAM), so a caller who passes `aria-label` gets a widget
+ * region that is reachable by landmark navigation and one who does not is no
+ * worse off than with a `<div>`.
+ */
 export function DefaultWrapper(props: HTMLProps<HTMLDivElement>) {
   return <section {...props} />;
 }
 
 /**
- * Default item chrome: a plain `<div>` carrying the `data-widget-*` attributes
- * that CMS click-to-edit overlays, analytics and E2E selectors key off.
+ * Default chrome around one widget: a `<div>` carrying the `data-widget-*`
+ * attributes that CMS click-to-edit overlays, analytics and E2E selectors key
+ * off.
  *
- * `meta` is deliberately dropped rather than forwarded: it is arbitrary
- * consumer data with no meaning to the DOM, and spreading it onto an element
- * would produce React unknown-attribute warnings. A custom `chrome.item` is
- * where meta is meant to be read.
+ * `meta` is dropped rather than forwarded. It is arbitrary consumer data with
+ * no meaning to the DOM, and React warns about an unknown attribute on every
+ * key of it that reaches an element. A custom `chrome.item` is where meta is
+ * read.
  */
 export function DefaultItem({
   meta: _meta,

--- a/libs/widget/vite.config.ts
+++ b/libs/widget/vite.config.ts
@@ -14,12 +14,6 @@ export default defineConfig(() => ({
       tsconfigPath: path.join(import.meta.dirname, 'tsconfig.lib.json'),
     }),
   ],
-  // Uncomment this if you are using workers.
-  // worker: {
-  //  plugins: [ nxViteTsPaths() ],
-  // },
-  // Configuration for building your library.
-  // See: https://vitejs.dev/guide/build.html#library-mode
   build: {
     outDir: './dist',
     emptyOutDir: true,
@@ -28,16 +22,18 @@ export default defineConfig(() => ({
       transformMixedEsModules: true,
     },
     lib: {
-      // Could also be a dictionary or array of multiple entry points.
       entry: 'src/index.ts',
       name: '@evanion/react-widget',
       fileName: 'index',
-      // Change this to the formats you want to support.
-      // Don't forget to update your package.json as well.
+      // ES only, which is the single form package.json declares: `type:
+      // module` plus an exports map whose every condition points at
+      // `dist/index.js`.
       formats: ['es' as const],
     },
     rolldownOptions: {
-      // External packages that should not be bundled into your library.
+      // React is a peer dependency, so it resolves to the consumer's copy.
+      // Bundling it would put a second React in the graph, and an element
+      // created by one copy is not recognised by the other's renderer.
       external: ['react', 'react-dom', 'react/jsx-runtime'],
     },
   },
@@ -71,12 +67,13 @@ export default defineConfig(() => ({
           exclude: ['**/*.server.{test,spec}.{ts,tsx}'],
         },
       },
-      // This package is importable from a React Server Component because it
-      // never carries 'use client'. React's `react-server` export condition
-      // omits createContext, useContext, Component and every stateful hook, so
-      // a reintroduced import breaks that silently: the build succeeds and
-      // every jsdom test still passes. This project resolves react under that
-      // condition so the failure surfaces here.
+      // The project that holds this package to its Server Component promise.
+      // `react/package.json` maps the `react-server` condition to
+      // `react.react-server.js`, which exports no createContext, useContext,
+      // Component or stateful hook. Nothing else in the repo resolves that
+      // condition -- the library build and the jsdom project both get the
+      // default entry, where every one of those exports is present -- so an
+      // import of one fails here and nowhere else.
       {
         extends: true,
         resolve: { conditions: ['react-server'] },


### PR DESCRIPTION
Raises every comment and docblock in `libs/widget` (`@evanion/react-widget`),
`libs/astro-widget`, `libs/token` and `libs/feature` to the same standard:
a comment states what the code does or requires, then the constraint outside the
file that forces it. No change narration, no issue numbers, no restatement of a
signature.

## Per package

| Package | Rewritten | Deleted | New docblocks |
| --- | --- | --- | --- |
| react-widget | 23 | 62 | 4 |
| astro-widget | 10 | 0 (2 shrunk to pointers) | 4 |
| token | 3 | 2 | 2 |
| feature | 11 | 2 | 1 |

The 62 deletions in react-widget are comments that carried no fact the file did
not already have: generator leftovers in `vite.config.ts` (`// Uncomment this if
you are using workers`, `// Could also be a dictionary or array of multiple
entry points`), and `// Verify X`, `// Example: X`, `// Initial render`,
`// Re-render with same props - should not cause widget to re-render` through
`widget.test.tsx`, `integration.test.tsx` and `performance.test.tsx`.

## Episodes turned into constraints

- The react-server guards now cite what enforces them. `react/package.json` maps
  the `react-server` condition to `react.react-server.js`, which exports no
  `createContext`, `useContext`, `Component` or stateful hook, and
  `react-dom/server` resolves under it to a module whose only statement throws
  `react-dom/server is not supported in React Server Components`. Nothing else
  in the repo resolves that condition, which is the reason the vitest project
  and `scripts/verify-packaging.mjs` both exist. The guards were not weakened.
- `WidgetChildren` resolving to `never` is explained by what the alternative
  admits rather than by the issue number where it bit.
- `libs/feature` cites `docs/specs/2026-09-11-feature-toggles.md` — "Cascade",
  "Result" and "Rollout bucketing" — where the constraint is a spec rule. The
  "2022 sketch" and `@evanion/luhn` issue references are gone.
- `DefaultWrapper` renders `<section>` because a named section maps to the
  `region` landmark role (HTML-AAM).

## token now executes its documented examples

`libs/token/vite.config.ts` wires `docExamples()` from `tools/doc-examples`, the
same mechanism `libs/luhn` and `libs/urn` use. Every `EXPR; // -> VALUE` line in
a marked README block and in `createToken`'s `@example` is rewritten into an
`expect` and run by vite-plugin-doctest — 5 README tests and 1 source test. A
claim that is wrong fails where it is written; verified by flipping
`token.n; // -> 32` to `33` and watching `README.md#4` fail.

`src/lib/docs.spec.ts` keeps what that form cannot carry, and says so at the
top:

- `generate` draws from `crypto.randomBytes`, so its documented outputs cannot
  be reproduced. What is checked instead is that each one is internally
  consistent — the printed `value` is the printed `body` plus a check character
  that validates, chunked by the documented `chunkSize`. Those README blocks
  are left unmarked and illustrative.
- Arithmetic a reader takes on trust: 35 bits, 34,359,738,368 values, the
  218,000-code collision point, 25 extra bits for 5 extra characters.
- The exhaustive single-substitution sweep and the adjacent-swap sweep that
  pins Luhn's blind spot to `{0, z}`.
- The dictionary rejections, which throw and so cannot be a value claim.

`libs/token/tsconfig.lib.json` gains the `tools/doc-examples` project reference
that `nx sync` requires for the new import.

## Verification

```
npx nx run-many -t lint test build typecheck check --all
  NX   Successfully ran targets lint, test, build, typecheck, check for 14 projects

node scripts/verify-packaging.mjs
  ✓ react-widget ships no 'use client' directive
  ✓ react-widget imports no client-only React API
  ✓ feature core imports nothing from react
  ✓ feature ships 'use client' on the react entry only
  Packaging verified.
```

## One thing that is wrong in the code, not in its comments

`libs/astro-widget/src/validate-blocks.ts` tests `!(type in registry)`. `in`
walks the prototype chain, so a CMS block of type `constructor`, `toString` or
`valueOf` validates clean. Its react-widget twin uses
`Object.prototype.hasOwnProperty.call(...)` for exactly this, and
`regressions.test.tsx` covers the four keys. Left alone here because this PR
changes comments only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019s6FWxb6zpDUvbN4j1XH2B
