### PR TITLE
docs(repo): state the constraint behind every comment in the apps, tools and configs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,13 +50,6 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      # This enables task distribution via Nx Cloud
-      # Run this command as early as possible, before dependencies are installed
-      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
-      # Uncomment this line to enable task distribution
-      # - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
-
-      # Cache node_modules
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
@@ -64,17 +57,16 @@ jobs:
 
       - run: npm ci
 
-      # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
-      # - run: npx nx-cloud record -- echo Hello World
-
-      # `check` is separate from `typecheck` on purpose. Nx infers a typecheck
-      # target from tsconfig.json, but disables it (replacing the command with
-      # an echo) whenever the resolved config sets `noEmit: true`, because
-      # `tsc --build` cannot run that way. Astro's shared config sets exactly
-      # that, so storefront's typecheck is a no-op -- and `astro build`
-      # does not typecheck either, unlike `next build`. `astro check` is the
-      # only thing that actually typechecks the .astro files.
+      # `check` is listed alongside `typecheck`, not instead of it. Nx infers a
+      # typecheck target from tsconfig.json but disables it -- replacing the
+      # command with an echo -- whenever the resolved config sets `noEmit: true`,
+      # because `tsc --build` cannot run that way. Astro's shared config sets
+      # exactly that, so storefront's typecheck target is a no-op, and `astro
+      # build` does not typecheck either, unlike `next build`. `astro check` is
+      # the only thing that typechecks the .astro files.
       - run: npx nx run-many -t lint test build typecheck check
-      # Nx Cloud recommends fixes for failures to help you get CI green faster. Learn more: https://nx.dev/ci/features/self-healing-ci
+
+      # Reports the run's task results to Nx Cloud. `always()` because the run it
+      # reports on is the failing one.
       - run: npx nx fix-ci
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,6 @@ jobs:
           PROJECTS: ${{ inputs.projects }}
         run: node scripts/resolve-release-projects.mjs
 
-      # Never publish an unverified tree.
       - name: Verify
         # Same target list as CI, including `check`. storefront's
         # inferred typecheck target is a disabled no-op (Astro's config sets
@@ -93,13 +92,19 @@ jobs:
       - name: Verify packaging
         run: npm run verify:packaging
 
+      # `nx release` commits the version bumps and tags them, so it needs an
+      # identity. The push itself authenticates as the deploy key above, not as
+      # this author.
       - name: Configure git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Version, changelog and tag
-        # Inputs go through env rather than being interpolated into the script.
+        # Inputs reach the script as environment variables. A `${{ }}`
+        # interpolation is substituted into the script text before the shell sees
+        # it, so a dispatch input containing shell syntax would run as part of
+        # this step.
         env:
           DRY_RUN: ${{ inputs.dry-run }}
           PROJECTS: ${{ steps.projects.outputs.projects }}

--- a/apps/docs/app/[[...mdxPath]]/page.tsx
+++ b/apps/docs/app/[[...mdxPath]]/page.tsx
@@ -1,6 +1,12 @@
 import { generateStaticParamsFor, importPage } from 'nextra/pages';
 import { useMDXComponents as getMDXComponents } from '../../mdx-components';
 
+/**
+ * Enumerates one route per MDX file under `content/`.
+ *
+ * `output: 'export'` in next.config.ts has no server to render an unlisted
+ * route, so a page missing from this list is missing from the deployed site.
+ */
 export const generateStaticParams = generateStaticParamsFor('mdxPath');
 
 interface GenerateMetadataProps {
@@ -13,6 +19,11 @@ export async function generateMetadata(props: GenerateMetadataProps) {
   return metadata;
 }
 
+/**
+ * The theme's page frame: table of contents, breadcrumbs, edit link and footer.
+ * Rendering MDX content without it produces the body of a docs page with none
+ * of the chrome around it.
+ */
 const Wrapper = getMDXComponents().wrapper;
 
 interface PageProps {

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -10,8 +10,7 @@ export const metadata = {
     default: 'Evanion Libraries',
     template: '%s | Evanion Libraries',
   },
-  description:
-    'Documentation for the Evanion open source libraries: compose, urn and react-widget.',
+  description: 'Documentation for the Evanion open source libraries.',
   metadataBase: new URL('https://docs.evanion.com'),
 };
 
@@ -25,21 +24,27 @@ const footer = (
   <Footer>MIT {new Date().getFullYear()} © Mikael Pettersson.</Footer>
 );
 
+/**
+ * The shell every docs page renders inside: Nextra's theme layout, built from
+ * the page map the MDX files produce.
+ *
+ * `async` because the sidebar comes from `getPageMap()`, which reads the page map
+ * Nextra compiles from `content/`. Under `output: 'export'` that happens once, at
+ * build time.
+ */
 export default async function RootLayout({ children }: PropsWithChildren) {
   return (
     <html
-      // Not required, but good for SEO
       lang="en"
-      // Required to be set
+      // nextra-theme-docs reads `dir` to place its sidebar and breadcrumbs; it
+      // has no default, so an unset value leaves both unplaced.
       dir="ltr"
-      // Suggested by `next-themes` package https://github.com/pacocoursey/next-themes#with-app
+      // next-themes, which the theme uses, writes the colour-scheme class onto
+      // this element from a blocking script before React hydrates. Without this
+      // the class the client sees never matches the server's markup.
       suppressHydrationWarning
     >
-      <Head
-      // ... Your additional head options
-      >
-        {/* Your additional tags should be passed as `children` of `<Head>` element */}
-      </Head>
+      <Head />
       <body>
         <Layout
           navbar={navbar}

--- a/apps/docs/components/PlaygroundExamples.tsx
+++ b/apps/docs/components/PlaygroundExamples.tsx
@@ -3,6 +3,15 @@
 import { useState } from 'react';
 import WidgetPlayground from './WidgetPlayground';
 
+/**
+ * The snippets the tab strip switches between.
+ *
+ * Each `code` string is handed to react-live in `noInline` mode, so it ends in a
+ * `render(…)` call and may only use names WidgetPlayground puts in scope:
+ * `createWidgets`, `render`, `React` and the hooks. An import, or a name that is
+ * not there, surfaces as a runtime error in the preview pane rather than at
+ * build time -- nothing typechecks these strings.
+ */
 const examples = {
   basic: {
     title: 'Basic Widget System',
@@ -217,6 +226,11 @@ render(<Widgets items={items} />)`,
   },
 };
 
+/**
+ * A tab strip over {@link examples}, feeding the selected snippet to one
+ * WidgetPlayground. Usable as a JSX tag in any MDX page through the map in
+ * mdx-components.js.
+ */
 export default function PlaygroundExamples() {
   const [selectedExample, setSelectedExample] =
     useState<keyof typeof examples>('basic');

--- a/apps/docs/components/WidgetPlayground.tsx
+++ b/apps/docs/components/WidgetPlayground.tsx
@@ -6,11 +6,31 @@ import { Editor } from '@monaco-editor/react';
 import type { OnMount } from '@monaco-editor/react';
 
 interface WidgetPlaygroundProps {
+  /**
+   * The snippet the preview starts from. It is evaluated by react-live in
+   * `noInline` mode, so it has to end in a `render(<… />)` call, and every name
+   * it uses has to be in `scope` below -- there is no module resolution inside
+   * the snippet.
+   */
   initialCode: string;
+  /** Editor height in pixels, and the preview panel's minimum height. */
   height?: number;
+  /** Whether the Code tab is offered. The preview tab is always there. */
   showEditor?: boolean;
 }
 
+/**
+ * An editable code sample with a live preview, usable as a JSX tag in any MDX
+ * page through the map in mdx-components.js.
+ *
+ * A client component: it evaluates the snippet in the browser and loads Monaco,
+ * neither of which has a server rendering.
+ *
+ * @example
+ * ```mdx
+ * <WidgetPlayground initialCode={`render(<b>hi</b>)`} height={300} />
+ * ```
+ */
 export default function WidgetPlayground({
   initialCode,
   height = 400,
@@ -20,7 +40,11 @@ export default function WidgetPlayground({
   const [activeTab, setActiveTab] = useState<'preview' | 'editor'>('preview');
   const [isDark, setIsDark] = useState(false);
 
-  // Detect theme from the document
+  // Monaco takes its theme as a prop rather than reading CSS, so the active
+  // theme has to be resolved in JS. next-themes, which nextra-theme-docs uses,
+  // records the choice by writing a class onto <html> outside React, so the
+  // element is observed directly; `prefers-color-scheme` covers the "system"
+  // setting, under which next-themes writes nothing.
   useEffect(() => {
     const checkTheme = () => {
       const isDarkMode =
@@ -32,7 +56,6 @@ export default function WidgetPlayground({
 
     checkTheme();
 
-    // Listen for theme changes
     const observer = new MutationObserver(checkTheme);
     observer.observe(document.documentElement, {
       attributes: true,
@@ -54,8 +77,11 @@ export default function WidgetPlayground({
     }
   }, []);
 
+  // Monaco's TypeScript defaults assume a plain module with no JSX and no
+  // ambient React, and its diagnostics are independent of react-live's
+  // evaluation. Without the three calls below the editor marks every snippet as
+  // broken while the preview renders it correctly.
   const handleEditorDidMount = useCallback<OnMount>((editor, monaco) => {
-    // Configure Monaco for TypeScript with JSX support
     monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
       target: monaco.languages.typescript.ScriptTarget.Latest,
       allowNonTsExtensions: true,
@@ -71,13 +97,15 @@ export default function WidgetPlayground({
       skipLibCheck: true,
     });
 
-    // Set the model to TypeScript
     const model = editor.getModel();
     if (model) {
       monaco.editor.setModelLanguage(model, 'typescript');
     }
 
-    // Add React types
+    // A hand-written subset of React's types, registered under the path Monaco
+    // resolves `react` from. The real @types/react is not reachable: Monaco
+    // resolves modules inside the worker, against files added here, and never
+    // against the bundle's node_modules.
     monaco.languages.typescript.typescriptDefaults.addExtraLib(
       `declare module 'react' {
         export = React;
@@ -105,7 +133,15 @@ export default function WidgetPlayground({
     );
   }, []);
 
-  // Simple mock for the playground
+  /**
+   * Stands in for `@evanion/react-widget`'s `createWidgets` inside the snippet.
+   *
+   * react-live evaluates a snippet against `scope` alone, with no module
+   * resolution, so every name the examples use has to be supplied here. This
+   * covers the lookup-and-render half the examples demonstrate; item validation
+   * and `chrome` are not implemented, so a snippet that passes `chrome` renders
+   * without it.
+   */
   const mockCreateWidgets = (config: {
     components: Record<string, React.ComponentType<Record<string, unknown>>>;
   }) => {
@@ -145,7 +181,9 @@ export default function WidgetPlayground({
     useMemo: React.useMemo,
     useCallback: React.useCallback,
     React: React,
-    render: (element: React.ReactElement) => element, // Add render function for noInline mode
+    // `noInline` makes react-live run the snippet as statements and render
+    // whatever it hands to `render`, which it expects the scope to provide.
+    render: (element: React.ReactElement) => element,
   };
 
   return (
@@ -202,9 +240,9 @@ export default function WidgetPlayground({
                   bracketPairs: true,
                   indentation: true,
                 },
-                // Fix tooltip positioning
                 hover: {
-                  // monaco 0.56 changed this from boolean to 'on' | 'off' | 'onKeyboardModifier'
+                  // monaco 0.56 types this as 'on' | 'off' | 'onKeyboardModifier',
+                  // not boolean.
                   enabled: 'on',
                   delay: 300,
                 },
@@ -212,7 +250,10 @@ export default function WidgetPlayground({
                   showKeywords: false,
                   showSnippets: false,
                 },
-                // Prevent tooltips from being cut off
+                // Monaco renders hover and suggestion widgets inside the editor
+                // element by default, where the docs layout's own overflow and
+                // stacking contexts clip anything taller than the editor. These
+                // two move them to <body>, outside every such context.
                 fixedOverflowWidgets: true,
                 overflowWidgetsDomNode: document.body,
               }}
@@ -297,7 +338,12 @@ export default function WidgetPlayground({
           z-index: 1;
         }
 
-        /* Fix Monaco Editor tooltip styling */
+        /*
+         * Hover widgets are reparented to <body> by overflowWidgetsDomNode, so
+         * they inherit the page's colours instead of the editor's theme. :global
+         * is what reaches them from a styled-jsx block, which otherwise scopes
+         * every selector to this component's own elements.
+         */
         :global(.monaco-editor .monaco-hover) {
           background: ${isDark ? '#1e1e1e' : '#ffffff'} !important;
           border: 1px solid ${isDark ? '#454545' : '#cccccc'} !important;
@@ -360,7 +406,6 @@ export default function WidgetPlayground({
           color: ${isDark ? '#cccccc' : '#333333'} !important;
         }
 
-        /* Additional tooltip styling for better visibility */
         :global(
           .monaco-editor
             .monaco-hover

--- a/apps/docs/mdx-components.js
+++ b/apps/docs/mdx-components.js
@@ -2,10 +2,20 @@ import { useMDXComponents as getThemeComponents } from 'nextra-theme-docs';
 import WidgetPlayground from './components/WidgetPlayground';
 import PlaygroundExamples from './components/PlaygroundExamples';
 
-// Get the default MDX components
 const themeComponents = getThemeComponents();
 
-// Merge components
+/**
+ * The component map every MDX page is compiled against.
+ *
+ * Nextra resolves this by convention: the file has to sit at the app root and
+ * export `useMDXComponents`, and `app/[[...mdxPath]]/page.tsx` reads `wrapper`
+ * off the same map. The components listed here are what an `.mdx` page may use
+ * as a JSX tag without importing anything.
+ *
+ * `components` is spread over the theme's own map and under the playground
+ * components, so a caller can override a theme element and cannot shadow a
+ * playground with one.
+ */
 export function useMDXComponents(components) {
   return {
     ...themeComponents,

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -2,9 +2,9 @@ import { join } from 'node:path';
 
 import nextra from 'nextra';
 
-// `composePlugins`/`withNx` from @nx/next are deprecated and removed in Nx 24.
-// A plain next.config is the recommended pattern now -- Next.js transpiles
-// workspace libraries on its own.
+// A plain Next config, not wrapped in @nx/next's `composePlugins`/`withNx`:
+// those are deprecated and removed in Nx 24, and Next transpiles workspace
+// libraries without them.
 const withNextra = nextra({
   defaultShowCopyCode: true,
   latex: true,
@@ -16,18 +16,13 @@ const withNextra = nextra({
 const workspaceRoot = join(import.meta.dirname, '../..');
 
 export default withNextra({
-  // A `file=… region=…` code block is filled from the named region in the
-  // package's README, which is itself executed as a test, so the docs app
-  // renders the example the package ships rather than a copy of it. A renamed
-  // or deleted region fails this build.
+  // Fills every `file=… region=…` code block from the named region of the
+  // package's own README, so a docs page renders the example the package ships
+  // and a renamed region fails this build. The loader carries the rest of the
+  // reasoning.
   //
-  // A loader rather than the remark plugin the demo-apps spec called for:
-  // Nextra hands `mdxOptions.remarkPlugins` to unified, which needs plugin
-  // functions, and Next 16 rejects a config carrying one. A loader's module
-  // path and its `{ root }` option are both strings, and it still runs inside
-  // `next build`, so no npm lifecycle hook is needed. Next 16 builds with
-  // Turbopack, so the rule goes here rather than in `webpack()`, which is
-  // never called.
+  // The rule goes under `turbopack` rather than in `webpack()`: Next 16 builds
+  // with Turbopack, and never calls `webpack()`.
   turbopack: {
     rules: {
       '*.mdx': {

--- a/apps/docs/postcss.config.js
+++ b/apps/docs/postcss.config.js
@@ -1,10 +1,6 @@
-// const { join } = require('path');
-
-// Note: If you use library-specific PostCSS/Tailwind configuration then you should remove the `postcssConfig` build
-// option from your application's configuration (i.e. project.json).
-//
-// See: https://nx.dev/guides/using-tailwind-css-in-react#step-4:-applying-configuration-to-libraries
-
+// CommonJS, and named .js rather than .mjs: postcss-load-config resolves this
+// file for `next build`, and the app's package.json does not set
+// "type": "module", so `.js` is CommonJS here.
 module.exports = {
   plugins: {
     '@tailwindcss/postcss': {},

--- a/apps/shop-api/src/app/app.module.ts
+++ b/apps/shop-api/src/app/app.module.ts
@@ -8,6 +8,14 @@ import { InventoryModule } from '../inventory/inventory.module.js';
 import { OrdersModule } from '../orders/orders.module.js';
 import { TelemetryModule } from '../telemetry/telemetry.module.js';
 
+/**
+ * The application's root module and DI graph entry point.
+ *
+ * CorrelationModule and TelemetryModule are both declared `global` where they
+ * are defined, so importing them once here is what makes CorrelationService and
+ * TelemetryService injectable throughout the feature modules without any of
+ * those modules importing either one.
+ */
 @Module({
   imports: [
     CorrelationModule.forRoot(),
@@ -17,20 +25,11 @@ import { TelemetryModule } from '../telemetry/telemetry.module.js';
     OrdersModule,
   ],
 })
-/**
- * The application's root module and DI graph entry point.
- *
- * Composes the three feature modules (games, inventory, orders) with
- * CorrelationModule and TelemetryModule. Both of those are `global` in their
- * own definitions, so importing them once, here, is what makes
- * CorrelationService and TelemetryService injectable everywhere else in the
- * app without each feature module importing either directly.
- */
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
-    // Must run on every route: this is what opens the AsyncLocalStorage
-    // context CorrelationService reads from, and everything the handler
-    // awaits -- guards, interceptors, the controller -- runs inside it.
+    // Every route, because the middleware is what opens the AsyncLocalStorage
+    // context CorrelationService reads from. A route it does not cover gets no
+    // context, and getCorrelationId() returns undefined there.
     consumer.apply(CorrelationIdMiddleware).forRoutes('*');
   }
 }

--- a/apps/shop-api/src/config.ts
+++ b/apps/shop-api/src/config.ts
@@ -1,4 +1,18 @@
-/** Shared between main.ts (what the server listens on) and InventoryClient
- * (what it calls back into, on localhost, for the orders -> inventory hop). */
+/**
+ * Path prefix every route is mounted under.
+ *
+ * Read by both `main.ts`, which sets it, and `InventoryClient`, which builds a
+ * URL back into this same process with it. One constant, because the outbound
+ * URL has to match the mounted path for the orders -> inventory hop to resolve.
+ */
 export const GLOBAL_PREFIX = 'api';
+
+/**
+ * Port the server listens on, and the port `InventoryClient` dials on
+ * localhost.
+ *
+ * Read at import time, so a test that sets `process.env.PORT` has to do it
+ * before the first import of this module -- `orders.e2e.spec.ts` imports
+ * dynamically for exactly that reason.
+ */
 export const PORT = Number(process.env.PORT) || 3000;

--- a/apps/shop-api/src/games/games.controller.ts
+++ b/apps/shop-api/src/games/games.controller.ts
@@ -17,9 +17,11 @@ export class GamesController {
     return this.games.findAll();
   }
 
-  /** `urn` is the full urn string, e.g. `urn:game:wingspan` -- not the bare
-   * nss `wingspan` -- since that is what Game.urn and GamesService compare
-   * against. */
+  /**
+   * @param urn The full urn, `urn:game:wingspan`, not the bare nss `wingspan`:
+   * it is matched against `Game.urn`, which GameURN writes in full. Colons are
+   * legal in a path segment, so nothing needs escaping on the way in.
+   */
   @Get(':urn')
   findOne(@Param('urn') urn: string): Game {
     return this.games.findByUrn(urn);

--- a/apps/shop-api/src/games/games.service.ts
+++ b/apps/shop-api/src/games/games.service.ts
@@ -5,12 +5,17 @@ import type { Game } from './game.model.js';
 /** Read-only accessor over the static GAMES_CATALOGUE. */
 @Injectable()
 export class GamesService {
+  /** The whole catalogue. A copy, so a caller cannot edit the shared array. */
   findAll(): Game[] {
     return [...GAMES_CATALOGUE];
   }
 
-  /** Throws rather than returning undefined when nothing matches -- the
-   * return type is Game, not an optional. */
+  /**
+   * The game with this urn, which is the full `urn:game:…` string.
+   *
+   * @throws {NotFoundException} when no game carries that urn, which Nest
+   * renders as a 404.
+   */
   findByUrn(urn: string): Game {
     const game = GAMES_CATALOGUE.find((candidate) => candidate.urn === urn);
     if (!game) {

--- a/apps/shop-api/src/inventory/inventory.service.ts
+++ b/apps/shop-api/src/inventory/inventory.service.ts
@@ -13,8 +13,13 @@ const STOCK: ReadonlyMap<string, number> = new Map([
 /** Read-only accessor over the static STOCK map. */
 @Injectable()
 export class InventoryService {
-  /** Throws rather than returning undefined when urn has no stock record --
-   * the return type is Stock, not an optional. */
+  /**
+   * The stock record for one game urn.
+   *
+   * @throws {NotFoundException} when the urn has no record, which Nest renders
+   * as a 404. InventoryClient translates that 404 back into a
+   * `NotFoundException` on the calling side of the HTTP hop.
+   */
   getStock(urn: string): Stock {
     const quantity = STOCK.get(urn);
     if (quantity === undefined) {

--- a/apps/shop-api/src/main.ts
+++ b/apps/shop-api/src/main.ts
@@ -3,6 +3,13 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app/app.module.js';
 import { GLOBAL_PREFIX, PORT } from './config.js';
 
+/**
+ * Starts the HTTP server on `PORT` with every route under `GLOBAL_PREFIX`.
+ *
+ * The prefix is set here and read by InventoryClient when it builds a URL back
+ * into this process, so the orders -> inventory hop resolves against the same
+ * path this call mounts.
+ */
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.setGlobalPrefix(GLOBAL_PREFIX);

--- a/apps/shop-api/src/orders/inventory-client.service.spec.ts
+++ b/apps/shop-api/src/orders/inventory-client.service.spec.ts
@@ -46,7 +46,9 @@ describe('InventoryClient', () => {
     );
   });
 
-  it('counts each construction, for the nestjs-correlation-id#31 regression guard', () => {
+  // The two counters are what orders.e2e.spec.ts reads to prove the provider
+  // stayed a singleton, so they have to count what they claim to count.
+  it('counts every construction', () => {
     InventoryClient.constructed = 0;
     const http = httpServiceStub(() => of(axiosResponse({})));
 

--- a/apps/shop-api/src/orders/inventory-client.service.ts
+++ b/apps/shop-api/src/orders/inventory-client.service.ts
@@ -4,11 +4,17 @@ import { firstValueFrom } from 'rxjs';
 import { GLOBAL_PREFIX, PORT } from '../config.js';
 import type { Stock } from '../inventory/stock.model.js';
 
+/**
+ * The shape of a rejected axios request that this file needs, declared locally
+ * rather than imported: axios reaches this app only through @nestjs/axios, and
+ * a structural check works on whatever the installed copy throws.
+ */
 interface AxiosLikeError {
   isAxiosError?: boolean;
   response?: { status?: number };
 }
 
+/** Whether a rejection carries an upstream 404 response. */
 const isNotFound = (error: unknown): boolean =>
   typeof error === 'object' &&
   error !== null &&
@@ -19,13 +25,12 @@ const isNotFound = (error: unknown): boolean =>
  * localhost. That is the correlation-id hop the demo exists to show: same
  * process, real network round trip, id visible on both sides.
  *
- * A plain singleton holding HttpService. Regression guard for
- * nestjs-correlation-id#31: withCorrelation() used to inject the then
- * request-scoped CorrelationService into an HttpModuleOptions factory,
- * which made HttpService -- and every provider holding it, including this
- * one -- request-scoped too: reconstructed per request, onModuleInit never
- * called. `constructed` and `initialised` are the regression guard; both
- * should stay at 1 across any number of requests.
+ * `constructed` and `initialised` are the probe for the scope invariant
+ * `withCorrelation()` has to preserve. Nest propagates request scope upward, so
+ * anything request-scoped on the path from `CorrelationService` to
+ * `HttpService` makes this class request-scoped too -- rebuilt per request, and
+ * never given `onModuleInit`. Both counters therefore stay at 1 across any
+ * number of requests; orders.e2e.spec.ts is what asserts it.
  */
 @Injectable()
 export class InventoryClient implements OnModuleInit {
@@ -42,6 +47,13 @@ export class InventoryClient implements OnModuleInit {
     InventoryClient.initialised += 1;
   }
 
+  /**
+   * The stock record the /inventory endpoint reports for `urn`, together with
+   * the correlation id that endpoint saw.
+   *
+   * @throws {NotFoundException} when the endpoint answers 404, so the caller
+   * handles an unknown urn the same way whether the lookup crossed HTTP or not.
+   */
   async getStock(urn: string): Promise<Stock & { correlationId?: string }> {
     try {
       const response = await firstValueFrom(

--- a/apps/shop-api/src/orders/orders.e2e.spec.ts
+++ b/apps/shop-api/src/orders/orders.e2e.spec.ts
@@ -3,9 +3,11 @@ import { request as httpRequest } from 'node:http';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 /**
- * node:http rather than fetch, matching nest/correlation-id's own e2e spec:
- * it lets a request set the header this app's PORT is bound to regardless of
- * what the global fetch/Headers API would normalise.
+ * One request, resolved to its status and raw body.
+ *
+ * node:http rather than fetch: the Headers API lower-cases every name it is
+ * given and every name it reports, so a test using it can neither send a
+ * specific header casing nor observe the casing that came back.
  */
 const request = (
   method: string,
@@ -44,10 +46,10 @@ describe('shop-api end to end: the correlation-id hop', () => {
   const HEADER = 'X-Correlation-Id';
   const PORT = 34599;
   let HEADER_PREFIX = '';
-  // Resolved dynamically, once PORT is set, so config.ts (read by
-  // InventoryClient at import time) picks up this exact test port -- a
-  // static top-level import would run before this line, ahead of ESM import
-  // hoisting, and see the wrong value.
+  // Imported dynamically inside beforeAll, after process.env.PORT is set.
+  // config.ts reads PORT at module evaluation and InventoryClient builds its
+  // base URL from it, and every static import of a module is evaluated before
+  // any statement of this one, so a top-level import would bake in port 3000.
   let InventoryClient: (typeof import('./inventory-client.service.js'))['InventoryClient'];
   let GameURN: (typeof import('../domain/game.urn.js'))['GameURN'];
 
@@ -122,15 +124,23 @@ describe('shop-api end to end: the correlation-id hop', () => {
     ]);
   });
 
-  describe('nestjs-correlation-id#31 regression', () => {
-    it('constructs the singleton holding HttpService exactly once across multiple requests', async () => {
+  /**
+   * Nest propagates request scope upward through the injection graph, so one
+   * request-scoped provider anywhere between `CorrelationService` and
+   * `HttpService` turns InventoryClient request-scoped: a new instance per
+   * request, and `onModuleInit` never called on any of them. Both counters
+   * distinguish that from the singleton the app is wired for, and neither
+   * changes a response, so nothing else here would notice.
+   */
+  describe('the provider holding HttpService stays a singleton', () => {
+    it('is constructed once across several requests', async () => {
       const wingspan = GameURN.stringify('wingspan');
       await request('POST', `${base}/${HEADER_PREFIX}/orders`, {
-        headers: { [HEADER]: 'e2e-regression-a' },
+        headers: { [HEADER]: 'e2e-singleton-a' },
         body: { items: [{ urn: wingspan, quantity: 1 }] },
       });
       await request('POST', `${base}/${HEADER_PREFIX}/orders`, {
-        headers: { [HEADER]: 'e2e-regression-b' },
+        headers: { [HEADER]: 'e2e-singleton-b' },
         body: { items: [{ urn: wingspan, quantity: 1 }] },
       });
 

--- a/apps/shop-api/src/orders/orders.service.ts
+++ b/apps/shop-api/src/orders/orders.service.ts
@@ -24,6 +24,16 @@ export class OrdersService {
     private readonly correlationService: CorrelationService,
   ) {}
 
+  /**
+   * Checks every cart line against live stock and returns the confirmed order.
+   *
+   * The stock checks run concurrently, so one request produces several inventory
+   * hops at once and all of them carry this request's correlation id -- which is
+   * what the returned `inventoryCorrelationIds` lets a caller verify.
+   *
+   * @throws {BadRequestException} for an empty cart, a urn with no stock record,
+   * or a line that asks for more copies than are in stock.
+   */
   async createOrder(request: CreateOrderRequest): Promise<OrderResult> {
     if (!request.items || request.items.length === 0) {
       throw new BadRequestException('Cart must contain at least one item');
@@ -64,8 +74,12 @@ export class OrdersService {
     };
   }
 
-  /** A urn with no inventory record is a bad request, not a 404: the client
-   * asked to order something that does not exist in the catalogue. */
+  /**
+   * Stock for one cart line.
+   *
+   * A urn with no inventory record surfaces as 400 rather than 404: the missing
+   * thing is in the request body, and the order endpoint itself exists.
+   */
   private async checkStock(
     item: CartItem,
   ): Promise<{ quantity: number; correlationId?: string }> {

--- a/apps/shop-api/src/telemetry/telemetry.service.ts
+++ b/apps/shop-api/src/telemetry/telemetry.service.ts
@@ -6,14 +6,18 @@ import type { TelemetryEvent } from './telemetry-event.model.js';
  * A mock observability sink -- a stand-in for something like Sentry or
  * Splunk. In-memory only, no external calls, per the demo's scope.
  *
- * Reads the correlation id itself, from the AsyncLocalStorage-backed
- * CorrelationService singleton, rather than having it threaded through every
- * call site. That is the property nestjs-correlation-id#31's fix provides: a
- * singleton can read the id of whichever request happens to be in flight
- * without the id being passed as a parameter.
+ * `record` takes no correlation id. It reads one from the
+ * AsyncLocalStorage-backed CorrelationService, which is a singleton and still
+ * resolves the id of whichever request is in flight, so neither this service nor
+ * any of its callers has to carry the id as a parameter.
  */
 @Injectable()
 export class TelemetryService {
+  /**
+   * How many events are kept. The sink is a process-lifetime array, so it needs
+   * a ceiling; past it the oldest event is dropped, and a trail older than the
+   * last 500 events is gone rather than paged.
+   */
   private static readonly MAX_EVENTS = 500;
 
   private readonly events: TelemetryEvent[] = [];
@@ -21,6 +25,7 @@ export class TelemetryService {
 
   constructor(private readonly correlationService: CorrelationService) {}
 
+  /** Records one event, stamped with the correlation id currently in scope. */
   record(
     source: string,
     type: string,
@@ -41,10 +46,12 @@ export class TelemetryService {
     return event;
   }
 
+  /** Every retained event, oldest first. A copy, so a caller cannot edit the sink. */
   list(): TelemetryEvent[] {
     return [...this.events];
   }
 
+  /** The retained events of one request, which is its trail across every source. */
   forCorrelationId(correlationId: string): TelemetryEvent[] {
     return this.events.filter((event) => event.correlationId === correlationId);
   }

--- a/apps/storefront/astro.config.mjs
+++ b/apps/storefront/astro.config.mjs
@@ -1,3 +1,9 @@
 import { defineConfig } from 'astro/config';
 
+// Empty, and required to be. tools/nx-astro infers this project's build, dev,
+// preview and check targets from the presence of this file, and derives the
+// paths it declares as inputs and outputs from Astro's documented defaults
+// rather than by reading the config. Setting srcDir, publicDir or outDir here
+// would leave those targets pointing at the old locations; set them in nx.json's
+// plugin options instead, which is where the plugin takes overrides.
 export default defineConfig({});

--- a/apps/storefront/src/registry.ts
+++ b/apps/storefront/src/registry.ts
@@ -3,4 +3,13 @@ import Hero from './blocks/Hero.astro';
 import Text from './blocks/Text.astro';
 import Kort from './blocks/Kort.astro';
 
+/**
+ * Maps the `type` of each entry in `data/sidan.json` to the component that
+ * renders it.
+ *
+ * Every type the data may use has to appear here: `Widgets` skips an entry whose
+ * type is absent rather than failing the build, so a missing key is a silently
+ * blank page section. `sidan.json` deliberately holds one unknown type, which
+ * is what `render.test.ts` asserts gets skipped.
+ */
 export const registry = defineBlocks({ hero: Hero, text: Text, kort: Kort });

--- a/apps/storefront/src/render.test.ts
+++ b/apps/storefront/src/render.test.ts
@@ -6,7 +6,13 @@ import { join } from 'node:path';
 const appRoot = join(import.meta.dirname, '..');
 const html = () => readFileSync(join(appRoot, 'dist', 'index.html'), 'utf8');
 
+/**
+ * Asserts against the HTML `astro build` emits, because what the blocks receive
+ * and whether an unknown one is skipped are decided by Astro's own renderer.
+ */
 describe('demo output', () => {
+  // `nx test` depends on `build`, so dist/ is normally already there; this
+  // builds it when the file is run directly, e.g. from an editor or `vitest`.
   beforeAll(() => {
     if (!existsSync(join(appRoot, 'dist', 'index.html'))) {
       execFileSync('npx', ['astro', 'build'], { cwd: appRoot, stdio: 'pipe' });

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,38 +1,47 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
+    // The types @commitlint/config-conventional allows, restated so the list is
+    // the one nx knows. nx reads the type to choose the bump: `feat` is a minor,
+    // `fix` a patch, a `!` or BREAKING CHANGE footer a major whatever the type,
+    // and every other type bumps nothing on its own
+    // (DEFAULT_CONVENTIONAL_COMMITS_CONFIG in nx's release config). A type nx has
+    // no entry for releases nothing and appears in no changelog.
     'type-enum': [
       2,
       'always',
       [
-        'feat', // A new feature
-        'fix', // A bug fix
-        'docs', // Documentation only changes
-        'style', // Changes that do not affect the meaning of the code
-        'refactor', // A code change that neither fixes a bug nor adds a feature
-        'perf', // A code change that improves performance
-        'test', // Adding missing tests or correcting existing tests
-        'build', // Changes that affect the build system or external dependencies
-        'ci', // Changes to our CI configuration files and scripts
-        'chore', // Other changes that don't modify src or test files
-        'revert', // Reverts a previous commit
+        'feat',
+        'fix',
+        'docs',
+        'style', // No change in behaviour: whitespace, formatting, naming
+        'refactor', // No change in behaviour, but the code itself moved
+        'perf',
+        'test',
+        'build', // The build system, or a dependency's version
+        'ci',
+        'chore', // Touches neither src nor test
+        'revert',
       ],
     ],
-    // Scopes for packages MUST equal the Nx project name with the `@evanion/`
-    // prefix stripped. Nx resolves conventional-commit scopes against project
-    // names, so a scope that does not match a project (`widget` vs the project
-    // `react-widget`) is attributed to nothing and silently downgraded to a
-    // patch bump instead of erroring.
+    // A package's scope is its Nx project name with the `@evanion/` prefix
+    // stripped. `nx release` matches a commit scope against project names with a
+    // word-boundary regex in which `-` counts as a word character, so the bare
+    // name resolves to its own project while a fragment of one -- `widget`
+    // against the project `react-widget` -- resolves to nothing, and a commit
+    // nx cannot attribute is capped at a patch bump rather than rejected.
     //
-    // This list is deliberately STATIC. Deriving it from the Nx project graph
-    // would run a graph computation inside the commit-msg hook on every single
-    // commit. `tools/repo-checks` has a test that fails the build if a project
-    // under nx.json's `release.projects` globs is missing from this list.
+    // The list is static: it is read in the commit-msg hook on every commit,
+    // where computing the Nx project graph would cost seconds per commit.
+    // tools/repo-checks/src/commitlint-scope-enum.test.ts is the other half --
+    // it fails the build when a project under nx.json's `release.projects`
+    // globs has no entry here.
     'scope-enum': [
       2,
       'always',
       [
-        // Nx projects (bare project names).
+        // Nx projects, by bare name. A commit under one of these that also sits
+        // under nx.json's `release.projects` globs is what versions a package.
         'astro-widget',
         'compose',
         'docs',
@@ -46,8 +55,9 @@ module.exports = {
         'storefront',
         'token',
         'urn',
-        // Repository scopes -- not projects. Taken from the scopes already in
-        // use on main, so existing practice keeps working.
+        // Repository scopes, for work that is not one package's. None of them
+        // names a project, so nx attributes such a commit to no package and it
+        // can contribute at most a patch bump to whatever files it touched.
         'ci',
         'deps',
         'deps-dev',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,17 +1,17 @@
 import nx from '@nx/eslint-plugin';
 
 /**
- * Rules every project should end up with.
+ * Rules every project ends up with, whatever else its own config pulls in.
  *
- * Exported because the per-project configs spread an nx preset *after* this
- * file, and those presets re-enable some of what is set here. Each project
- * applies these last so they actually win.
+ * Exported because a per-project config spreads an nx preset after this file and
+ * those presets re-enable some of what is set here. Applying this object last in
+ * each project's config is what makes these the effective settings.
  */
 export const sharedRules = {
-  // These libraries advertise type safety, so an untyped escape hatch is a
-  // defect rather than a style preference. The two that remain are generic
-  // *constraint* positions TypeScript offers no alternative for, and each
-  // carries an inline disable explaining why.
+  // An error, not a warning: these packages are published as typed, so an `any`
+  // in a public signature is a defect in the product. Where TypeScript offers no
+  // alternative -- a generic constraint position -- the `any` carries an inline
+  // disable naming the reason.
   '@typescript-eslint/no-explicit-any': 'error',
 
   // The base rule does not understand TypeScript overload signatures and flags
@@ -30,6 +30,9 @@ export default [
       // Where tsc puts the declarations it emits only because `tsc --build`
       // has no check-only mode. Generated, never shipped, never read.
       '**/out-tsc',
+      // Vite writes these beside a TypeScript config while loading it, and
+      // deletes them again. A lint run that catches one mid-build fails on a
+      // file that no longer exists.
       '**/vite.config.*.timestamp*',
       '**/vitest.config.*.timestamp*',
     ],

--- a/nest/correlation-id/src/constants.ts
+++ b/nest/correlation-id/src/constants.ts
@@ -1,13 +1,27 @@
-export const CORRELATION_ID_HEADER = 'X-Correlation-Id';
 /**
+ * The header `CorrelationModule.forRoot()` reads and writes when the caller
+ * names none.
+ *
+ * No correlation header is registered with IANA, so there is no canonical
+ * spelling to defer to; `X-Correlation-Id` and `X-Request-Id` are the two in
+ * common use. The casing here is what goes out on the wire: Node lowercases
+ * incoming header names, so the configured casing only ever affects the
+ * response.
+ */
+export const CORRELATION_ID_HEADER = 'X-Correlation-Id';
+
+/**
+ * Injection token for the resolved `CorrelationConfig`.
+ *
  * Namespaced because the provider is registered in a `global: true` module: a
- * bare 'CORRELATION_CONFIG' would collide silently with any other package that
- * happened to pick the same string. Deliberately a string and not a Symbol --
- * a bare `Symbol()` is not stable across duplicate copies of a module, which
- * would reintroduce exactly the hazard the single ESM build removes.
+ * bare `'CORRELATION_CONFIG'` collides silently with any other package that
+ * picks the same string. A string and not a Symbol: a `Symbol()` is identity-
+ * based, so two copies of this module would mint two tokens and Nest would
+ * fail to resolve one of them.
  */
 export const CORRELATION_CONFIG_TOKEN =
   '@evanion/nestjs-correlation-id:CORRELATION_CONFIG';
+
 /**
  * Token of the provider that attaches the outgoing-request interceptor to the
  * axios instance `withCorrelation` configures. Nothing injects it; it exists so
@@ -15,5 +29,23 @@ export const CORRELATION_CONFIG_TOKEN =
  */
 export const CORRELATION_AXIOS_INTERCEPTOR =
   '@evanion/nestjs-correlation-id:AXIOS_INTERCEPTOR';
+
+/**
+ * Accepts an incoming id of 1 to 128 word characters, dots, colons and hyphens,
+ * and rejects everything else — in particular CR and LF.
+ *
+ * An id that passes is echoed into the response header and carried into
+ * whatever the application logs, so it is attacker-controlled text in two sinks
+ * that are line-oriented. Restricting it to an RFC 9110 token subset is what
+ * keeps a header value from splitting a response or forging a log line, and the
+ * 128-character cap bounds what a single request can append to every log line
+ * it touches. A UUID, the shape `forRoot()` generates by default, is 36.
+ *
+ * @example
+ * ```ts
+ * DEFAULT_CORRELATION_ID_VALIDATOR('018f3a2b-7c41-7e3a-9f55-2c1d4e6a8b90'); // true
+ * DEFAULT_CORRELATION_ID_VALIDATOR('abc\r\nX-Admin: 1'); // false
+ * ```
+ */
 export const DEFAULT_CORRELATION_ID_VALIDATOR = (value: string): boolean =>
   /^[\w.:-]{1,128}$/.test(value);

--- a/nest/correlation-id/src/correlation-id.middleware.spec.ts
+++ b/nest/correlation-id/src/correlation-id.middleware.spec.ts
@@ -26,8 +26,11 @@ function mockService(generated = 'test123') {
 /**
  * Models what node:http actually gives a middleware: `req.headers` keyed by
  * lower-case name, `res.getHeader`/`res.setHeader` case-insensitive on lookup
- * but preserving the casing they were given. The old mock returned the same
- * value for every header name, which made casing untestable by construction.
+ * but preserving the casing they were given.
+ *
+ * Keyed per header name rather than answering every lookup with one value: the
+ * middleware's whole header contract is about which name and which casing, so a
+ * mock that ignores the name cannot fail when the middleware gets either wrong.
  */
 function mockReqRes(incoming?: string | string[]) {
   const req = {

--- a/nest/correlation-id/src/correlation-id.middleware.ts
+++ b/nest/correlation-id/src/correlation-id.middleware.ts
@@ -17,6 +17,22 @@ const singleValue = (
   value: string | string[] | undefined,
 ): string | undefined => (Array.isArray(value) ? value.join(', ') : value);
 
+/**
+ * Opens a correlation context around every request, reusing the id the caller
+ * sent when it passes `validate` and minting one otherwise.
+ *
+ * Typed against `node:http` rather than Express: `req`/`res` are only read for
+ * headers, so the same middleware class works under either adapter.
+ *
+ * @example
+ * ```ts
+ * export class AppModule implements NestModule {
+ *   configure(consumer: MiddlewareConsumer) {
+ *     consumer.apply(CorrelationIdMiddleware).forRoutes('*');
+ *   }
+ * }
+ * ```
+ */
 @Injectable()
 export class CorrelationIdMiddleware implements NestMiddleware {
   constructor(
@@ -43,6 +59,10 @@ export class CorrelationIdMiddleware implements NestMiddleware {
         ? incoming
         : this.correlationService.generate();
 
+    // A generated id is written back onto the request, so anything reading the
+    // header rather than CorrelationService -- a proxy, an access logger, a
+    // framework-level request logger -- sees the same id. A header that arrived
+    // is left exactly as it came in, including one `validate` rejected.
     if (!req.headers[key]) req.headers[key] = correlationId;
     // setHeader preserves the casing it is given, so the configured casing is
     // what goes out on the wire.

--- a/nest/correlation-id/src/correlation.e2e.spec.ts
+++ b/nest/correlation-id/src/correlation.e2e.spec.ts
@@ -63,10 +63,15 @@ class Upstream {
 const upstream = new Upstream();
 
 /**
- * A plain singleton holding HttpService. Before CorrelationService moved to
- * AsyncLocalStorage, `withCorrelation()` made HttpService request-scoped, which
- * made this request-scoped too: a new instance per request, and onModuleInit
- * never called. Both counters are the regression guard.
+ * A singleton holding HttpService, and the probe for the scope invariant
+ * `withCorrelation()` has to preserve.
+ *
+ * Nest propagates request scope upward: a provider injecting a request-scoped
+ * provider becomes request-scoped itself, and so does every provider holding
+ * it. A request-scoped provider is constructed per request and never receives
+ * `onModuleInit`, so both counters stay at 1 for any number of requests exactly
+ * as long as nothing on the path from `HttpService` to `CorrelationService` is
+ * request-scoped.
  */
 @Injectable()
 class Downstream implements OnModuleInit {

--- a/nest/correlation-id/src/correlation.module.ts
+++ b/nest/correlation-id/src/correlation.module.ts
@@ -10,8 +10,35 @@ import { CorrelationService } from './correlation.service.js';
 // a type referenced in a decorated signature cannot be a value import.
 import type { CorrelationConfig } from './interfaces/correlation-config.interface.js';
 
+/**
+ * Provides `CorrelationService` and the correlation configuration to the whole
+ * application.
+ *
+ * @example
+ * ```ts
+ * @Module({ imports: [CorrelationModule.forRoot()] })
+ * export class AppModule implements NestModule {
+ *   configure(consumer: MiddlewareConsumer) {
+ *     consumer.apply(CorrelationIdMiddleware).forRoutes('*');
+ *   }
+ * }
+ * ```
+ */
 @Module({})
 export class CorrelationModule {
+  /**
+   * Fills in every unset field of `config` and returns the module, registered
+   * `global: true`.
+   *
+   * Global because `CorrelationIdMiddleware`, `withCorrelation()` and every
+   * provider that reads an id all resolve `CORRELATION_CONFIG_TOKEN` from the
+   * root injector: without it each consuming module would have to import this
+   * one, and `HttpModule.registerAsync(withCorrelation())` fails with
+   * `Nest can't resolve dependencies of the HTTP_MODULE_OPTIONS`.
+   *
+   * Call it once. A second `forRoot()` registers a second configuration
+   * provider under the same token, and the last import wins.
+   */
   static forRoot(config?: Partial<CorrelationConfig>): DynamicModule {
     const correlationConfigProvider: Provider = {
       provide: CORRELATION_CONFIG_TOKEN,

--- a/nest/correlation-id/src/interfaces/correlation-config.interface.ts
+++ b/nest/correlation-id/src/interfaces/correlation-config.interface.ts
@@ -1,5 +1,24 @@
+/**
+ * The resolved configuration of the correlation module, as
+ * `CorrelationModule.forRoot()` builds it. Every field is filled in there, so
+ * consumers of the injection token never see a partial object.
+ */
 export interface CorrelationConfig {
+  /**
+   * Header the middleware reads an incoming id from and writes the outgoing id
+   * to, in the casing it goes out in. Matching against the request is
+   * case-insensitive because Node lowercases incoming header names.
+   */
   header: string;
+  /** Mints an id when the request carried none that {@link validate} accepts. */
   generator: () => string;
+  /**
+   * Decides whether an incoming id is used as-is or replaced by a generated
+   * one. An id that passes is echoed back in a response header and reaches the
+   * application's logs, so a validator that accepts CR or LF accepts response
+   * splitting and log forging.
+   *
+   * Defaults to `DEFAULT_CORRELATION_ID_VALIDATOR`.
+   */
   validate?: (value: string) => boolean;
 }

--- a/nest/correlation-id/vite.config.ts
+++ b/nest/correlation-id/vite.config.ts
@@ -17,9 +17,10 @@ export default defineConfig(() => ({
     coverage: {
       reportsDirectory: './test-output/vitest/coverage',
       provider: 'v8' as const,
-      // Without an explicit include, v8 reports only the files a test happened
-      // to load -- so the suite printed 100% while never loading two of the
-      // five source modules.
+      // v8 coverage is collected from the modules the run actually loaded, so
+      // without an explicit include a source file no test imports is absent
+      // from the report rather than reported as uncovered, and the percentage
+      // is computed over the loaded subset.
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.spec.ts', 'src/index.ts'],
     },

--- a/nx.json
+++ b/nx.json
@@ -10,6 +10,9 @@
       "!{projectRoot}/tsconfig.spec.json",
       "!{projectRoot}/src/test-setup.[jt]s"
     ],
+    // Part of every target's hash, so a change to the workflow that runs the
+    // targets invalidates the cache instead of replaying results produced under
+    // the previous one.
     "sharedGlobals": ["{workspaceRoot}/.github/workflows/ci.yml"]
   },
   "nxCloudId": "68bf338daff9c334d6ac12a1",
@@ -98,6 +101,10 @@
   ],
   "targetDefaults": {
     "test": {
+      // Tests read build output: storefront's render.test.ts asserts on the HTML
+      // `astro build` emits. `build` orders a project's own build ahead of its
+      // tests, `^build` its dependencies'. A test like that passes without this
+      // wherever a previous run left dist/ behind, and fails on a clean checkout.
       "dependsOn": ["^build", "build"]
     }
   },
@@ -115,35 +122,52 @@
     }
   },
   "release": {
+    // Each package carries its own version: they are published separately and
+    // share no release cadence.
     "projectsRelationship": "independent",
     "projects": ["libs/*", "nest/*"],
     "releaseTag": {
+      // The tag has to name the project, because independent versioning puts
+      // several `1.0.0` tags in one repository otherwise, and the tag is where
+      // nx starts reading commits for the next version of that package.
       "pattern": "{projectName}@{version}"
     },
     "version": {
       "conventionalCommits": true,
+      // Where the current version comes from when the package has no release
+      // tag yet: its package.json on disk. The default resolver asks the npm
+      // registry, which has no entry for a name that has never been published.
       "fallbackCurrentVersionResolver": "disk",
+      // While a package is below 1.0.0, a breaking change takes the minor and a
+      // feature the patch, so a 0.x package does not reach 1.0.0 on its first
+      // breaking change.
       "adjustSemverBumpsForZeroMajorVersion": true
     },
     "conventionalCommits": {
-      // A conventional-commit scope is matched against Nx project names. A
-      // scope that matches no project is not an error: it silently downgrades
-      // the bump to patch, so `feat(scope)!:` with a BREAKING CHANGE footer can
-      // resolve as a patch release. `scope-enum` in commitlint.config.js
-      // enforces that every scope used here is a real project name, which is
-      // what this setting requires.
+      // Attribute each commit to the project its scope names, rather than to
+      // every project whose files it touched.
+      //
+      // A scope matching no project is not an error. nx treats the commit as
+      // indirectly relevant and caps it at a patch bump
+      // (semver.js:29, determineSemverChange), so `feat(typo)!:` with a
+      // BREAKING CHANGE footer releases as a patch. `scope-enum` in
+      // commitlint.config.js is what rejects a scope that names no project, and
+      // tools/repo-checks keeps that list in step with this glob.
       "useCommitScope": true,
-      // nx's defaults mark `refactor` as hidden from the changelog, on the
-      // reading that a refactor changes no behaviour. A `refactor(x)!` does,
-      // and it is the commit that makes a release major, so hiding it leaves a
-      // major version whose changelog does not say what broke. Unhiding it also
-      // restores the Breaking Changes section, which is rendered from the
-      // commits the changelog shows.
+      // nx hides `refactor` from the changelog by default, on the reading that a
+      // refactor changes no behaviour. A `refactor(x)!` changes behaviour and is
+      // the commit that makes the release major, so hiding it publishes a major
+      // version whose changelog does not say what broke. The Breaking Changes
+      // section is rendered from the commits the changelog shows, so it is
+      // hidden along with them.
       "types": {
         "refactor": { "changelog": { "hidden": false } }
       }
     },
     "changelog": {
+      // No workspace-level changelog: the packages have independent versions, so
+      // there is no single version for it to be a changelog of. Each package
+      // gets its own, published as a GitHub release against its own tag.
       "workspaceChangelog": false,
       "projectChangelogs": {
         "createRelease": "github"

--- a/scripts/resolve-release-projects.mjs
+++ b/scripts/resolve-release-projects.mjs
@@ -6,9 +6,10 @@
 // the raw input, so the set that gets versioned and the set that gets published
 // cannot drift apart.
 //
-// An unmatched name exits non-zero before either command runs. Nx reports a
-// filter that matches nothing as "please report this as a bug", which is the
-// right message for an Nx bug and the wrong one for a typo.
+// An unmatched name exits non-zero before either command runs, and the error
+// lists what is releasable. Nx reports a filter matching nothing as "please
+// report this as a bug", which is the right message for an Nx bug and the wrong
+// one for a typo in a workflow input.
 
 import { createProjectGraphAsync, parseJson, workspaceRoot } from '@nx/devkit';
 import { findMatchingProjects } from 'nx/src/devkit-internals';
@@ -55,6 +56,8 @@ if (requested.length === 0) {
   );
 }
 
+// nx.json carries `//` comments, so it needs the comment-tolerant parser nx
+// itself reads it with; `JSON.parse` throws on it.
 const nxJson = parseJson(
   readFileSync(join(workspaceRoot, 'nx.json'), 'utf-8'),
   {

--- a/scripts/verify-packaging.mjs
+++ b/scripts/verify-packaging.mjs
@@ -1,17 +1,20 @@
 #!/usr/bin/env node
 /**
- * Packs each publishable library, installs the tarballs into a throwaway
- * project outside the workspace, and checks that a real consumer can both
- * import them and see their types.
+ * Packs every publishable library, installs the tarballs into a throwaway
+ * project outside the workspace, and checks that a consumer can import them and
+ * see their types.
  *
- * This exists because a bug got all the way to the edge of a release that
- * nothing else caught: vite-plugin-dts emitted extensionless re-exports
- * (`export * from './Compose'`), which a consumer on moduleResolution
- * node16/nodenext cannot resolve -- so `@evanion/compose` and
- * `@evanion/react-widget` appeared to export nothing at all. Every in-repo
- * check passed, because inside the workspace those modules resolve from source.
+ * Nothing inside the repo can tell whether a package resolves as published.
+ * tsconfig.base.json sets `customConditions: ["@evanion/source"]`, so every
+ * in-workspace import reaches a package's TypeScript source and the exports map,
+ * the emitted declarations and the build output are all bypassed. A package can
+ * therefore typecheck, test and lint clean while exporting nothing a consumer
+ * can reach -- an extensionless relative specifier in an emitted .d.ts is enough,
+ * because `moduleResolution: nodenext` requires the extension.
  *
- * Anything that only shows up once the package is packed belongs here.
+ * Everything that only exists once the package is packed is checked here: the
+ * exports map, the conditions in it, the declarations as emitted, the entry
+ * points, and the directives and imports the bundler left in the output.
  */
 import { execFileSync } from 'node:child_process';
 import {
@@ -25,7 +28,14 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
 const ROOT = resolve(import.meta.dirname, '..');
-// [directory, package name]
+
+/**
+ * Every publishable package, as `[directory, package name]`.
+ *
+ * A package missing from this list is packed by nothing and checked by nothing;
+ * the count is asserted after packing so a failed `npm pack` cannot pass as a
+ * shorter list.
+ */
 const LIBS = [
   ['libs/compose', '@evanion/compose'],
   ['libs/urn', '@evanion/urn'],
@@ -82,6 +92,10 @@ try {
       include: ['consumer.ts'],
     }),
   );
+  // Names every public export and assigns the types to annotated bindings, so
+  // `tsc` fails on a symbol that stopped being exported and on one whose type
+  // stopped being reachable. `void [...]` at the end keeps the values used
+  // without running anything.
   writeFileSync(
     join(dir, 'consumer.ts'),
     `
@@ -165,6 +179,10 @@ void [ComposeProvider, provider, parsed, arr, err, items, widgetProblems, Defaul
   run('npx', ['tsc', '-p', 'tsconfig.json'], dir);
   console.log('  ✓ every package exposes its types under nodenext');
 
+  // A second pass at runtime: the typecheck above resolves through the exports
+  // map's `types` condition, node resolves through `import`, and the two point
+  // at different files. A declaration can promise a value the emitted JavaScript
+  // does not export.
   console.log('Importing at runtime…');
   writeFileSync(
     join(dir, 'runtime.mjs'),

--- a/tools/doc-examples/src/expect-comments.ts
+++ b/tools/doc-examples/src/expect-comments.ts
@@ -24,6 +24,7 @@
 /** The comment marker a value claim is written with. */
 const MARKER = '->';
 
+/** A line claiming a value that cannot be turned into an assertion. */
 export class ExpectCommentError extends Error {
   // Explicit fields rather than constructor parameter properties: Nx loads a
   // vite.config.ts importing this module under Node's strip-only TypeScript
@@ -165,17 +166,6 @@ export function rewriteLine(line: string, file: string, number: number): string 
 }
 
 /**
- * Rewrites a static import into the dynamic form, because doctest runs a block
- * as a function body and a static import is only legal at module top level.
- *
- * The alternative is to hide the imports in a per-package preamble, which
- * costs the README the line a reader most needs — which package the names come
- * from. The specifier is untouched, so a block resolves `@evanion/luhn` the
- * way a consumer does, through the package's own exports map.
- *
- * One line in, one line out, same as the value claims.
- */
-/**
  * `{ a, b as c, type T }` as a destructuring pattern.
  *
  * An inline `type` specifier names nothing at runtime, so it is dropped rather
@@ -191,6 +181,18 @@ function namedBindings(clause: string): string {
     .join(', ');
 }
 
+/**
+ * Rewrites a static import into the dynamic form, or returns null for a line
+ * that is not an import.
+ *
+ * doctest runs a code block as a function body, where a static import is a
+ * syntax error. The alternative is to move the imports into a per-package
+ * preamble, which costs the README the line a reader most needs — which package
+ * the names come from. The specifier is untouched, so the block resolves
+ * `@evanion/luhn` the way a consumer does, through the package's exports map.
+ *
+ * One line in, one line out, same as the value claims.
+ */
 function rewriteImport(line: string): string | null {
   const indent = line.slice(0, line.length - line.trimStart().length);
   const source = line.trim();

--- a/tools/doc-examples/src/mdx-region-loader.mjs
+++ b/tools/doc-examples/src/mdx-region-loader.mjs
@@ -29,8 +29,8 @@ import { readRegion } from './regions.mjs';
  * source file is edited above them, which is the failure this exists to
  * remove.
  *
- * A missing file or region throws, so the build fails. An unenforced sync
- * mechanism drifts within a month.
+ * A missing file or region throws, so `next build` fails rather than deploying a
+ * page with an empty code block where an example should be.
  */
 
 const REFERENCE = /(?:^|\s)file=(\S+)\s+region=([\w-]+)/;
@@ -96,10 +96,16 @@ export function expandRegions(source, root, file) {
   return out.join('\n');
 }
 
+/**
+ * The loader entry point, configured in apps/docs/next.config.ts under
+ * `turbopack.rules`. `root` is the workspace root every reference resolves from.
+ */
 export default function mdxRegionLoader(source) {
   const { root } = this.getOptions();
 
-  // A page is rebuilt when a README it pulls a region from changes.
+  // Declares each referenced README as an input of this page, so editing one
+  // rebuilds the pages that quote it. Without this the page's own mtime is the
+  // only thing the build watches, and a page keeps serving a stale region.
   for (const match of source.matchAll(new RegExp(REFERENCE, 'g'))) {
     this.addDependency(join(root, match[1]));
   }

--- a/tools/doc-examples/src/regions.mjs
+++ b/tools/doc-examples/src/regions.mjs
@@ -23,6 +23,7 @@ const REGION = /<!--\s*#region\s+([\w-]+)\s*-->/;
 const ENDREGION = /<!--\s*#endregion\s+([\w-]+)\s*-->/;
 const FENCE = /^\s*(`{3,})(.*)$/;
 
+/** A malformed or missing region, with the file and line in its message. */
 export class RegionError extends Error {
   constructor(message) {
     super(message);

--- a/tools/doc-examples/src/vite-config.ts
+++ b/tools/doc-examples/src/vite-config.ts
@@ -6,8 +6,17 @@ import { expectComments } from './vite-plugin.ts';
 /**
  * The Vite configuration that makes a package's documented examples run.
  *
- * Every published package wires the same three things, so they live here
- * rather than in seven copies that drift apart.
+ * Every published package wires the same three things, so they live here rather
+ * than in a copy per package.
+ *
+ * @example
+ * ```ts
+ * // libs/<package>/vite.config.ts
+ * export default defineConfig(() => ({
+ *   ...docExamples(),
+ *   test: { includeSource: docExampleSources() },
+ * }));
+ * ```
  */
 export function docExamples(options: { preamble?: string } = {}) {
   return {

--- a/tools/nx-astro/src/index.ts
+++ b/tools/nx-astro/src/index.ts
@@ -1,11 +1,13 @@
 /**
- * Thin internal Nx plugin giving Astro projects inferred targets.
+ * Internal Nx plugin that gives every Astro project `build`, `dev`, `preview`
+ * and `check` targets, inferred from the presence of an `astro.config`.
  *
- * Nx's own tooling-plugin guide parses srcDir/outDir out of the Astro config
- * with a regex, and says outright that there are better ways. A regex over a
- * JavaScript config breaks the moment a value is a variable, an import or a
- * spread. Every Astro project in this workspace uses Astro's documented
- * defaults, so we take the defaults and let nx.json override them.
+ * The paths those targets declare as inputs and outputs come from Astro's
+ * documented defaults, overridable through the plugin's options in nx.json. The
+ * config file is never parsed: Nx's own tooling-plugin guide regexes srcDir and
+ * outDir out of it while saying there are better ways, and a regex over a
+ * JavaScript config reads nothing useful the moment a value is a variable, an
+ * import or a spread -- silently, as a wrong cache key rather than an error.
  */
 import {
   createNodesFromFiles,
@@ -15,13 +17,25 @@ import {
   type TargetConfiguration,
 } from '@nx/devkit';
 import { existsSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 
+/** Plugin options, as given in nx.json's `plugins` entry for this file. */
 export interface AstroPluginOptions {
+  /** Defaults to `build`. */
   buildTargetName?: string;
+  /** Defaults to `dev`. */
   devTargetName?: string;
+  /** Defaults to `preview`. */
   previewTargetName?: string;
+  /** Defaults to `check`. */
   checkTargetName?: string;
+  /**
+   * Astro's `srcDir`, `publicDir` and `outDir`, which are taken at their
+   * documented defaults (`./src`, `./public`, `dist`) and have to be repeated
+   * here whenever a project's astro.config overrides one. They decide what Nx
+   * hashes as the target's inputs and what it caches as its outputs, so a stale
+   * value means a build served from cache after the real sources changed.
+   */
   srcDir?: string;
   publicDir?: string;
   outDir?: string;
@@ -29,6 +43,12 @@ export interface AstroPluginOptions {
 
 const astroConfigGlob = '**/astro.config.{mjs,ts}';
 
+/**
+ * Registers one project per matched `astro.config`.
+ *
+ * `createNodesV2` is the entry name Nx looks up on a plugin module; a plugin
+ * exporting anything else contributes no targets and reports no error.
+ */
 export const createNodesV2: CreateNodesV2<AstroPluginOptions> = [
   astroConfigGlob,
   async (configFiles, options, context) =>
@@ -44,7 +64,9 @@ async function createNodesInternal(
   const projectRoot = dirname(configFilePath);
   const abs = join(context.workspaceRoot, projectRoot);
 
-  // Only treat it as a project if Nx would already consider it one.
+  // Nx identifies a project by its package.json or project.json. An astro
+  // config anywhere else -- a fixture, an example, a template -- is not a
+  // project, and adding targets to one produces a graph node nothing owns.
   if (
     !existsSync(join(abs, 'package.json')) &&
     !existsSync(join(abs, 'project.json'))
@@ -56,13 +78,19 @@ async function createNodesInternal(
   const publicDir = opts.publicDir ?? './public';
   const outDir = opts.outDir ?? 'dist';
 
+  // `^build` because an .astro file imports workspace libraries, and astro
+  // resolves those through each package's exports map to its build output --
+  // which has to exist by then.
   const build: TargetConfiguration = {
     command: 'astro build',
     dependsOn: ['^build'],
     options: { cwd: projectRoot },
     cache: true,
     inputs: [
-      '{projectRoot}/astro.config.mjs',
+      // The config file as matched, not a fixed name: the glob accepts .mjs and
+      // .ts, and a config left out of the inputs means an edit to it does not
+      // invalidate the cached build.
+      `{projectRoot}/${basename(configFilePath)}`,
       joinPathFragments('{projectRoot}', srcDir, '**', '*'),
       joinPathFragments('{projectRoot}', publicDir, '**', '*'),
       { externalDependencies: ['astro'] },
@@ -70,6 +98,7 @@ async function createNodesInternal(
     outputs: [`{projectRoot}/${outDir}`],
   };
 
+  // Uncached, both of them: a long-running server has no output to replay.
   const dev: TargetConfiguration = {
     command: 'astro dev',
     options: { cwd: projectRoot },
@@ -80,6 +109,11 @@ async function createNodesInternal(
     options: { cwd: projectRoot },
   };
 
+  // Cached with no `outputs`, which is how Nx caches a pass/fail: `astro check`
+  // writes nothing. It is a separate target because the `typecheck` target Nx
+  // infers from tsconfig.json is disabled whenever the resolved config sets
+  // `noEmit`, as Astro's shared config does, and `astro build` does not
+  // typecheck -- so this is the only target that checks the .astro files.
   const check: TargetConfiguration = {
     command: 'astro check',
     options: { cwd: projectRoot },

--- a/tools/repo-checks/src/commitlint-scope-enum.test.ts
+++ b/tools/repo-checks/src/commitlint-scope-enum.test.ts
@@ -6,18 +6,20 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 /**
- * `nx release` resolves conventional-commit scopes against Nx PROJECT NAMES
- * (getCommitsRelevantToProjects in
- * nx/src/command-line/release/utils/shared.js). A scope that matches no
- * project is not an error -- semver.js downgrades the commit to a `patch`
- * bump. That is how `feat(widget)!:` on `@evanion/react-widget` resolved as
- * 0.1.1 instead of 0.2.0.
+ * The invariant: every project nx.json releases has a matching entry in
+ * commitlint's `scope-enum`, under the bare name Nx resolves a commit scope to.
  *
- * commitlint's `scope-enum` is therefore the guardrail, and it has to be a
- * static list: it runs in the commit-msg hook on every commit and cannot
- * afford a project-graph computation. Static list, dynamic test -- this is the
- * test. It fails the build when a releasable project is added without the
- * matching scope.
+ * `nx release` matches conventional-commit scopes against Nx project names
+ * (`getCommitsRelevantToProjects` in
+ * nx/src/command-line/release/utils/shared.js). A scope matching no project is
+ * not an error: semver.js attributes the commit to nothing and the bump falls
+ * back to `patch`, so `feat(x)!:` with a typo'd scope ships as a patch release
+ * with an empty Breaking Changes section.
+ *
+ * `scope-enum` is what turns that into an error, and it has to be a static list
+ * because it runs in the commit-msg hook on every commit and cannot afford a
+ * project-graph computation. This test is the dynamic half: it fails when a
+ * releasable project exists with no scope to name it in a commit.
  */
 
 const require_ = createRequire(import.meta.url);
@@ -45,7 +47,10 @@ function readScopeEnum(): string[] {
   return scopes;
 }
 
-/** nx.json carries `//` comments, so it needs the JSONC fallback Nx itself uses. */
+/**
+ * nx.json carries `//` comments, so it is read with the same comment-tolerant
+ * parser Nx itself reads it with. `JSON.parse` throws on it.
+ */
 function readReleaseProjectPatterns(): string[] {
   const nxJson = parseJson<{ release?: { projects?: string | string[] } }>(
     readFileSync(join(workspaceRoot, 'nx.json'), 'utf-8'),
@@ -58,7 +63,16 @@ function readReleaseProjectPatterns(): string[] {
   return Array.isArray(patterns) ? patterns : [patterns as string];
 }
 
-/** `@evanion/react-widget` -> `react-widget`. This is what Nx matches a scope against. */
+/**
+ * `@evanion/react-widget` -> `react-widget`.
+ *
+ * A commit scope that is not a literal project name is matched against the
+ * project names with the word-boundary regex in `addMatchingProjectsByName`
+ * (nx/src/utils/find-matching-projects.js), where `@` and `-` both count as word
+ * characters. A bare name therefore matches its own scoped project and nothing
+ * else, while a fragment of one -- `widget` against `react-widget` -- matches
+ * nothing at all.
+ */
 function bareName(projectName: string): string {
   return projectName.replace(/^@[^/]+\//, '');
 }
@@ -96,8 +110,9 @@ describe('commitlint scope-enum', () => {
   });
 
   it('lists no scope carrying the @evanion/ prefix', () => {
-    // A scope of `@evanion/react-widget` would not survive the bare-name
-    // matching Nx does, so reject the prefixed form outright.
+    // One spelling per project. Nx resolves both forms, so a list holding the
+    // prefixed one as well would let two different scopes release the same
+    // project, and this test's bare-name comparison would stop covering it.
     expect(readScopeEnum().filter((scope) => scope.includes('/'))).toEqual([]);
   });
 });

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,15 +1,31 @@
 {
   "compilerOptions": {
+    // Every project is a composite project referenced from a solution
+    // tsconfig.json, which is what lets `tsc --build` skip the ones whose
+    // inputs have not changed.
     "composite": true,
     "declarationMap": true,
+    // Declarations only. Where a project's JavaScript comes from a bundler, a
+    // second emit from tsc would be a second producer writing the same files;
+    // where it comes from `tsc --build`, this is what makes the typecheck
+    // target's own emit discardable -- see
+    // tools/repo-checks/src/tsc-emit-outside-build-output.test.ts.
     "emitDeclarationOnly": true,
+    // Helpers are imported from tslib rather than inlined per file, so every
+    // package built by tsc declares tslib as a runtime dependency. A package
+    // whose JavaScript is bundled does not: the bundler resolves the helper at
+    // build time.
     "importHelpers": true,
     "isolatedModules": true,
-    "lib": [
-      "es2022"
-    ],
+    "lib": ["es2022"],
+    // nodenext on both, which is the resolution mode a consumer on Node ESM
+    // uses. It requires a file extension in every relative specifier, including
+    // in emitted .d.ts files; scripts/verify-packaging.mjs checks the packed
+    // result against the same setting.
     "module": "nodenext",
     "moduleResolution": "nodenext",
+    // A failed build writes nothing, so a downstream project cannot typecheck
+    // against declarations emitted from code that did not compile.
     "noEmitOnError": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
@@ -18,13 +34,15 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "es2022",
-    "customConditions": [
-      "@evanion/source"
-    ],
+    // Resolves every in-workspace import of `@evanion/*` to the package's
+    // TypeScript source, through the `@evanion/source` condition in its exports
+    // map. Nothing in the repo typechecks against another package's build
+    // output, so no build order is needed to typecheck -- and nothing here
+    // exercises the published resolution, which is what
+    // scripts/verify-packaging.mjs exists for.
+    "customConditions": ["@evanion/source"],
     "noUncheckedSideEffectImports": false,
-    "types": [
-      "*"
-    ],
+    "types": ["*"],
     "esModuleInterop": false,
     "ignoreDeprecations": "6.0",
     "noUncheckedIndexedAccess": true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,22 @@
 import { defineConfig } from 'vitest/config';
 
+/**
+ * The workspace-wide `vitest` run: every project's own config, as a Vitest
+ * project.
+ *
+ * This is for running the whole suite by hand. CI and the release gate go
+ * through `nx run-many -t test`, which runs each project's config directly and
+ * never reads this file -- @nx/vitest infers a project's `test` target from a
+ * project-local vite.config/vitest.config, not from the list below. A project
+ * added here but missing such a file runs here and nowhere else.
+ */
 export default defineConfig({
   test: {
     projects: [
       '**/vite.config.{mjs,js,ts,mts}',
       '**/vitest.config.{mjs,js,ts,mts}',
+      // This file matches its own glob, and a config that lists itself as a
+      // project recurses.
       '!vitest.config.ts',
     ],
   },


### PR DESCRIPTION
Raises every comment and docblock in `nest/correlation-id`, `apps/*`, `tools/*`, the root configs, `scripts/` and the workflows to one rule: say what the code does or requires, then the fact outside the file that forces it. Nothing under `libs/` is touched.

## Counts

| Area | Rewritten | Deleted | Added |
|---|---|---|---|
| nest/correlation-id | 4 | 0 | 10 |
| apps/shop-api | 8 | 1 | 11 |
| apps/storefront | 0 | 0 | 4 |
| apps/docs | 12 | 6 | 8 |
| tools/nx-astro | 3 | 0 | 9 |
| tools/repo-checks | 4 | 0 | 0 |
| tools/doc-examples | 4 | 0 | 4 |
| root configs | 6 | 0 | 13 |
| scripts + workflows | 6 | 4 | 3 |

## What the comments now record that they did not before

- `nx.json`: why the release tag carries the project name, why the current version falls back to disk, what a zero major does to a bump, why there is no workspace changelog, and why `sharedGlobals` lists the CI workflow. The `useCommitScope` and `refactor` notes keep their facts and gain the nx source location (`semver.js:29`).
- `tsconfig.base.json` had no comments at all. It now records `composite`, `emitDeclarationOnly`, `importHelpers` and the tslib dependency it implies, `nodenext`, `noEmitOnError`, and the `@evanion/source` condition that is the reason `verify-packaging.mjs` exists.
- `commitlint.config.js`: how nx actually resolves a scope — the word-boundary regex over project names in `addMatchingProjectsByName`, where `-` counts as a word character, so `widget` matches neither `react-widget` nor `astro-widget` — plus what each type bumps.
- `tools/nx-astro`: that the plugin never parses the astro config, and what a stale path option costs (a cached build after the sources moved). `apps/storefront/astro.config.mjs` says why it has to stay empty.
- `scripts/verify-packaging.mjs`: the in-repo blind spot it covers, stated as the resolution rule rather than as the bug that surfaced it, and why there is a second runtime pass after the typecheck.

## Fixes found while writing them

- `AppModule`'s docblock sat between the decorator and the class, where it documented nothing. Moved above the decorator.
- `rewriteImport`'s docblock sat above `namedBindings`, so each function carried the other's documentation.
- `tools/nx-astro` declared `{projectRoot}/astro.config.mjs` as a build input while its own glob also accepts `.ts`, so a TypeScript config was not part of the build's cache key. Now uses the matched filename.
- `apps/docs` advertised itself as documenting "compose, urn and react-widget"; there are eight packages. The description no longer enumerates them.

## Verified

- `npx nx run-many -t lint test build typecheck check --all` — 51 tasks, 14 projects, green (13 pre-existing lint warnings in `tools/nx-astro/src/index.test.ts`, 0 errors).
- `node scripts/verify-packaging.mjs` — every check passes.
- `npx nx test @evanion/repo-checks` — 63 tests, including the nx.json release-block comment guard.
- `actionlint` 1.7.12 on the workflows — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019s6FWxb6zpDUvbN4j1XH2B
